### PR TITLE
Avoid clearing history between searches

### DIFF
--- a/Sirius/src/search.cpp
+++ b/Sirius/src/search.cpp
@@ -36,7 +36,6 @@ SearchThread::SearchThread(uint32_t id, std::thread&& thread)
 
 void SearchThread::reset()
 {
-    history.clear();
     nodes = 0;
     rootPly = 0;
     checkCounter = TIME_CHECK_INTERVAL;
@@ -102,6 +101,7 @@ void Search::newGame()
     for (auto& thread : m_Threads)
     {
         thread->reset();
+        thread->history.clear();
     }
     m_TT.reset();
 }


### PR DESCRIPTION
tc: 8+0.08
book: pohl.epd
sprt bounds: [-5, 0]
```
Score of sirius-5.0-no-clear-hist vs sirius-5.0-history-refactor: 1455 - 1383 - 2469  [0.507] 5307
...      sirius-5.0-no-clear-hist playing White: 1046 - 403 - 1205  [0.621] 2654
...      sirius-5.0-no-clear-hist playing Black: 409 - 980 - 1264  [0.392] 2653
...      White vs Black: 2026 - 812 - 2469  [0.614] 5307
Elo difference: 4.7 +/- 6.8, LOS: 91.2 %, DrawRatio: 46.5 %
SPRT: llr 2.97 (100.7%), lbound -2.94, ubound 2.94 - H1 was accepted
Finished match
```