### PR TITLE
Added 4 ply continuation history

### DIFF
--- a/Sirius/src/search.cpp
+++ b/Sirius/src/search.cpp
@@ -417,9 +417,10 @@ int Search::search(SearchThread& thread, int depth, SearchPly* stack, int alpha,
     MoveList moves;
     genMoves<MoveGenType::NOISY_QUIET>(board, moves);
 
-    std::array<CHEntry*, 2> contHistEntries = {
+    std::array<CHEntry*, 3> contHistEntries = {
         rootPly > 0 ? stack[-1].contHistEntry : nullptr,
-        rootPly > 1 ? stack[-2].contHistEntry : nullptr
+        rootPly > 1 ? stack[-2].contHistEntry : nullptr,
+        rootPly > 3 ? stack[-4].contHistEntry : nullptr
     };
 
     MoveOrdering ordering(


### PR DESCRIPTION
tc: 8+0.08
book: pohl.epd
sprt bounds: [0, 5]
```
Score of sirius-5.0-4ply-cont-hist vs sirius-5.0-nmp-static-eval: 2134 - 1968 - 3474  [0.511] 7576
...      sirius-5.0-4ply-cont-hist playing White: 1546 - 509 - 1733  [0.637] 3788
...      sirius-5.0-4ply-cont-hist playing Black: 588 - 1459 - 1741  [0.385] 3788
...      White vs Black: 3005 - 1097 - 3474  [0.626] 7576
Elo difference: 7.6 +/- 5.7, LOS: 99.5 %, DrawRatio: 45.9 %
SPRT: llr 2.96 (100.7%), lbound -2.94, ubound 2.94 - H1 was accepted
```
Bench: 13421734