### PR TITLE
Added pawn table

### DIFF
--- a/Sirius/CMakeLists.txt
+++ b/Sirius/CMakeLists.txt
@@ -36,6 +36,7 @@ set(SRCS
     "src/eval/eval.h"
     "src/eval/eval_constants.h"
     "src/eval/eval_state.h"
+    "src/eval/pawn_table.h"
     "src/eval/phase.cpp"
     "src/eval/phase.h"
 

--- a/Sirius/src/eval/eval.cpp
+++ b/Sirius/src/eval/eval.cpp
@@ -40,17 +40,14 @@ PackedScore evaluatePieces(const Board& board)
     return eval;
 }
 
+
+
 template<Color color>
 PackedScore evaluatePawns(const Board& board)
 {
     Bitboard ourPawns = board.getPieces(color, PieceType::PAWN);
-    Bitboard attacks = attacks::pawnAttacks<color>(ourPawns);
-    Bitboard threats = attacks & board.getColor(~color);
 
     PackedScore eval{0, 0};
-
-    while (threats)
-        eval += THREATS[static_cast<int>(PieceType::PAWN) - static_cast<int>(PieceType::PAWN)][static_cast<int>(getPieceType(board.getPieceAt(threats.poplsb()))) - static_cast<int>(PieceType::PAWN)];
 
     Bitboard pawns = ourPawns;
     while (pawns)
@@ -64,7 +61,38 @@ PackedScore evaluatePawns(const Board& board)
     return eval;
 }
 
-int evaluate(const Board& board)
+PackedScore evaluatePawns(const Board& board, PawnTable* pawnTable)
+{
+    if (pawnTable)
+    {
+        const auto& entry = pawnTable->probe(board.pawnKey());
+        if (entry.pawnKey == board.pawnKey())
+            return entry.score;
+    }
+
+    PackedScore eval = evaluatePawns<Color::WHITE>(board) - evaluatePawns<Color::BLACK>(board);
+    if (pawnTable)
+    {
+        PawnEntry replace = {board.pawnKey(), eval};
+        pawnTable->store(replace);
+    }
+    return eval;
+}
+
+// I'll figure out how to add the other pieces here later
+template<Color color>
+PackedScore evaluateThreats(const Board& board)
+{
+    Bitboard ourPawns = board.getPieces(color, PieceType::PAWN);
+    Bitboard attacks = attacks::pawnAttacks<color>(ourPawns);
+    Bitboard threats = attacks & board.getColor(~color);
+    PackedScore eval{0, 0};
+    while (threats)
+        eval += THREATS[static_cast<int>(PieceType::PAWN) - static_cast<int>(PieceType::PAWN)][static_cast<int>(getPieceType(board.getPieceAt(threats.poplsb()))) - static_cast<int>(PieceType::PAWN)];
+    return eval;
+}
+
+int evaluate(const Board& board, search::SearchThread* thread)
 {
     if (!eval::canForceMate(board))
         return SCORE_DRAW;
@@ -77,7 +105,8 @@ int evaluate(const Board& board)
     eval += evaluatePieces<Color::WHITE, PieceType::ROOK>(board) - evaluatePieces<Color::BLACK, PieceType::ROOK>(board);
     eval += evaluatePieces<Color::WHITE, PieceType::QUEEN>(board) - evaluatePieces<Color::BLACK, PieceType::QUEEN>(board);
 
-    eval += evaluatePawns<Color::WHITE>(board) - evaluatePawns<Color::BLACK>(board);
+    eval += evaluatePawns(board, thread ? &thread->pawnTable : nullptr);
+    eval += evaluateThreats<Color::WHITE>(board) - evaluateThreats<Color::BLACK>(board);
 
     return (color == Color::WHITE ? 1 : -1) * eval::getFullEval(eval.mg(), eval.eg(), board.evalState().phase);
 }

--- a/Sirius/src/eval/eval.h
+++ b/Sirius/src/eval/eval.h
@@ -2,11 +2,12 @@
 
 #include "phase.h"
 #include "draw.h"
+#include "../search.h"
 #include "../board.h"
 
 namespace eval
 {
 
-int evaluate(const Board& board);
+int evaluate(const Board& board, search::SearchThread* thread = nullptr);
 
 }

--- a/Sirius/src/eval/pawn_table.h
+++ b/Sirius/src/eval/pawn_table.h
@@ -1,0 +1,45 @@
+#include <vector>
+#include "../zobrist.h"
+#include "../defs.h"
+
+struct PawnEntry
+{
+    ZKey pawnKey;
+    PackedScore score;
+};
+
+class PawnTable
+{
+public:
+    static constexpr size_t SIZE = 2048;
+    static_assert((SIZE & (SIZE - 1)) == 0, "PawnCache::SIZE must be a power of 2");
+    PawnTable();
+
+    PawnEntry probe(ZKey pawnKey) const;
+    void store(PawnEntry entry);
+
+    void clear();
+private:
+    std::vector<PawnEntry> m_Entries;
+};
+
+inline PawnTable::PawnTable()
+    : m_Entries(SIZE)
+{
+
+}
+
+inline PawnEntry PawnTable::probe(ZKey pawnKey) const
+{
+    return m_Entries[pawnKey.value % SIZE];
+}
+
+inline void PawnTable::store(PawnEntry entry)
+{
+    m_Entries[entry.pawnKey.value % SIZE] = entry;
+}
+
+inline void PawnTable::clear()
+{
+    std::fill(m_Entries.begin(), m_Entries.end(), PawnEntry{});
+}

--- a/Sirius/src/search.cpp
+++ b/Sirius/src/search.cpp
@@ -93,6 +93,7 @@ void Search::newGame()
     {
         thread->reset();
         thread->history.clear();
+        thread->pawnTable.clear();
     }
     m_TT.reset();
 }
@@ -344,7 +345,7 @@ int Search::search(SearchThread& thread, int depth, SearchStack* stack, int alph
         return SCORE_DRAW;
 
     if (rootPly >= MAX_PLY)
-        return eval::evaluate(board);
+        return eval::evaluate(board, &thread);
 
     if (depth <= 0)
         return qsearch(thread, stack, alpha, beta);
@@ -610,7 +611,7 @@ int Search::qsearch(SearchThread& thread, SearchStack* stack, int alpha, int bet
     }
 
     bool inCheck = board.checkers().any();
-    int staticEval = inCheck ? SCORE_NONE : eval::evaluate(board);
+    int staticEval = inCheck ? SCORE_NONE : eval::evaluate(board, &thread);
 
     int posEval = staticEval;
     if (!inCheck && ttHit && (

--- a/Sirius/src/search.h
+++ b/Sirius/src/search.h
@@ -5,6 +5,7 @@
 #include "tt.h"
 #include "time_man.h"
 #include "history.h"
+#include "eval/pawn_table.h"
 
 #include <array>
 #include <deque>
@@ -91,6 +92,7 @@ struct SearchThread
     int selDepth = 0;
     std::array<SearchStack, MAX_PLY + 1> stack;
     History history;
+    PawnTable pawnTable;
 };
 
 class Search


### PR DESCRIPTION
```
Score of sirius-6.0-pawn-table vs sirius-6.0-threats: 1237 - 1076 - 1203  [0.523] 3516
...      sirius-6.0-pawn-table playing White: 790 - 368 - 600  [0.620] 1758
...      sirius-6.0-pawn-table playing Black: 447 - 708 - 603  [0.426] 1758
...      White vs Black: 1498 - 815 - 1203  [0.597] 3516
Elo difference: 15.9 +/- 9.3, LOS: 100.0 %, DrawRatio: 34.2 %
SPRT: llr 2.97 (101.0%), lbound -2.94, ubound 2.94 - H1 was accepted
```

tc: 1+0.01
book: pohl.epd
sprt bounds: [0, 5]

Bench: 12046367(same as last without pawn table)