### PR TITLE
Added internal iterative reductions

### DIFF
--- a/Sirius/src/search.cpp
+++ b/Sirius/src/search.cpp
@@ -376,6 +376,8 @@ int Search::search(SearchThread& thread, int depth, SearchPly* searchPly, int al
         ))
             return ttScore;
     }
+    else if (depth >= MIN_IIR_DEPTH)
+        depth--;
 
     int staticEval = eval::evaluate(board);
     BoardState state;

--- a/Sirius/src/search_params.h
+++ b/Sirius/src/search_params.h
@@ -5,6 +5,8 @@ constexpr uint32_t TIME_CHECK_INTERVAL = 2048;
 
 constexpr int ASP_INIT_DELTA = 25;
 
+constexpr int MIN_IIR_DEPTH = 4;
+
 constexpr int RFP_MAX_DEPTH = 8;
 constexpr int RFP_MARGIN = 75;
 


### PR DESCRIPTION
tc: 10+0.1
book: pohl.epd
sprt bounds: [0, 10]
formula: `depth >= 4 && !ttHit`
```
Score of sirius-5.0-iir vs sirius-5.0-nmp-depth-reduction: 1262 - 1143 - 1789  [0.514] 4194
...      sirius-5.0-iir playing White: 865 - 336 - 897  [0.626] 2098
...      sirius-5.0-iir playing Black: 397 - 807 - 892  [0.402] 2096
...      White vs Black: 1672 - 733 - 1789  [0.612] 4194
Elo difference: 9.9 +/- 8.0, LOS: 99.2 %, DrawRatio: 42.7 %
SPRT: llr 2.95 (100.1%), lbound -2.94, ubound 2.94 - H1 was accepted
```