### PR TITLE
lmr improving

### DIFF
--- a/Sirius/src/search.cpp
+++ b/Sirius/src/search.cpp
@@ -482,6 +482,7 @@ int Search::search(SearchThread& thread, int depth, SearchPly* searchPly, int al
         {
             reduction = baseLMR;
 
+            reduction += !improving;
             reduction -= isPV;
             reduction -= givesCheck;
 


### PR DESCRIPTION
tc: 8+0.08
book: pohl.epd
sprt bounds: [0, 10]

```
Score of sirius-5.0-lmr-improving vs sirius-5.0-pseudo-legal-movegen: 487 - 407 - 719  [0.525] 1613
...      sirius-5.0-lmr-improving playing White: 366 - 108 - 333  [0.660] 807
...      sirius-5.0-lmr-improving playing Black: 121 - 299 - 386  [0.390] 806
...      White vs Black: 665 - 229 - 719  [0.635] 1613
Elo difference: 17.2 +/- 12.6, LOS: 99.6 %, DrawRatio: 44.6 %
SPRT: llr 2.96 (100.4%), lbound -2.94, ubound 2.94 - H1 was accepted
```
Bench: 4023399