### PR TITLE
lmr adjustment by fail-high count in the next ply

### DIFF
--- a/Sirius/src/search.cpp
+++ b/Sirius/src/search.cpp
@@ -420,6 +420,8 @@ int Search::search(SearchThread& thread, int depth, SearchPly* searchPly, int al
     std::array<Move, MAX_PLY + 1> childPV;
     searchPly[1].pv = childPV.data();
 
+    searchPly[1].failHighCount = 0;
+
     searchPly->bestMove = Move();
 
     TTEntry::Bound bound = TTEntry::Bound::UPPER_BOUND;
@@ -492,6 +494,8 @@ int Search::search(SearchThread& thread, int depth, SearchPly* searchPly, int al
             reduction -= isPV;
             reduction -= givesCheck;
 
+            reduction += searchPly[1].failHighCount > 3;
+
             reduction = std::clamp(reduction, 0, depth - 2);
         }
 
@@ -540,6 +544,7 @@ int Search::search(SearchThread& thread, int depth, SearchPly* searchPly, int al
 
             if (bestScore >= beta)
             {
+                searchPly->failHighCount++;
                 if (quiet)
                 {
                     storeKiller(searchPly, move);

--- a/Sirius/src/search.cpp
+++ b/Sirius/src/search.cpp
@@ -494,7 +494,7 @@ int Search::search(SearchThread& thread, int depth, SearchPly* searchPly, int al
             reduction -= isPV;
             reduction -= givesCheck;
 
-            reduction += searchPly[1].failHighCount > 3;
+            reduction += searchPly[1].failHighCount >= LMR_FAIL_HIGH_COUNT_MARGIN;
 
             reduction = std::clamp(reduction, 0, depth - 2);
         }

--- a/Sirius/src/search.h
+++ b/Sirius/src/search.h
@@ -25,6 +25,8 @@ struct SearchPly
     CHEntry* contHistEntry;
 
     int staticEval;
+
+    uint32_t failHighCount;
 };
 
 struct SearchInfo

--- a/Sirius/src/search_params.h
+++ b/Sirius/src/search_params.h
@@ -32,6 +32,7 @@ constexpr int HIST_PRUNING_MARGIN = 1536;
 constexpr int LMR_MIN_DEPTH = 3;
 constexpr int LMR_MIN_MOVES_NON_PV = 3;
 constexpr int LMR_MIN_MOVES_PV = 5;
+constexpr int LMR_FAIL_HIGH_COUNT_MARGIN = 4;
 
 constexpr double LMR_BASE = 0.77;
 constexpr double LMR_DIVISOR = 2.36;


### PR DESCRIPTION
tc: 8+0.08
book: pohl.epd
sprt bounds: [0, 5]

```
Score of sirius-5.0-lmr-failhigh-count vs sirius-5.0-history-pruning: 1904 - 1744 - 3022  [0.512] 6670
...      sirius-5.0-lmr-failhigh-count playing White: 1375 - 466 - 1495  [0.636] 3336
...      sirius-5.0-lmr-failhigh-count playing Black: 529 - 1278 - 1527  [0.388] 3334
...      White vs Black: 2653 - 995 - 3022  [0.624] 6670
Elo difference: 8.3 +/- 6.2, LOS: 99.6 %, DrawRatio: 45.3 %
SPRT: llr 2.95 (100.2%), lbound -2.94, ubound 2.94 - H1 was accepted
```
Bench: 13614333