### PR TITLE
Adjust lmr based on history

### DIFF
--- a/Sirius/src/search.cpp
+++ b/Sirius/src/search.cpp
@@ -433,10 +433,12 @@ int Search::search(SearchThread& thread, int depth, SearchPly* searchPly, int al
     for (int moveIdx = 0; moveIdx < static_cast<int>(moves.size()); moveIdx++)
     {
         auto [move, moveScore] = ordering.selectMove(static_cast<uint32_t>(moveIdx));
-		bool quiet = moveIsQuiet(board, move);
+        bool quiet = moveIsQuiet(board, move);
         bool quietLosing = moveScore < MoveOrdering::KILLER_SCORE;
 
         int baseLMR = lmrTable[std::min(depth, 63)][std::min(movesPlayed, 63)];
+        if (quiet)
+            baseLMR -= moveScore / 8192;
 
         if (!root && quietLosing && bestScore > -SCORE_WIN)
         {


### PR DESCRIPTION
tc: 8+0.08
book: pohl.epd
sprt bounds: [0, 5]
```
Score of sirius-5.0-lmr-history vs sirius-5.0-hist-stuff: 1875 - 1716 - 3034  [0.512] 6625
...      sirius-5.0-lmr-history playing White: 1319 - 507 - 1487  [0.623] 3313
...      sirius-5.0-lmr-history playing Black: 556 - 1209 - 1547  [0.401] 3312
...      White vs Black: 2528 - 1063 - 3034  [0.611] 6625
Elo difference: 8.3 +/- 6.2, LOS: 99.6 %, DrawRatio: 45.8 %
SPRT: llr 2.96 (100.5%), lbound -2.94, ubound 2.94 - H1 was accepted
```
Bench: 6257589