### PR TITLE
Use more recent history scores in search

### DIFF
--- a/Sirius/src/move_ordering.cpp
+++ b/Sirius/src/move_ordering.cpp
@@ -110,11 +110,5 @@ ScoredMove MoveOrdering::selectMove(uint32_t index)
     std::swap(m_Moves[bestIndex], m_Moves[index]);
     std::swap(m_MoveScores[bestIndex], m_MoveScores[index]);
 
-    Move move = m_Moves[index];
-    int score = m_MoveScores[index];
-    int history = 0;
-    if (moveIsQuiet(m_Board, move) && score < KILLER_SCORE)
-        history = score;
-
-    return {move, score, history};
+    return {m_Moves[index], m_MoveScores[index]};
 }

--- a/Sirius/src/move_ordering.h
+++ b/Sirius/src/move_ordering.h
@@ -9,7 +9,6 @@ struct ScoredMove
 {
     Move move;
     int score;
-    int history;
 };
 
 bool moveIsQuiet(const Board& board, Move move);


### PR DESCRIPTION
Score of sirius-6.0-recent-hist vs sirius-6.0-pawn-shield: 2466 - 2476 - 4470  [0.499] 9412
...      sirius-6.0-recent-hist playing White: 1933 - 552 - 2221  [0.647] 4706
...      sirius-6.0-recent-hist playing Black: 533 - 1924 - 2249  [0.352] 4706
...      White vs Black: 3857 - 1085 - 4470  [0.647] 9412
Elo difference: -0.4 +/- 5.1, LOS: 44.3 %, DrawRatio: 47.5 %
SPRT: llr 1.58 (53.7%), lbound -2.94, ubound 2.94

tc: 8+0.08
book: pohl.epd
sprt bounds: [0, -5]

stopped early cus I couldn't be bothered

Bench: 11043462