### PR TITLE
Tweak aspiration windows

### DIFF
--- a/Sirius/src/search.cpp
+++ b/Sirius/src/search.cpp
@@ -265,8 +265,14 @@ int Search::iterDeep(SearchThread& thread, bool report, bool normalSearch)
 int Search::aspWindows(SearchThread& thread, int depth, Move& bestMove, int prevScore)
 {
     int delta = ASP_INIT_DELTA;
-    int alpha = prevScore - delta;
-    int beta = prevScore + delta;
+    int alpha = -SCORE_MAX;
+    int beta = SCORE_MAX;
+
+    if (depth >= MIN_ASP_DEPTH)
+    {
+        alpha = prevScore - delta;
+        beta = prevScore + delta;
+    }
 
     while (true)
     {
@@ -287,7 +293,7 @@ int Search::aspWindows(SearchThread& thread, int depth, Move& bestMove, int prev
             else
                 return searchScore;
         }
-        delta *= 2;
+        delta += delta / 2;
     }
 }
 

--- a/Sirius/src/search_params.h
+++ b/Sirius/src/search_params.h
@@ -3,7 +3,8 @@ namespace search
 
 constexpr uint32_t TIME_CHECK_INTERVAL = 2048;
 
-constexpr int ASP_INIT_DELTA = 25;
+constexpr int ASP_INIT_DELTA = 15;
+constexpr int MIN_ASP_DEPTH = 5;
 
 constexpr int MIN_IIR_DEPTH = 4;
 


### PR DESCRIPTION
tc: 8+0.08
book: pohl.epd
sprt bounds: [0, 5]
```
Score of sirius-5.0-asp-tweak vs sirius-5.0-qsearch-bugfix: 659 - 536 - 1106  [0.527] 2301
...      sirius-5.0-asp-tweak playing White: 480 - 132 - 539  [0.651] 1151
...      sirius-5.0-asp-tweak playing Black: 179 - 404 - 567  [0.402] 1150
...      White vs Black: 884 - 311 - 1106  [0.625] 2301
Elo difference: 18.6 +/- 10.2, LOS: 100.0 %, DrawRatio: 48.1 %
SPRT: llr 2.96 (100.5%), lbound -2.94, ubound 2.94 - H1 was accepted
```

Bench: 11778220