### PR TITLE
Pseudo legal

### DIFF
--- a/Sirius/src/board.cpp
+++ b/Sirius/src/board.cpp
@@ -938,7 +938,6 @@ void Board::updateCheckInfo()
     uint32_t kingIdx = m_SideToMove == Color::WHITE ? whiteKingIdx : blackKingIdx;
 
     m_State->checkInfo.checkers = attackersTo(flip(m_SideToMove), kingIdx);
-    m_State->checkInfo.targetMask = checkers() ? attacks::moveMaskBB(kingIdx, getLSB(checkers())) : ~0ull;
     m_State->checkInfo.blockers[static_cast<int>(Color::WHITE)] =
         pinnersBlockers(whiteKingIdx, getColor(Color::BLACK), m_State->checkInfo.pinners[static_cast<int>(Color::WHITE)]);
     m_State->checkInfo.blockers[static_cast<int>(Color::BLACK)] =

--- a/Sirius/src/board.cpp
+++ b/Sirius/src/board.cpp
@@ -27,7 +27,7 @@ void Board::setToFen(const std::string_view& fen)
     m_Squares = {};
     m_Pieces = {};
     m_Colors = {};
-    
+
     m_EvalState.init();
     m_State->zkey.value = 0;
     m_State->pawnKey.value = 0;
@@ -178,7 +178,7 @@ void Board::setToEpd(const std::string_view& epd)
     m_Squares = {};
     m_Pieces = {};
     m_Colors = {};
-    
+
     m_EvalState.init();
     m_State->zkey.value = 0;
     m_State->pawnKey.value = 0;
@@ -337,7 +337,7 @@ constexpr std::array<char, 16> pieceChars = {
 
 std::string Board::stringRep() const
 {
-    
+
     std::string result;
     const char* between = "+---+---+---+---+---+---+---+---+\n";
 
@@ -903,12 +903,42 @@ bool Board::see_margin(Move move, int margin) const
     return us;
 }
 
+bool Board::isLegal(Move move) const
+{
+    uint32_t kingIdx = getLSB(getPieces(m_SideToMove, PieceType::KING));
+    int from = move.srcPos();
+    int to = move.dstPos();
+
+    if (move.type() == MoveType::ENPASSANT)
+    {
+        int captureSq = to + (m_SideToMove == Color::WHITE ? -8 : 8);
+        BitBoard piecesAfter = (1ull << to) | (getAllPieces() ^ (1ull << from) ^ (1ull << captureSq));
+        return !(attacks::getRookAttacks(kingIdx, piecesAfter) & (getPieces(flip(m_SideToMove), PieceType::ROOK) | getPieces(flip(m_SideToMove), PieceType::QUEEN))) &&
+            !(attacks::getBishopAttacks(kingIdx, piecesAfter) & (getPieces(flip(m_SideToMove), PieceType::BISHOP) | getPieces(flip(m_SideToMove), PieceType::QUEEN)));
+    }
+
+    if (getPieceType(m_Squares[from]) == PieceType::KING)
+    {
+        if (move.type() == MoveType::CASTLE && squareAttacked(flip(m_SideToMove), (move.srcPos() + move.dstPos()) / 2))
+            return false;
+        return !squareAttacked(flip(m_SideToMove), move.dstPos(), getAllPieces() ^ (1ull << from));
+    }
+
+    // pinned pieces
+    return !(
+        (checkBlockers(m_SideToMove) & (1ull << move.srcPos())) &&
+        !(attacks::pinRayBB(kingIdx, move.srcPos()) & (1ull << move.dstPos()))
+    );
+}
+
 void Board::updateCheckInfo()
 {
     uint32_t whiteKingIdx = getLSB(getPieces(Color::WHITE, PieceType::KING));
     uint32_t blackKingIdx = getLSB(getPieces(Color::BLACK, PieceType::KING));
+    uint32_t kingIdx = m_SideToMove == Color::WHITE ? whiteKingIdx : blackKingIdx;
 
-    m_State->checkInfo.checkers = attackersTo(flip(m_SideToMove), m_SideToMove == Color::WHITE ? whiteKingIdx : blackKingIdx);
+    m_State->checkInfo.checkers = attackersTo(flip(m_SideToMove), kingIdx);
+    m_State->checkInfo.targetMask = checkers() ? attacks::moveMaskBB(kingIdx, getLSB(checkers())) : ~0ull;
     m_State->checkInfo.blockers[static_cast<int>(Color::WHITE)] =
         pinnersBlockers(whiteKingIdx, getColor(Color::BLACK), m_State->checkInfo.pinners[static_cast<int>(Color::WHITE)]);
     m_State->checkInfo.blockers[static_cast<int>(Color::BLACK)] =

--- a/Sirius/src/board.h
+++ b/Sirius/src/board.h
@@ -12,7 +12,6 @@
 struct CheckInfo
 {
     BitBoard checkers;
-    BitBoard targetMask;
     std::array<BitBoard, 2> pinners;
     std::array<BitBoard, 2> blockers;
 

--- a/Sirius/src/board.h
+++ b/Sirius/src/board.h
@@ -12,8 +12,10 @@
 struct CheckInfo
 {
     BitBoard checkers;
+    BitBoard targetMask;
     std::array<BitBoard, 2> pinners;
     std::array<BitBoard, 2> blockers;
+
 };
 
 struct BoardState
@@ -55,8 +57,6 @@ public:
     std::string fenStr() const;
     std::string epdStr() const;
 
-    void printDbg() const;
-
     void makeMove(Move move, BoardState& state);
     void unmakeMove(Move move);
     void makeNullMove(BoardState& state);
@@ -91,13 +91,15 @@ public:
     BitBoard pinnersBlockers(uint32_t square, BitBoard attackers, BitBoard& pinners) const;
 
     BitBoard checkers() const;
-    BitBoard pinners(Color color) const;
     BitBoard checkBlockers(Color color) const;
 
     bool see_margin(Move move, int margin) const;
+    bool isLegal(Move move) const;
 
     const eval::EvalState& evalState() const;
 private:
+    BitBoard pinners(Color color) const;
+
     void updateCheckInfo();
     void calcRepetitions();
     void addPiece(int pos, Color color, PieceType piece);

--- a/Sirius/src/comm/cmdline.cpp
+++ b/Sirius/src/comm/cmdline.cpp
@@ -17,7 +17,7 @@ CmdLine::CmdLine()
     std::cout << "Sirius " << SIRIUS_VERSION_STRING << std::endl;
 
     std::ifstream openings("res/gaviota_trim.pgn");
-    if (openings.is_open())
+    /*if (openings.is_open())
     {
         std::ostringstream sstr;
         sstr << openings.rdbuf();
@@ -28,7 +28,7 @@ CmdLine::CmdLine()
     else
     {
         std::cout << "No opening book loaded" << std::endl;
-    }
+    }*/
 }
 
 void CmdLine::run()

--- a/Sirius/src/comm/cmdline.cpp
+++ b/Sirius/src/comm/cmdline.cpp
@@ -17,7 +17,7 @@ CmdLine::CmdLine()
     std::cout << "Sirius " << SIRIUS_VERSION_STRING << std::endl;
 
     std::ifstream openings("res/gaviota_trim.pgn");
-    /*if (openings.is_open())
+    if (openings.is_open())
     {
         std::ostringstream sstr;
         sstr << openings.rdbuf();
@@ -28,7 +28,7 @@ CmdLine::CmdLine()
     else
     {
         std::cout << "No opening book loaded" << std::endl;
-    }*/
+    }
 }
 
 void CmdLine::run()

--- a/Sirius/src/misc.cpp
+++ b/Sirius/src/misc.cpp
@@ -109,7 +109,7 @@ void testQuiescence(Board& board, int depth)
     if (depth == 0)
     {
         MoveList captures;
-        genMoves<MoveGenType::CAPTURES>(board, captures);
+        genMoves<MoveGenType::NOISY>(board, captures);
 
         for (Move move : captures)
         {
@@ -147,7 +147,7 @@ void testSEE()
         board.setToEpd(std::string_view(line).substr(0, sep1));
 
         int moveStart = sep1 + 2;
-        
+
         MoveList moves;
         genMoves<MoveGenType::LEGAL>(board, moves);
 

--- a/Sirius/src/movegen.cpp
+++ b/Sirius/src/movegen.cpp
@@ -61,10 +61,10 @@ void genMoves(const Board& board, MoveList& moves)
     if ((checkers & (checkers - 1)) == 0)
     {
         uint32_t kingIdx = getLSB(board.getPieces(color, PieceType::KING));
-        BitBoard moveMask = ~board.getColor(board.sideToMove()) & (checkers ? attacks::moveMaskBB(kingIdx, getLSB(checkers)) : ~0ull);
+        BitBoard moveMask = ~board.getColor(color) & (checkers ? attacks::moveMaskBB(kingIdx, getLSB(checkers)) : ~0ull);
+        genPawnMoves<type, color>(board, moves, moveMask);
         if constexpr (type == MoveGenType::NOISY)
             moveMask &= board.getColor(flip<color>());
-        genPawnMoves<type, color>(board, moves, moveMask);
         genKnightMoves<type, color>(board, moves, moveMask);
         genBishopMoves<type, color>(board, moves, moveMask);
         genRookMoves<type, color>(board, moves, moveMask);

--- a/Sirius/src/movegen.h
+++ b/Sirius/src/movegen.h
@@ -6,7 +6,8 @@
 enum class MoveGenType
 {
     LEGAL,
-    CAPTURES
+    NOISY_QUIET,
+    NOISY
 };
 
 using MoveList = StaticVector<Move, 256>;

--- a/Sirius/src/search.cpp
+++ b/Sirius/src/search.cpp
@@ -403,13 +403,6 @@ int Search::search(SearchThread& thread, int depth, SearchPly* searchPly, int al
     MoveList moves;
     genMoves<MoveGenType::NOISY_QUIET>(board, moves);
 
-    if (moves.size() == 0)
-    {
-        if (inCheck)
-            return -SCORE_MATE + rootPly;
-        return SCORE_DRAW;
-    }
-
     std::array<CHEntry*, 2> contHistEntries = {
         rootPly > 0 ? searchPly[-1].contHistEntry : nullptr,
         rootPly > 1 ? searchPly[-2].contHistEntry : nullptr
@@ -555,6 +548,13 @@ int Search::search(SearchThread& thread, int depth, SearchPly* searchPly, int al
                 return bestScore;
             }
         }
+    }
+
+    if (movesPlayed == 0)
+    {
+        if (inCheck)
+            return -SCORE_MATE + rootPly;
+        return SCORE_DRAW;
     }
 
     m_TT.store(bucket, board.zkey(), depth, rootPly, bestScore, searchPly->bestMove, bound);

--- a/Sirius/src/search.cpp
+++ b/Sirius/src/search.cpp
@@ -401,7 +401,7 @@ int Search::search(SearchThread& thread, int depth, SearchPly* searchPly, int al
     }
 
     MoveList moves;
-    genMoves<MoveGenType::LEGAL>(board, moves);
+    genMoves<MoveGenType::NOISY_QUIET>(board, moves);
 
     if (moves.size() == 0)
     {
@@ -439,6 +439,8 @@ int Search::search(SearchThread& thread, int depth, SearchPly* searchPly, int al
     for (int moveIdx = 0; moveIdx < static_cast<int>(moves.size()); moveIdx++)
     {
         auto [move, moveScore, moveHistory] = ordering.selectMove(static_cast<uint32_t>(moveIdx));
+        if (!board.isLegal(move))
+            continue;
         bool quiet = moveIsQuiet(board, move);
         bool quietLosing = moveScore < MoveOrdering::KILLER_SCORE;
 
@@ -599,7 +601,7 @@ int Search::qsearch(SearchThread& thread, SearchPly* searchPly, int alpha, int b
     searchPly[1].pv = childPV.data();
 
     MoveList captures;
-    genMoves<MoveGenType::CAPTURES>(board, captures);
+    genMoves<MoveGenType::NOISY>(board, captures);
 
     MoveOrdering ordering(board, captures, ttMove);
 
@@ -609,6 +611,8 @@ int Search::qsearch(SearchThread& thread, SearchPly* searchPly, int alpha, int b
     for (int moveIdx = 0; moveIdx < static_cast<int>(captures.size()); moveIdx++)
     {
         auto [move, moveScore, moveHistory] = ordering.selectMove(moveIdx);
+        if (!board.isLegal(move))
+            continue;
         if (!board.see_margin(move, 0))
             continue;
         board.makeMove(move, state);

--- a/Sirius/src/util/static_vector.h
+++ b/Sirius/src/util/static_vector.h
@@ -31,6 +31,7 @@ public:
         std::fill(begin(), end(), value);
     }
 
+
     size_t size() const
     {
         return m_Size;
@@ -76,6 +77,11 @@ public:
     {
         assert(pos < m_Size);
         return m_Data[pos];
+    }
+
+    void resize(size_t size)
+    {
+        m_Size = size;
     }
 private:
     std::array<T, Capacity> m_Data;


### PR DESCRIPTION
tc: 5+0.05
book: pohl.epd
sprt bounds: [-5, 0]

```
Score of sirius-5.0-pseudo-legal-movegen vs sirius-5.0-node-tm: 336 - 225 - 404  [0.558] 965
...      sirius-5.0-pseudo-legal-movegen playing White: 230 - 58 - 195  [0.678] 483
...      sirius-5.0-pseudo-legal-movegen playing Black: 106 - 167 - 209  [0.437] 482
...      White vs Black: 397 - 164 - 404  [0.621] 965
Elo difference: 40.1 +/- 16.7, LOS: 100.0 %, DrawRatio: 41.9 %
SPRT: llr 2.95 (100.3%), lbound -2.94, ubound 2.94 - H1 was accepted
```

Bench: 4994450
Bench changes because pseudo-legal movegen sometimes generates illegal moves, which can create slight changes in the ordering of moves with equal history scores/capture scores.

This patch also includes a fix to the noisy move generator, which, previously, did not include non-capturing promotions. It probably should be tested separately but I'm too lazy to dothat.