### PR TITLE
Added followup move history/2 ply continuation history

### DIFF
--- a/Sirius/src/search.cpp
+++ b/Sirius/src/search.cpp
@@ -412,8 +412,9 @@ int Search::search(SearchThread& thread, int depth, SearchPly* searchPly, int al
         return SCORE_DRAW;
     }
 
-    std::array<CHEntry*, 1> contHistEntries = {
-        rootPly > 0 ? searchPly[-1].contHistEntry : nullptr
+    std::array<CHEntry*, 2> contHistEntries = {
+        rootPly > 0 ? searchPly[-1].contHistEntry : nullptr,
+        rootPly > 1 ? searchPly[-2].contHistEntry : nullptr
     };
 
     MoveOrdering ordering(


### PR DESCRIPTION
tc: 8+0.08
book: pohl.epd
sprt bounds: [0, 5]
```
Score of sirius-5.0-2ply-cont-hist vs sirius-5.0-cont-hist: 1283 - 1138 - 1935  [0.517] 4356
...      sirius-5.0-2ply-cont-hist playing White: 900 - 331 - 947  [0.631] 2178
...      sirius-5.0-2ply-cont-hist playing Black: 383 - 807 - 988  [0.403] 2178
...      White vs Black: 1707 - 714 - 1935  [0.614] 4356
Elo difference: 11.6 +/- 7.7, LOS: 99.8 %, DrawRatio: 44.4 %
SPRT: llr 2.95 (100.1%), lbound -2.94, ubound 2.94 - H1 was accepted
```
Bench: 7077919