### PR TITLE
Use tt score for static eval

### DIFF
--- a/Sirius/src/defs.h
+++ b/Sirius/src/defs.h
@@ -154,6 +154,7 @@ constexpr int SCORE_MATE = 32700;
 constexpr int SCORE_MATE_IN_MAX = SCORE_MATE - MAX_PLY;
 constexpr int SCORE_WIN = 31000;
 constexpr int SCORE_DRAW = 0;
+constexpr int SCORE_NONE = -32701;
 
 inline bool isMateScore(int score)
 {

--- a/Sirius/src/search.cpp
+++ b/Sirius/src/search.cpp
@@ -624,7 +624,7 @@ int Search::qsearch(SearchThread& thread, SearchPly* searchPly, int alpha, int b
     if (eval > alpha)
         alpha = eval;
 
-    int bestScore = eval;
+    int bestScore = inCheck ? -SCORE_MATE : eval;
 
     if (rootPly >= MAX_PLY)
         return alpha;


### PR DESCRIPTION
tc: 8+0.08
book: pohl.epd
sprt bounds: [0, 5]
```
Score of sirius-5.0-tt-eval vs sirius-5.0-lmr-failhigh-count: 397 - 275 - 537  [0.550] 1209
...      sirius-5.0-tt-eval playing White: 279 - 65 - 261  [0.677] 605
...      sirius-5.0-tt-eval playing Black: 118 - 210 - 276  [0.424] 604
...      White vs Black: 489 - 183 - 537  [0.627] 1209
Elo difference: 35.2 +/- 14.6, LOS: 100.0 %, DrawRatio: 44.4 %
SPRT: llr 2.96 (100.7%), lbound -2.94, ubound 2.94 - H1 was accepted
```
Bench: 11968329