### PR TITLE
NMP reduction based on static eval

### DIFF
--- a/Sirius/src/search.cpp
+++ b/Sirius/src/search.cpp
@@ -402,7 +402,7 @@ int Search::search(SearchThread& thread, int depth, SearchPly* stack, int alpha,
             BitBoard nonPawns = board.getColor(board.sideToMove()) ^ board.getPieces(board.sideToMove(), PieceType::PAWN);
             if ((nonPawns & (nonPawns - 1)) && depth >= NMP_MIN_DEPTH)
             {
-                int r = NMP_BASE_REDUCTION + depth / NMP_DEPTH_REDUCTION;
+                int r = NMP_BASE_REDUCTION + depth / NMP_DEPTH_REDUCTION + std::min((posEval - beta) / NMP_EVAL_REDUCTION, NMP_MAX_EVAL_REDUCTION);
                 board.makeNullMove(state);
                 rootPly++;
                 int nullScore = -search(thread, depth - r, stack + 1, -beta, -beta + 1, false);

--- a/Sirius/src/search_params.h
+++ b/Sirius/src/search_params.h
@@ -15,6 +15,8 @@ constexpr int RFP_MARGIN = 80;
 constexpr int NMP_MIN_DEPTH = 2;
 constexpr int NMP_BASE_REDUCTION = 3;
 constexpr int NMP_DEPTH_REDUCTION = 3;
+constexpr int NMP_EVAL_REDUCTION = 200;
+constexpr int NMP_MAX_EVAL_REDUCTION = 3;
 
 constexpr int FP_BASE_MARGIN = 120;
 constexpr int FP_DEPTH_MARGIN = 75;


### PR DESCRIPTION
tc: 8+0.08
book: pohl.epd
sprt bounds: [0, 5]
```
Score of sirius-5.0-nmp-static-eval vs sirius-5.0-hist-pruning-pv: 1636 - 1483 - 2602  [0.513] 5721
...      sirius-5.0-nmp-static-eval playing White: 1211 - 422 - 1228  [0.638] 2861
...      sirius-5.0-nmp-static-eval playing Black: 425 - 1061 - 1374  [0.389] 2860
...      White vs Black: 2272 - 847 - 2602  [0.625] 5721
Elo difference: 9.3 +/- 6.6, LOS: 99.7 %, DrawRatio: 45.5 %
SPRT: llr 2.95 (100.3%), lbound -2.94, ubound 2.94 - H1 was accepted
```
Bench: 11616375