### PR TITLE
lmp improving

### DIFF
--- a/Sirius/src/search.cpp
+++ b/Sirius/src/search.cpp
@@ -383,7 +383,7 @@ int Search::search(SearchThread& thread, int depth, SearchPly* searchPly, int al
         depth--;
 
     int staticEval = searchPly->staticEval = eval::evaluate(board);
-    bool improving = rootPly > 1 && searchPly->staticEval > searchPly[-2].staticEval;
+    bool improving = !inCheck && rootPly > 1 && searchPly->staticEval > searchPly[-2].staticEval;
     BoardState state;
 
     if (!isPV && !inCheck)

--- a/Sirius/src/search.cpp
+++ b/Sirius/src/search.cpp
@@ -382,7 +382,8 @@ int Search::search(SearchThread& thread, int depth, SearchPly* searchPly, int al
     else if (depth >= MIN_IIR_DEPTH)
         depth--;
 
-    int staticEval = eval::evaluate(board);
+    int staticEval = searchPly->staticEval = eval::evaluate(board);
+    bool improving = rootPly > 1 && searchPly->staticEval > searchPly[-2].staticEval;
     BoardState state;
 
     if (!isPV && !inCheck)
@@ -460,7 +461,7 @@ int Search::search(SearchThread& thread, int depth, SearchPly* searchPly, int al
             if (!isPV &&
                 !inCheck &&
                 depth <= LMP_MAX_DEPTH &&
-                movesPlayed >= LMP_MIN_MOVES_BASE + depth * depth)
+                movesPlayed >= LMP_MIN_MOVES_BASE + depth * depth / (improving ? 1 : 2))
                 break;
 
             if (!isPV &&

--- a/Sirius/src/search.h
+++ b/Sirius/src/search.h
@@ -17,8 +17,11 @@ struct SearchPly
 {
     Move* pv;
     int pvLength;
+
     Move bestMove;
     std::array<Move, 2> killers;
+
+    int staticEval;
 };
 
 struct SearchInfo


### PR DESCRIPTION
tc: 8+0.08
book: pohl.epd
sprt bounds: [0, 5]
```
Score of sirius-5.0-lmp-improving vs sirius-5.0-see-prune-margin: 630 - 509 - 1037  [0.528] 2176
...      sirius-5.0-lmp-improving playing White: 431 - 135 - 522  [0.636] 1088
...      sirius-5.0-lmp-improving playing Black: 199 - 374 - 515  [0.420] 1088
...      White vs Black: 805 - 334 - 1037  [0.608] 2176
Elo difference: 19.3 +/- 10.6, LOS: 100.0 %, DrawRatio: 47.7 %
SPRT: llr 2.91 (100.6%), lbound -2.25, ubound 2.89 - H1 was accepted
```