### PR TITLE
Added node tm

### DIFF
--- a/Sirius/src/search.cpp
+++ b/Sirius/src/search.cpp
@@ -251,7 +251,7 @@ int Search::iterDeep(SearchThread& thread, bool report, bool normalSearch)
                 comm::currComm->reportSearchInfo(info);
             }
         }
-        if (m_TimeMan.stopSoft(thread.limits))
+        if (m_TimeMan.stopSoft(bestMove, thread.nodes, thread.limits))
             break;
     }
 
@@ -471,6 +471,7 @@ int Search::search(SearchThread& thread, int depth, SearchPly* searchPly, int al
 
         searchPly->contHistEntry = &history.contHistEntry(ExtMove::from(board, move));
 
+        uint64_t nodesBefore = thread.nodes;
         board.makeMove(move, state);
         thread.nodes++;
         bool givesCheck = board.checkers() != 0;
@@ -510,6 +511,8 @@ int Search::search(SearchThread& thread, int depth, SearchPly* searchPly, int al
         }
         rootPly--;
         board.unmakeMove(move);
+        if (root && thread.isMainThread())
+            m_TimeMan.updateNodes(move, thread.nodes - nodesBefore);
 
         searchPly->contHistEntry = nullptr;
 

--- a/Sirius/src/time_man.cpp
+++ b/Sirius/src/time_man.cpp
@@ -22,7 +22,13 @@ Duration TimeManager::elapsed() const
 
 void TimeManager::startSearch()
 {
+    std::fill(m_NodeCounts.begin(), m_NodeCounts.end(), 0);
     m_StartTime = std::chrono::steady_clock::now();
+}
+
+void TimeManager::updateNodes(Move move, uint64_t nodes)
+{
+    m_NodeCounts[move.fromTo()] += nodes;
 }
 
 bool TimeManager::stopHard(const SearchLimits& searchLimits) const
@@ -34,9 +40,11 @@ bool TimeManager::stopHard(const SearchLimits& searchLimits) const
     return false;
 }
 
-bool TimeManager::stopSoft(const SearchLimits& searchLimits) const
+bool TimeManager::stopSoft(Move bestMove, uint64_t totalNodes, const SearchLimits& searchLimits) const
 {
-    if (searchLimits.clock.enabled && elapsed() > m_SoftBound)
+    double bmNodes = static_cast<double>(m_NodeCounts[bestMove.fromTo()]) / static_cast<double>(totalNodes);
+    double scale = (1.5 - bmNodes) * 1.35;
+    if (searchLimits.clock.enabled && elapsed() > m_SoftBound * scale)
         return true;
     return false;
 }

--- a/Sirius/src/time_man.h
+++ b/Sirius/src/time_man.h
@@ -29,10 +29,13 @@ public:
     Duration elapsed() const;
 
     void startSearch();
+    void updateNodes(Move move, uint64_t nodes);
     bool stopHard(const SearchLimits& searchLimits) const;
-    bool stopSoft(const SearchLimits& searchLimits) const;
+    bool stopSoft(Move bestMove, uint64_t totalNodes, const SearchLimits& searchLimits) const;
 private:
     TimePoint m_StartTime;
     Duration m_HardBound;
     Duration m_SoftBound;
+
+    std::array<uint64_t, 4096> m_NodeCounts;
 };


### PR DESCRIPTION
tc: 8+0.08
book: pohl.epd
sprt bounds: [0, 5]
```
Score of sirius-5.0-node-tm vs sirius-5.0-tt-age-fix: 1174 - 1027 - 1568  [0.520] 3769
...      sirius-5.0-node-tm playing White: 838 - 287 - 760  [0.646] 1885
...      sirius-5.0-node-tm playing Black: 336 - 740 - 808  [0.393] 1884
...      White vs Black: 1578 - 623 - 1568  [0.627] 3769
Elo difference: 13.6 +/- 8.5, LOS: 99.9 %, DrawRatio: 41.6 %
SPRT: llr 2.96 (100.5%), lbound -2.94, ubound 2.94 - H1 was accepted
```
Bench: 5299328