### PR TITLE
Added capture history

### DIFF
--- a/Sirius/src/history.cpp
+++ b/Sirius/src/history.cpp
@@ -43,12 +43,22 @@ int History::getQuietStats(ExtMove move, std::span<const CHEntry* const> contHis
     return score;
 }
 
+int History::getNoisyStats(ExtMove move) const
+{
+    return getCaptHist(move);
+}
+
 void History::updateQuietStats(ExtMove move, std::span<CHEntry*> contHistEntries, int bonus)
 {
     updateMainHist(move, bonus);
     for (auto entry : contHistEntries)
         if (entry)
             updateContHist(entry, move, bonus);
+}
+
+void History::updateNoisyStats(ExtMove move, int bonus)
+{
+    updateCaptHist(move, bonus);
 }
 
 int History::getMainHist(ExtMove move) const
@@ -61,6 +71,11 @@ int History::getContHist(const CHEntry* entry, ExtMove move) const
     return (*entry)[static_cast<int>(move.movingPiece())][move.dstPos()];
 }
 
+int History::getCaptHist(ExtMove move) const
+{
+    return m_CaptHist[static_cast<int>(move.capturedPiece())][static_cast<int>(move.movingPiece())][move.dstPos()];
+}
+
 void History::updateMainHist(ExtMove move, int bonus)
 {
     m_MainHist[static_cast<int>(getPieceColor(move.movingPiece()))][move.fromTo()].update(bonus);
@@ -69,4 +84,9 @@ void History::updateMainHist(ExtMove move, int bonus)
 void History::updateContHist(CHEntry* entry, ExtMove move, int bonus)
 {
     (*entry)[static_cast<int>(move.movingPiece())][move.dstPos()].update(bonus);
+}
+
+void History::updateCaptHist(ExtMove move, int bonus)
+{
+    m_CaptHist[static_cast<int>(move.capturedPiece())][static_cast<int>(move.movingPiece())][move.dstPos()].update(bonus);
 }

--- a/Sirius/src/history.h
+++ b/Sirius/src/history.h
@@ -94,6 +94,7 @@ static constexpr int HISTORY_MAX = 16384;
 using MainHist = std::array<std::array<HistoryEntry<HISTORY_MAX>, 4096>, 2>;
 using CHEntry = std::array<std::array<HistoryEntry<HISTORY_MAX>, 64>, 16>;
 using ContHist = std::array<std::array<CHEntry, 64>, 16>;
+using CaptHist = std::array<std::array<std::array<HistoryEntry<HISTORY_MAX>, 64>, 16>, 16>;
 
 int historyBonus(int depth);
 
@@ -113,16 +114,21 @@ public:
     }
 
     int getQuietStats(ExtMove move, std::span<const CHEntry* const> contHistEntries) const;
+    int getNoisyStats(ExtMove move) const;
 
     void clear();
     void updateQuietStats(ExtMove move, std::span<CHEntry*> contHistEntries, int bonus);
+    void updateNoisyStats(ExtMove move, int bonus);
 private:
     int getMainHist(ExtMove move) const;
     int getContHist(const CHEntry* entry, ExtMove move) const;
+    int getCaptHist(ExtMove move) const;
 
     void updateMainHist(ExtMove move, int bonus);
     void updateContHist(CHEntry* entry, ExtMove move, int bonus);
+    void updateCaptHist(ExtMove move, int bonus);
 
     MainHist m_MainHist;
     ContHist m_ContHist;
+    CaptHist m_CaptHist;
 };

--- a/Sirius/src/move_ordering.cpp
+++ b/Sirius/src/move_ordering.cpp
@@ -35,7 +35,7 @@ bool moveIsCapture(const Board& board, Move move)
         board.getPieceAt(move.dstPos()) != Piece::NONE;
 }
 
-MoveOrdering::MoveOrdering(const Board& board, MoveList& moves, Move hashMove)
+MoveOrdering::MoveOrdering(const Board& board, MoveList& moves, Move hashMove, const History& history)
     : m_Board(board), m_Moves(moves)
 {
     for (uint32_t i = 0; i < m_Moves.size(); i++)
@@ -51,7 +51,7 @@ MoveOrdering::MoveOrdering(const Board& board, MoveList& moves, Move hashMove)
 
         bool isCapture = moveIsCapture(board, move);
         bool isPromotion = move.type() == MoveType::PROMOTION;
-
+        score = history.getNoisyStats(ExtMove::from(board, move));
         if (isCapture)
             score += mvvLva(board, move);
         if (isPromotion)
@@ -80,11 +80,11 @@ MoveOrdering::MoveOrdering(const Board& board, MoveList& moves, Move hashMove, c
 
         if (isCapture)
         {
-            score = CAPTURE_SCORE * board.see(move, 0) + mvvLva(board, move);
+            score = history.getNoisyStats(ExtMove::from(board, move)) + CAPTURE_SCORE * board.see(move, 0) + mvvLva(board, move);
         }
         else if (isPromotion)
         {
-            score = PROMOTION_SCORE + promotionBonus(move);
+            score = history.getNoisyStats(ExtMove::from(board, move)) + PROMOTION_SCORE + promotionBonus(move);
         }
         else if (move == killers[0] || move == killers[1])
             score = KILLER_SCORE + (move == killers[0]);

--- a/Sirius/src/move_ordering.h
+++ b/Sirius/src/move_ordering.h
@@ -22,7 +22,7 @@ public:
     static constexpr int PROMOTION_SCORE = 400000;
     static constexpr int CAPTURE_SCORE = 500000;
 
-    MoveOrdering(const Board& board, MoveList& moves, Move hashMove);
+    MoveOrdering(const Board& board, MoveList& moves, Move hashMove, const History& history);
     MoveOrdering(const Board& board, MoveList& moves, Move hashMove, const std::array<Move, 2>& killers, std::span<const CHEntry* const> contHistEntries, const History& history);
 
     ScoredMove selectMove(uint32_t index);


### PR DESCRIPTION
```
Score of sirius-capt-hist vs sirius-pawn-storm-fix: 2244 - 2076 - 3688  [0.510] 8008
...      sirius-capt-hist playing White: 1756 - 444 - 1805  [0.664] 4005
...      sirius-capt-hist playing Black: 488 - 1632 - 1883  [0.357] 4003
...      White vs Black: 3388 - 932 - 3688  [0.653] 8008
Elo difference: 7.3 +/- 5.6, LOS: 99.5 %, DrawRatio: 46.1 %
SPRT: llr 2.95 (100.1%), lbound -2.94, ubound 2.94 - H1 was accepted
```
tc: 8+0.08
book: pohl.epd
sprt bounds: [0, 5]

Bench: 11244390