### PR TITLE
Best move fix

### DIFF
--- a/Sirius/src/search.cpp
+++ b/Sirius/src/search.cpp
@@ -516,6 +516,19 @@ int Search::search(SearchThread& thread, int depth, SearchPly* searchPly, int al
         {
             bestScore = score;
 
+            if (bestScore > alpha)
+            {
+                bound = TTEntry::Bound::EXACT;
+                alpha = bestScore;
+                searchPly->bestMove = move;
+                if (isPV)
+                {
+                    searchPly->pv[0] = move;
+                    searchPly->pvLength = searchPly[1].pvLength + 1;
+                    memcpy(searchPly->pv + 1, searchPly[1].pv, searchPly[1].pvLength * sizeof(Move));
+                }
+            }
+
             if (bestScore >= beta)
             {
                 if (quiet)
@@ -532,19 +545,6 @@ int Search::search(SearchThread& thread, int depth, SearchPly* searchPly, int al
                 }
                 m_TT.store(bucket, board.zkey(), depth, rootPly, bestScore, move, TTEntry::Bound::LOWER_BOUND);
                 return bestScore;
-            }
-
-            if (bestScore > alpha)
-            {
-                bound = TTEntry::Bound::EXACT;
-                alpha = bestScore;
-                searchPly->bestMove = move;
-                if (isPV)
-                {
-                    searchPly->pv[0] = move;
-                    searchPly->pvLength = searchPly[1].pvLength + 1;
-                    memcpy(searchPly->pv + 1, searchPly[1].pv, searchPly[1].pvLength * sizeof(Move));
-                }
             }
         }
     }

--- a/Sirius/src/search.h
+++ b/Sirius/src/search.h
@@ -111,7 +111,7 @@ private:
     void threadLoop(SearchThread& thread);
 
     int iterDeep(SearchThread& thread, bool report, bool normalSearch);
-    int aspWindows(SearchThread& thread, int depth, int prevScore);
+    int aspWindows(SearchThread& thread, int depth, Move& bestMove, int prevScore);
 
     void storeKiller(SearchPly* ply, Move killer);
     int search(SearchThread& thread, int depth, SearchPly* searchPly, int alpha, int beta, bool isPV);


### PR DESCRIPTION
sprt bound: [-5,0]
book: pohl.epd
tc: 8+0.08
```
Score of sirius-5.0-best-move-fix vs sirius-5.0-rfp-improving: 1642 - 1574 - 2683  [0.506] 5899
...      sirius-5.0-best-move-fix playing White: 1173 - 433 - 1344  [0.625] 2950
...      sirius-5.0-best-move-fix playing Black: 469 - 1141 - 1339  [0.386] 2949
...      White vs Black: 2314 - 902 - 2683  [0.620] 5899
Elo difference: 4.0 +/- 6.5, LOS: 88.5 %, DrawRatio: 45.5 %
SPRT: llr 2.92 (100.9%), lbound -2.25, ubound 2.89 - H1 was accepted
```