### PR TITLE
Added history pruning

### DIFF
--- a/Sirius/src/search.cpp
+++ b/Sirius/src/search.cpp
@@ -465,8 +465,8 @@ int Search::search(SearchThread& thread, int depth, SearchPly* searchPly, int al
 
             if (!isPV &&
                 quiet &&
-                depth < 5 &&
-                moveHistory < -1536 * depth)
+                depth <= MAX_HIST_PRUNING_DEPTH &&
+                moveHistory < -HIST_PRUNING_MARGIN * depth)
                 break;
         }
 

--- a/Sirius/src/search.cpp
+++ b/Sirius/src/search.cpp
@@ -462,6 +462,12 @@ int Search::search(SearchThread& thread, int depth, SearchPly* searchPly, int al
                 depth <= MAX_SEE_PRUNE_DEPTH &&
                 !board.see_margin(move, depth * (quiet ? SEE_PRUNE_MARGIN_QUIET : SEE_PRUNE_MARGIN_NOISY)))
                 continue;
+
+            if (!isPV &&
+                quiet &&
+                depth < 5 &&
+                moveHistory < -1536 * depth)
+                break;
         }
 
         searchPly->contHistEntry = &history.contHistEntry(ExtMove::from(board, move));

--- a/Sirius/src/search_params.h
+++ b/Sirius/src/search_params.h
@@ -26,6 +26,9 @@ constexpr int MAX_SEE_PRUNE_DEPTH = 8;
 constexpr int SEE_PRUNE_MARGIN_NOISY = -100;
 constexpr int SEE_PRUNE_MARGIN_QUIET = -60;
 
+constexpr int MAX_HIST_PRUNING_DEPTH = 4;
+constexpr int HIST_PRUNING_MARGIN = 1536;
+
 constexpr int LMR_MIN_DEPTH = 3;
 constexpr int LMR_MIN_MOVES_NON_PV = 3;
 constexpr int LMR_MIN_MOVES_PV = 5;


### PR DESCRIPTION
tc: 8+0.08
book: pohl.epd
sprt bounds: [0, 5]
```
Score of sirius-5.0-history-pruning vs sirius-5.0-lmr-improving: 376 - 256 - 516  [0.552] 1148
...      sirius-5.0-history-pruning playing White: 253 - 67 - 254  [0.662] 574
...      sirius-5.0-history-pruning playing Black: 123 - 189 - 262  [0.443] 574
...      White vs Black: 442 - 190 - 516  [0.610] 1148
Elo difference: 36.5 +/- 14.9, LOS: 100.0 %, DrawRatio: 44.9 %
SPRT: llr 2.96 (100.4%), lbound -2.94, ubound 2.94 - H1 was accepted
```
Bench: 14659304