### PR TITLE
Different history bonus + reduced max history to 16384

### DIFF
--- a/Sirius/src/history.cpp
+++ b/Sirius/src/history.cpp
@@ -22,7 +22,8 @@ void fillHistTable(std::array<T, N>& arr, int value)
 
 int historyBonus(int depth)
 {
-    return std::min(16 * depth * depth, 1200);
+    // formula from berserk
+    return std::min(1896, 4 * depth * depth + 120 * depth - 120);
 }
 
 

--- a/Sirius/src/history.h
+++ b/Sirius/src/history.h
@@ -89,7 +89,7 @@ inline void HistoryEntry<MAX_VAL>::update(int bonus)
     m_Value += bonus - m_Value * std::abs(bonus) / MAX_VAL;
 }
 
-static constexpr int HISTORY_MAX = 65536;
+static constexpr int HISTORY_MAX = 16384;
 
 using MainHist = std::array<std::array<HistoryEntry<HISTORY_MAX>, 4096>, 2>;
 

--- a/Sirius/src/search.cpp
+++ b/Sirius/src/search.cpp
@@ -526,7 +526,6 @@ int Search::search(SearchThread& thread, int depth, SearchPly* searchPly, int al
                 {
                     storeKiller(searchPly, move);
 
-                    // formula from akimbo
                     int bonus = historyBonus(depth);
                     history.updateQuietStats(ExtMove::from(board, move), bonus);
                     for (int j = 0; j < static_cast<int>(quietsTried.size() - 1); j++)


### PR DESCRIPTION
tc: 8+0.08
book: pohl.epd
sprt bounds: [0, 5]
```
Score of sirius-5.0-hist-stuff vs sirius-5.0-no-clear-hist: 1544 - 1395 - 2559  [0.514] 5498
...      sirius-5.0-hist-stuff playing White: 1109 - 371 - 1269  [0.634] 2749
...      sirius-5.0-hist-stuff playing Black: 435 - 1024 - 1290  [0.393] 2749
...      White vs Black: 2133 - 806 - 2559  [0.621] 5498
Elo difference: 9.4 +/- 6.7, LOS: 99.7 %, DrawRatio: 46.5 %
SPRT: llr 2.95 (100.2%), lbound -2.94, ubound 2.94 - H1 was accepted
```
Bench: 6236317