### PR TITLE
Score first killer above second + clear child killers

### DIFF
--- a/Sirius/src/move_ordering.cpp
+++ b/Sirius/src/move_ordering.cpp
@@ -87,7 +87,7 @@ MoveOrdering::MoveOrdering(const Board& board, MoveList& moves, Move hashMove, c
             score = PROMOTION_SCORE + promotionBonus(move);
         }
         else if (move == killers[0] || move == killers[1])
-            score = KILLER_SCORE;
+            score = KILLER_SCORE + (move == killers[0]);
         else
             score = history.getQuietStats(ExtMove::from(board, move), contHistEntries);
         m_MoveScores[i] = score;
@@ -115,6 +115,6 @@ ScoredMove MoveOrdering::selectMove(uint32_t index)
     int history = 0;
     if (moveIsQuiet(m_Board, move) && score < KILLER_SCORE)
         history = score;
-    
+
     return {move, score, history};
 }

--- a/Sirius/src/search.cpp
+++ b/Sirius/src/search.cpp
@@ -388,6 +388,8 @@ int Search::search(SearchThread& thread, int depth, SearchPly* stack, int alpha,
     ))
         posEval = ttScore;
 
+    stack[1].killers = {};
+
     BoardState state;
 
     if (!isPV && !inCheck)


### PR DESCRIPTION
tc: 8+0.08
book: pohl.epd
sprt bounds: [0, 5]
```
Score of sirius-5.0-killer-stuff vs sirius-5.0-4ply-cont-hist: 2018 - 1855 - 3219  [0.511] 7092
...      sirius-5.0-killer-stuff playing White: 1428 - 496 - 1623  [0.631] 3547
...      sirius-5.0-killer-stuff playing Black: 590 - 1359 - 1596  [0.392] 3545
...      White vs Black: 2787 - 1086 - 3219  [0.620] 7092
Elo difference: 8.0 +/- 6.0, LOS: 99.6 %, DrawRatio: 45.4 %
SPRT: llr 2.95 (100.3%), lbound -2.94, ubound 2.94 - H1 was accepted
```
Bench: 10119927