### PR TITLE
Fixed tt aging

### DIFF
--- a/Sirius/src/tt.h
+++ b/Sirius/src/tt.h
@@ -70,7 +70,7 @@ public:
 
     void incAge()
     {
-        m_CurrAge = (m_CurrAge + 1) & (GEN_CYCLE_LENGTH);
+        m_CurrAge = (m_CurrAge + 1) % GEN_CYCLE_LENGTH;
     }
 
     void reset()


### PR DESCRIPTION
tc: 8+0.08
book: pohl.epd
sprt bounds: [-5, 0]
```
Score of sirius-5.0-tt-age-fix vs sirius-5.0-2ply-cont-hist: 2491 - 2437 - 3749  [0.503] 8677
...      sirius-5.0-tt-age-fix playing White: 1753 - 732 - 1854  [0.618] 4339
...      sirius-5.0-tt-age-fix playing Black: 738 - 1705 - 1895  [0.389] 4338
...      White vs Black: 3458 - 1470 - 3749  [0.615] 8677
Elo difference: 2.2 +/- 5.5, LOS: 77.9 %, DrawRatio: 43.2 %
SPRT: llr 2.95 (100.2%), lbound -2.94, ubound 2.94 - H1 was accepted
```
Bench: 7077919