### PR TITLE
Refactor how quiets and noisies are handled

### DIFF
--- a/Sirius/src/move_ordering.cpp
+++ b/Sirius/src/move_ordering.cpp
@@ -8,7 +8,10 @@ namespace
 int mvvLva(const Board& board, Move move)
 {
     int srcPiece = static_cast<int>(getPieceType(board.getPieceAt(move.srcPos())));
-    int dstPiece = static_cast<int>(getPieceType(board.getPieceAt(move.dstPos())));
+    int dstPiece = static_cast<int>(move.type() == MoveType::ENPASSANT ?
+        PieceType::PAWN :
+        getPieceType(board.getPieceAt(move.dstPos()))
+    );
     return 10 * dstPiece - srcPiece + 6;
 }
 
@@ -26,6 +29,12 @@ bool moveIsQuiet(const Board& board, Move move)
 		board.getPieceAt(move.dstPos()) == PIECE_NONE;
 }
 
+bool moveIsCapture(const Board& board, Move move)
+{
+    return move.type() == MoveType::ENPASSANT ||
+        board.getPieceAt(move.dstPos()) != PIECE_NONE;
+}
+
 MoveOrdering::MoveOrdering(const Board& board, MoveList& moves, Move hashMove)
     : m_Moves(moves)
 {
@@ -40,7 +49,7 @@ MoveOrdering::MoveOrdering(const Board& board, MoveList& moves, Move hashMove)
             continue;
         }
 
-        bool isCapture = static_cast<bool>(board.getPieceAt(move.dstPos()));
+        bool isCapture = moveIsCapture(board, move);
         bool isPromotion = move.type() == MoveType::PROMOTION;
 
         if (isCapture)
@@ -66,7 +75,7 @@ MoveOrdering::MoveOrdering(const Board& board, MoveList& moves, Move hashMove, s
             continue;
         }
 
-        bool isCapture = static_cast<bool>(board.getPieceAt(move.dstPos()));
+        bool isCapture = moveIsCapture(board, move);
         bool isPromotion = move.type() == MoveType::PROMOTION;
 
         if (isCapture)

--- a/Sirius/src/move_ordering.cpp
+++ b/Sirius/src/move_ordering.cpp
@@ -19,6 +19,13 @@ int promotionBonus(Move move)
 
 }
 
+bool moveIsQuiet(const Board& board, Move move)
+{
+	return move.type() != MoveType::PROMOTION &&
+		move.type() != MoveType::ENPASSANT &&
+		board.getPieceAt(move.dstPos()) == PIECE_NONE;
+}
+
 MoveOrdering::MoveOrdering(const Board& board, MoveList& moves, Move hashMove)
     : m_Moves(moves)
 {

--- a/Sirius/src/move_ordering.h
+++ b/Sirius/src/move_ordering.h
@@ -10,6 +10,8 @@ struct ExtMove
     int score;
 };
 
+bool moveIsQuiet(const Board& board, Move move);
+
 class MoveOrdering
 {
 public:

--- a/Sirius/src/move_ordering.h
+++ b/Sirius/src/move_ordering.h
@@ -11,6 +11,7 @@ struct ExtMove
 };
 
 bool moveIsQuiet(const Board& board, Move move);
+bool moveIsCapture(const Board& board, Move move);
 
 class MoveOrdering
 {

--- a/Sirius/src/search.cpp
+++ b/Sirius/src/search.cpp
@@ -437,8 +437,7 @@ int Search::search(SearchThread& thread, int depth, SearchPly* searchPly, int al
     for (int movesPlayed = 0; movesPlayed < static_cast<int>(moves.size()); movesPlayed++)
     {
         auto [move, moveScore] = ordering.selectMove(static_cast<uint32_t>(movesPlayed));
-        bool isCapture = board.getPieceAt(move.dstPos()) != PIECE_NONE;
-        bool isPromotion = move.type() == MoveType::PROMOTION;
+		bool quiet = moveIsQuiet(board, move);
         bool quietLosing = moveScore < MoveOrdering::KILLER_SCORE;
 
         int baseLMR = lmrTable[std::min(depth, 63)][std::min(movesPlayed, 63)];
@@ -467,7 +466,7 @@ int Search::search(SearchThread& thread, int depth, SearchPly* searchPly, int al
         }
         board.makeMove(move, state);
         bool givesCheck = board.checkers() != 0;
-        if (!isPromotion && !isCapture)
+        if (quiet)
             quietsTried.push_back(move);
         rootPly++;
 
@@ -511,7 +510,7 @@ int Search::search(SearchThread& thread, int depth, SearchPly* searchPly, int al
 
             if (bestScore >= beta)
             {
-                if (!isPromotion && !isCapture)
+                if (quiet)
                 {
                     storeKiller(searchPly, move);
 


### PR DESCRIPTION
En passant is now considered as a capture

tc: 10+0.1
book: pohl.epd
sprt bounds: [-5, 0]
```
Score of sirius-5.0-ep-noisy vs sirius-5.0-3fold-lmr: 2778 - 2733 - 4162  [0.502] 9673
...      sirius-5.0-ep-noisy playing White: 1899 - 872 - 2066  [0.606] 4837
...      sirius-5.0-ep-noisy playing Black: 879 - 1861 - 2096  [0.398] 4836
...      White vs Black: 3760 - 1751 - 4162  [0.604] 9673
Elo difference: 1.6 +/- 5.2, LOS: 72.8 %, DrawRatio: 43.0 %
SPRT: llr 2.89 (100.2%), lbound -2.25, ubound 2.89 - H1 was accepted
```