### PR TITLE
Added countermove history/continuation history

### DIFF
--- a/Sirius/src/history.cpp
+++ b/Sirius/src/history.cpp
@@ -30,17 +30,24 @@ int historyBonus(int depth)
 void History::clear()
 {
     fillHistTable(m_MainHist, 0);
+    fillHistTable(m_ContHist, 0);
 }
 
-int History::getQuietStats(ExtMove move) const
+int History::getQuietStats(ExtMove move, std::span<const CHEntry* const> contHistEntries) const
 {
     int score = getMainHist(move);
+    for (auto entry : contHistEntries)
+        if (entry)
+            score += getContHist(entry, move);
     return score;
 }
 
-void History::updateQuietStats(ExtMove move, int bonus)
+void History::updateQuietStats(ExtMove move, std::span<CHEntry*> contHistEntries, int bonus)
 {
     updateMainHist(move, bonus);
+    for (auto entry : contHistEntries)
+        if (entry)
+            updateContHist(entry, move, bonus);
 }
 
 int History::getMainHist(ExtMove move) const
@@ -48,7 +55,17 @@ int History::getMainHist(ExtMove move) const
     return m_MainHist[static_cast<int>(getPieceColor(move.movingPiece()))][move.fromTo()];
 }
 
+int History::getContHist(const CHEntry* entry, ExtMove move) const
+{
+    return (*entry)[static_cast<int>(move.movingPiece())][move.dstPos()];
+}
+
 void History::updateMainHist(ExtMove move, int bonus)
 {
     m_MainHist[static_cast<int>(getPieceColor(move.movingPiece()))][move.fromTo()].update(bonus);
+}
+
+void History::updateContHist(CHEntry* entry, ExtMove move, int bonus)
+{
+    (*entry)[static_cast<int>(move.movingPiece())][move.dstPos()].update(bonus);
 }

--- a/Sirius/src/history.h
+++ b/Sirius/src/history.h
@@ -92,6 +92,8 @@ inline void HistoryEntry<MAX_VAL>::update(int bonus)
 static constexpr int HISTORY_MAX = 16384;
 
 using MainHist = std::array<std::array<HistoryEntry<HISTORY_MAX>, 4096>, 2>;
+using CHEntry = std::array<std::array<HistoryEntry<HISTORY_MAX>, 64>, 16>;
+using ContHist = std::array<std::array<CHEntry, 64>, 16>;
 
 int historyBonus(int depth);
 
@@ -100,14 +102,27 @@ class History
 public:
     History() = default;
 
-    int getQuietStats(ExtMove move) const;
+    CHEntry& contHistEntry(ExtMove move)
+    {
+        return m_ContHist[static_cast<int>(move.movingPiece())][move.dstPos()];
+    }
+
+    const CHEntry& contHistEntry(ExtMove move) const
+    {
+        return m_ContHist[static_cast<int>(move.movingPiece())][move.dstPos()];
+    }
+
+    int getQuietStats(ExtMove move, std::span<const CHEntry* const> contHistEntries) const;
 
     void clear();
-    void updateQuietStats(ExtMove move, int bonus);
+    void updateQuietStats(ExtMove move, std::span<CHEntry*> contHistEntries, int bonus);
 private:
     int getMainHist(ExtMove move) const;
+    int getContHist(const CHEntry* entry, ExtMove move) const;
 
     void updateMainHist(ExtMove move, int bonus);
+    void updateContHist(CHEntry* entry, ExtMove move, int bonus);
 
     MainHist m_MainHist;
+    ContHist m_ContHist;
 };

--- a/Sirius/src/move_ordering.cpp
+++ b/Sirius/src/move_ordering.cpp
@@ -61,7 +61,7 @@ MoveOrdering::MoveOrdering(const Board& board, MoveList& moves, Move hashMove)
     }
 }
 
-MoveOrdering::MoveOrdering(const Board& board, MoveList& moves, Move hashMove, const std::array<Move, 2>& killers, const History& history)
+MoveOrdering::MoveOrdering(const Board& board, MoveList& moves, Move hashMove, const std::array<Move, 2>& killers, std::span<const CHEntry* const> contHistEntries, const History& history)
     : m_Moves(moves)
 {
     for (uint32_t i = 0; i < m_Moves.size(); i++)
@@ -89,7 +89,7 @@ MoveOrdering::MoveOrdering(const Board& board, MoveList& moves, Move hashMove, c
         else if (move == killers[0] || move == killers[1])
             score = KILLER_SCORE;
         else
-            score = history.getQuietStats(ExtMove::from(board, move));
+            score = history.getQuietStats(ExtMove::from(board, move), contHistEntries);
         m_MoveScores[i] = score;
     }
 }

--- a/Sirius/src/move_ordering.h
+++ b/Sirius/src/move_ordering.h
@@ -17,12 +17,12 @@ bool moveIsCapture(const Board& board, Move move);
 class MoveOrdering
 {
 public:
-    static constexpr int KILLER_SCORE = 65550;
-    static constexpr int PROMOTION_SCORE = 65555;
-    static constexpr int CAPTURE_SCORE = 65560;
+    static constexpr int KILLER_SCORE = 300000;
+    static constexpr int PROMOTION_SCORE = 400000;
+    static constexpr int CAPTURE_SCORE = 500000;
 
     MoveOrdering(const Board& board, MoveList& moves, Move hashMove);
-    MoveOrdering(const Board& board, MoveList& moves, Move hashMove, const std::array<Move, 2>& killers, const History& history);
+    MoveOrdering(const Board& board, MoveList& moves, Move hashMove, const std::array<Move, 2>& killers, std::span<const CHEntry* const> contHistEntries, const History& history);
 
     ScoredMove selectMove(uint32_t index);
 private:

--- a/Sirius/src/search.h
+++ b/Sirius/src/search.h
@@ -22,6 +22,8 @@ struct SearchPly
     Move bestMove;
     std::array<Move, 2> killers;
 
+    CHEntry* contHistEntry;
+
     int staticEval;
 };
 


### PR DESCRIPTION
tc: 8+0.08
book: pohl.epd
sprt bounds: [0, 5]
```
Score of sirius-5.0-cont-hist vs sirius-5.0-new-eval: 1434 - 1283 - 2089  [0.516] 4806
...      sirius-5.0-cont-hist playing White: 1029 - 363 - 1011  [0.639] 2403
...      sirius-5.0-cont-hist playing Black: 405 - 920 - 1078  [0.393] 2403
...      White vs Black: 1949 - 768 - 2089  [0.623] 4806
Elo difference: 10.9 +/- 7.4, LOS: 99.8 %, DrawRatio: 43.5 %
SPRT: llr 2.97 (100.8%), lbound -2.94, ubound 2.94 - H1 was accepted
```
Bench: 7055689