### PR TITLE
Separate see pruning margins for noisy and quiet moves

### DIFF
--- a/Sirius/src/search.cpp
+++ b/Sirius/src/search.cpp
@@ -465,9 +465,10 @@ int Search::search(SearchThread& thread, int depth, SearchPly* searchPly, int al
 
             if (!isPV &&
                 depth <= MAX_SEE_PRUNE_DEPTH &&
-                !board.see_margin(move, depth * SEE_PRUNE_MARGIN))
+                !board.see_margin(move, depth * (quiet ? SEE_PRUNE_MARGIN_QUIET : SEE_PRUNE_MARGIN_NOISY)))
                 continue;
         }
+
         board.makeMove(move, state);
         bool givesCheck = board.checkers() != 0;
         if (quiet)

--- a/Sirius/src/search_params.h
+++ b/Sirius/src/search_params.h
@@ -22,7 +22,8 @@ constexpr int LMP_MAX_DEPTH = 8;
 constexpr int LMP_MIN_MOVES_BASE = 3;
 
 constexpr int MAX_SEE_PRUNE_DEPTH = 8;
-constexpr int SEE_PRUNE_MARGIN = -100;
+constexpr int SEE_PRUNE_MARGIN_NOISY = -100;
+constexpr int SEE_PRUNE_MARGIN_QUIET = -60;
 
 constexpr int LMR_MIN_DEPTH = 3;
 constexpr int LMR_MIN_MOVES_NON_PV = 3;


### PR DESCRIPTION
tc: 8+0.08
book: pohl.epd
sprt bounds: [0, 5]
```
Score of sirius-5.0-see-prune-margin vs sirius-5.0-soft-tm: 1235 - 1094 - 1923  [0.517] 4252
...      sirius-5.0-see-prune-margin playing White: 879 - 305 - 943  [0.635] 2127
...      sirius-5.0-see-prune-margin playing Black: 356 - 789 - 980  [0.398] 2125
...      White vs Black: 1668 - 661 - 1923  [0.618] 4252
Elo difference: 11.5 +/- 7.7, LOS: 99.8 %, DrawRatio: 45.2 %
SPRT: llr 2.9 (100.5%), lbound -2.25, ubound 2.89 - H1 was accepted
```