### PR TITLE
Added soft time management + modified time bounds

### DIFF
--- a/Sirius/src/search.cpp
+++ b/Sirius/src/search.cpp
@@ -245,7 +245,7 @@ int Search::iterDeep(SearchThread& thread, bool report, bool normalSearch)
     {
         thread.plies[0].pv = pv.data();
         int searchScore = aspWindows(thread, depth, score);
-        if (m_ShouldStop)
+        if (m_ShouldStop || m_TimeMan.stopSoft(thread.limits))
             break;
         score = searchScore;
         if (report)
@@ -324,7 +324,7 @@ int Search::search(SearchThread& thread, int depth, SearchPly* searchPly, int al
     if (--thread.checkCounter == 0)
     {
         thread.checkCounter = TIME_CHECK_INTERVAL;
-        if (m_TimeMan.shouldStop(thread.limits))
+        if (m_TimeMan.stopHard(thread.limits))
         {
             m_ShouldStop = true;
             return alpha;

--- a/Sirius/src/search.cpp
+++ b/Sirius/src/search.cpp
@@ -245,7 +245,7 @@ int Search::iterDeep(SearchThread& thread, bool report, bool normalSearch)
     {
         thread.plies[0].pv = pv.data();
         int searchScore = aspWindows(thread, depth, score);
-        if (m_ShouldStop || m_TimeMan.stopSoft(thread.limits))
+        if (m_ShouldStop)
             break;
         score = searchScore;
         if (report)
@@ -262,6 +262,9 @@ int Search::iterDeep(SearchThread& thread, bool report, bool normalSearch)
                 comm::currComm->reportSearchInfo(info);
             }
         }
+
+        if (m_TimeMan.stopSoft(thread.limits))
+            break;
     }
 
     if (report)

--- a/Sirius/src/time_man.h
+++ b/Sirius/src/time_man.h
@@ -29,8 +29,10 @@ public:
     Duration elapsed() const;
 
     void startSearch();
-    bool shouldStop(const SearchLimits& searchLimits) const;
+    bool stopHard(const SearchLimits& searchLimits) const;
+    bool stopSoft(const SearchLimits& searchLimits) const;
 private:
     TimePoint m_StartTime;
-    Duration m_AllocatedTime;
+    Duration m_HardBound;
+    Duration m_SoftBound;
 };


### PR DESCRIPTION
tc: 8+0.08
book: pohl.epd
sprt bounds: [0, 10]
```
Score of sirius-5.0-soft-tm vs sirius-5.0-moves-played: 85 - 28 - 80  [0.648] 193
...      sirius-5.0-soft-tm playing White: 51 - 8 - 38  [0.722] 97
...      sirius-5.0-soft-tm playing Black: 34 - 20 - 42  [0.573] 96
...      White vs Black: 71 - 42 - 80  [0.575] 193
Elo difference: 105.8 +/- 38.0, LOS: 100.0 %, DrawRatio: 41.5 %
SPRT: llr 2.92 (101.0%), lbound -2.25, ubound 2.89 - H1 was accepted
```