### PR TITLE
rfp improving

### DIFF
--- a/Sirius/src/search.cpp
+++ b/Sirius/src/search.cpp
@@ -389,7 +389,7 @@ int Search::search(SearchThread& thread, int depth, SearchPly* searchPly, int al
     if (!isPV && !inCheck)
     {
         // reverse futility pruning
-        if (depth <= RFP_MAX_DEPTH && staticEval >= beta + RFP_MARGIN * depth)
+        if (depth <= RFP_MAX_DEPTH && staticEval >= beta + (RFP_MARGIN - RFP_IMPROVING_FACTOR * improving) * depth)
             return staticEval;
 
         // null move pruning

--- a/Sirius/src/search_params.h
+++ b/Sirius/src/search_params.h
@@ -8,7 +8,7 @@ constexpr int ASP_INIT_DELTA = 25;
 constexpr int MIN_IIR_DEPTH = 4;
 
 constexpr int RFP_MAX_DEPTH = 8;
-constexpr int RFP_IMPROVING_FACTOR = 30;
+constexpr int RFP_IMPROVING_FACTOR = 40;
 constexpr int RFP_MARGIN = 90;
 
 constexpr int NMP_MIN_DEPTH = 2;

--- a/Sirius/src/search_params.h
+++ b/Sirius/src/search_params.h
@@ -8,6 +8,7 @@ constexpr int ASP_INIT_DELTA = 25;
 constexpr int MIN_IIR_DEPTH = 4;
 
 constexpr int RFP_MAX_DEPTH = 8;
+constexpr int RFP_IMPROVING_FACTOR = 30;
 constexpr int RFP_MARGIN = 90;
 
 constexpr int NMP_MIN_DEPTH = 2;

--- a/Sirius/src/search_params.h
+++ b/Sirius/src/search_params.h
@@ -8,8 +8,8 @@ constexpr int ASP_INIT_DELTA = 25;
 constexpr int MIN_IIR_DEPTH = 4;
 
 constexpr int RFP_MAX_DEPTH = 8;
-constexpr int RFP_IMPROVING_FACTOR = 40;
-constexpr int RFP_MARGIN = 90;
+constexpr int RFP_IMPROVING_FACTOR = 30;
+constexpr int RFP_MARGIN = 80;
 
 constexpr int NMP_MIN_DEPTH = 2;
 constexpr int NMP_BASE_REDUCTION = 3;

--- a/Sirius/src/search_params.h
+++ b/Sirius/src/search_params.h
@@ -8,7 +8,7 @@ constexpr int ASP_INIT_DELTA = 25;
 constexpr int MIN_IIR_DEPTH = 4;
 
 constexpr int RFP_MAX_DEPTH = 8;
-constexpr int RFP_MARGIN = 75;
+constexpr int RFP_MARGIN = 90;
 
 constexpr int NMP_MIN_DEPTH = 2;
 constexpr int NMP_BASE_REDUCTION = 3;


### PR DESCRIPTION
tc: 8+0.08
sprt bounds: [0, 10]
book: pohl.epd
```
Score of sirius-5.0-rfp-improving vs sirius-5.0-lmp-improving: 554 - 472 - 900  [0.521] 1926
...      sirius-5.0-rfp-improving playing White: 402 - 137 - 424  [0.638] 963
...      sirius-5.0-rfp-improving playing Black: 152 - 335 - 476  [0.405] 963
...      White vs Black: 737 - 289 - 900  [0.616] 1926
Elo difference: 14.8 +/- 11.3, LOS: 99.5 %, DrawRatio: 46.7 %
SPRT: llr 2.94 (101.7%), lbound -2.25, ubound 2.89 - H1 was accepted
```