### PR TITLE
TT prefetching

### DIFF
--- a/Sirius/src/board.h
+++ b/Sirius/src/board.h
@@ -94,6 +94,7 @@ public:
 
     bool see(Move move, int margin) const;
     bool isLegal(Move move) const;
+    ZKey keyAfter(Move move) const;
 
     const eval::EvalState& evalState() const;
 private:

--- a/Sirius/src/misc.cpp
+++ b/Sirius/src/misc.cpp
@@ -104,6 +104,26 @@ void testSAN(Board& board, int depth)
     }
 }
 
+void testKeyAfter(Board& board, int depth)
+{
+    if (depth == 0)
+        return;
+
+    MoveList moves;
+    genMoves<MoveGenType::LEGAL>(board, moves);
+
+    BoardState state;
+    for (Move move : moves)
+    {
+        ZKey keyAfter = board.keyAfter(move);
+        board.makeMove(move, state);
+        if (keyAfter != board.zkey())
+            throw std::runtime_error("key does not match");
+        testKeyAfter(board, depth - 1);
+        board.unmakeMove(move);
+    }
+}
+
 void testQuiescence(Board& board, int depth)
 {
     if (depth == 0)

--- a/Sirius/src/misc.h
+++ b/Sirius/src/misc.h
@@ -8,6 +8,8 @@ uint64_t perft(Board& board, int depth);
 
 void testSAN(Board& board, int depth);
 
+void testKeyAfter(Board& board, int depth);
+
 void testQuiescence(Board& board, int depth);
 
 void testSEE();

--- a/Sirius/src/search.cpp
+++ b/Sirius/src/search.cpp
@@ -482,7 +482,7 @@ int Search::search(SearchThread& thread, int depth, SearchPly* stack, int alpha,
                 break;
         }
 
-        //m_TT.prefetch(board.keyAfter(move));
+        m_TT.prefetch(board.keyAfter(move));
         stack->contHistEntry = &history.contHistEntry(ExtMove::from(board, move));
 
         uint64_t nodesBefore = thread.nodes;

--- a/Sirius/src/search.cpp
+++ b/Sirius/src/search.cpp
@@ -482,6 +482,7 @@ int Search::search(SearchThread& thread, int depth, SearchPly* stack, int alpha,
                 break;
         }
 
+        //m_TT.prefetch(board.keyAfter(move));
         stack->contHistEntry = &history.contHistEntry(ExtMove::from(board, move));
 
         uint64_t nodesBefore = thread.nodes;

--- a/Sirius/src/tt.h
+++ b/Sirius/src/tt.h
@@ -66,7 +66,7 @@ public:
     TTBucket* probe(ZKey key, bool& found, int ply, int& score, Move& move, int& depth, TTEntry::Bound& bound);
     void store(TTBucket* bucket, ZKey key, int depth, int ply, int score, Move move, TTEntry::Bound type);
     int quality(int age, int depth) const;
-    uint32_t index(uint64_t key) const;
+    void prefetch(ZKey key) const;
 
     void incAge()
     {
@@ -79,6 +79,8 @@ public:
         m_CurrAge = 0;
     }
 private:
+    uint32_t index(uint64_t key) const;
+
     std::vector<TTBucket> m_Buckets;
     int m_CurrAge;
 };


### PR DESCRIPTION
tc: 5+0.05
book: pohl.epd
sprt bounds: [0, 5]
```
Score of sirius-5.0-tt-prefetch vs sirius-5.0-refactor: 1519 - 1366 - 2219  [0.515] 5104
...      sirius-5.0-tt-prefetch playing White: 1080 - 358 - 1114  [0.641] 2552
...      sirius-5.0-tt-prefetch playing Black: 439 - 1008 - 1105  [0.389] 2552
...      White vs Black: 2088 - 797 - 2219  [0.626] 5104
Elo difference: 10.4 +/- 7.2, LOS: 99.8 %, DrawRatio: 43.5 %
SPRT: llr 2.96 (100.6%), lbound -2.94, ubound 2.94 - H1 was accepted
```
Bench: 10119927