### PR TITLE
Increase nmp reduction based on depth

### DIFF
--- a/Sirius/src/search.cpp
+++ b/Sirius/src/search.cpp
@@ -392,7 +392,7 @@ int Search::search(SearchThread& thread, int depth, SearchPly* searchPly, int al
             BitBoard nonPawns = board.getColor(board.sideToMove()) ^ board.getPieces(board.sideToMove(), PieceType::PAWN);
             if ((nonPawns & (nonPawns - 1)) && depth >= NMP_MIN_DEPTH)
             {
-                int r = NMP_BASE_REDUCTION;
+                int r = NMP_BASE_REDUCTION + depth / NMP_DEPTH_REDUCTION;
                 board.makeNullMove(state);
                 rootPly++;
                 int nullScore = -search(thread, depth - r, searchPly + 1, -beta, -beta + 1, false);

--- a/Sirius/src/search_params.h
+++ b/Sirius/src/search_params.h
@@ -10,6 +10,7 @@ constexpr int RFP_MARGIN = 75;
 
 constexpr int NMP_MIN_DEPTH = 2;
 constexpr int NMP_BASE_REDUCTION = 3;
+constexpr int NMP_DEPTH_REDUCTION = 3;
 
 constexpr int FP_BASE_MARGIN = 120;
 constexpr int FP_DEPTH_MARGIN = 75;


### PR DESCRIPTION
tc: 8+0.08
book: pohl.epd
sprt bounds: [0, 10]
resign: movecount=8 score=800
formula: depth / 3
```
Score of sirius-5.0-nmp-depth-reduction vs sirius-5.0-nmp-static-eval: 286 - 215 - 376  [0.540] 877
...      sirius-5.0-nmp-depth-reduction playing White: 203 - 57 - 179  [0.666] 439
...      sirius-5.0-nmp-depth-reduction playing Black: 83 - 158 - 197  [0.414] 438
...      White vs Black: 361 - 140 - 376  [0.626] 877
Elo difference: 28.2 +/- 17.4, LOS: 99.9 %, DrawRatio: 42.9 %
SPRT: llr 2.96 (100.5%), lbound -2.94, ubound 2.94 - H1 was accepted
```