### PR TITLE
Added staticEval >= beta to nmp

### DIFF
--- a/Sirius/src/search.cpp
+++ b/Sirius/src/search.cpp
@@ -387,7 +387,7 @@ int Search::search(SearchThread& thread, int depth, SearchPly* searchPly, int al
             return staticEval;
 
         // null move pruning
-        if (board.pliesFromNull() > 0)
+        if (board.pliesFromNull() > 0 && staticEval >= beta)
         {
             BitBoard nonPawns = board.getColor(board.sideToMove()) ^ board.getPieces(board.sideToMove(), PieceType::PAWN);
             if ((nonPawns & (nonPawns - 1)) && depth >= NMP_MIN_DEPTH)


### PR DESCRIPTION
tc: 8+0.08
sprt bounds: [0, 10]
resign: movecount=8, score=800
hash: 64 MB
```
Score of sirius-5.0-nmp-static-eval vs sirius-5.0: 218 - 150 - 275  [0.553] 643
...      sirius-5.0-nmp-static-eval playing White: 147 - 44 - 131  [0.660] 322
...      sirius-5.0-nmp-static-eval playing Black: 71 - 106 - 144  [0.445] 321
...      White vs Black: 253 - 115 - 275  [0.607] 643
Elo difference: 36.9 +/- 20.3, LOS: 100.0 %, DrawRatio: 42.8 %
SPRT: llr 2.99 (101.4%), lbound -2.94, ubound 2.94 - H1 was accepted
```