### PR TITLE
Do history pruning in pv nodes

### DIFF
--- a/Sirius/src/search.cpp
+++ b/Sirius/src/search.cpp
@@ -476,8 +476,7 @@ int Search::search(SearchThread& thread, int depth, SearchPly* stack, int alpha,
                 !board.see_margin(move, depth * (quiet ? SEE_PRUNE_MARGIN_QUIET : SEE_PRUNE_MARGIN_NOISY)))
                 continue;
 
-            if (!isPV &&
-                quiet &&
+            if (quiet &&
                 depth <= MAX_HIST_PRUNING_DEPTH &&
                 moveHistory < -HIST_PRUNING_MARGIN * depth)
                 break;


### PR DESCRIPTION
tc: 8+0.08
book: pohl.epd
sprt bounds: [0, 5]
```
Score of sirius-5.0-hist-pruning-pv vs sirius-5.0-asp-tweak: 2091 - 1926 - 3340  [0.511] 7357
...      sirius-5.0-hist-pruning-pv playing White: 1501 - 544 - 1634  [0.630] 3679
...      sirius-5.0-hist-pruning-pv playing Black: 590 - 1382 - 1706  [0.392] 3678
...      White vs Black: 2883 - 1134 - 3340  [0.619] 7357
Elo difference: 7.8 +/- 5.9, LOS: 99.5 %, DrawRatio: 45.4 %
SPRT: llr 2.96 (100.4%), lbound -2.94, ubound 2.94 - H1 was accepted
```
Bench: 12226814