### PR TITLE
Added 3fold lmr

### DIFF
--- a/Sirius/src/search.cpp
+++ b/Sirius/src/search.cpp
@@ -493,7 +493,10 @@ int Search::search(SearchThread& thread, int depth, SearchPly* searchPly, int al
         {
             score = -search(thread, newDepth - reduction, searchPly + 1, -(alpha + 1), -alpha, false);
 
-            if (score > alpha && (isPV || reduction > 0))
+            if (score > alpha && reduction > 0)
+                score = -search(thread, newDepth, searchPly + 1, -(alpha + 1), -alpha, false);
+
+            if (score > alpha && isPV)
                 score = -search(thread, newDepth, searchPly + 1, -beta, -alpha, true);
         }
         rootPly--;


### PR DESCRIPTION
tc: 10+0.1
book: pohl.epd
sprt bounds: [0, 10]
```
Score of sirius-5.0-3fold-lmr vs sirius-5.0-iir: 486 - 406 - 727  [0.525] 1619
...      sirius-5.0-3fold-lmr playing White: 325 - 135 - 350  [0.617] 810
...      sirius-5.0-3fold-lmr playing Black: 161 - 271 - 377  [0.432] 809
...      White vs Black: 596 - 296 - 727  [0.593] 1619
Elo difference: 17.2 +/- 12.6, LOS: 99.6 %, DrawRatio: 44.9 %
SPRT: llr 2.97 (100.9%), lbound -2.94, ubound 2.94 - H1 was accepted
```