### PR TITLE
Adjust rfp margin by history

### DIFF
--- a/Sirius/src/search.cpp
+++ b/Sirius/src/search.cpp
@@ -387,7 +387,7 @@ int Search::search(SearchThread& thread, int depth, SearchStack* stack, int alph
     if (!isPV && !inCheck)
     {
         // reverse futility pruning
-        if (depth <= rfpMaxDepth && posEval >= beta + (improving ? rfpImprovingMargin : rfpMargin) * depth)
+        if (depth <= rfpMaxDepth && posEval >= beta + (improving ? rfpImprovingMargin : rfpMargin) * depth + stack[-1].histScore / rfpHistDivisor)
             return posEval;
 
         // null move pruning
@@ -478,6 +478,7 @@ int Search::search(SearchThread& thread, int depth, SearchStack* stack, int alph
 
         m_TT.prefetch(board.keyAfter(move));
         stack->contHistEntry = &history.contHistEntry(ExtMove::from(board, move));
+        stack->histScore = histScore;
 
         uint64_t nodesBefore = thread.nodes;
         board.makeMove(move, state);
@@ -528,6 +529,7 @@ int Search::search(SearchThread& thread, int depth, SearchStack* stack, int alph
             m_TimeMan.updateNodes(move, thread.nodes - nodesBefore);
 
         stack->contHistEntry = nullptr;
+        stack->histScore = 0;
 
         if (m_ShouldStop)
             return alpha;

--- a/Sirius/src/search.h
+++ b/Sirius/src/search.h
@@ -24,6 +24,7 @@ struct SearchStack
     std::array<Move, 2> killers;
 
     CHEntry* contHistEntry;
+    int histScore;
 
     int staticEval;
 

--- a/Sirius/src/search_params.h
+++ b/Sirius/src/search_params.h
@@ -60,6 +60,7 @@ SEARCH_PARAM(minIIRDepth, 4, 2, 9, 1);
 SEARCH_PARAM(rfpMaxDepth, 8, 4, 10, 1);
 SEARCH_PARAM(rfpImprovingMargin, 50, 30, 80, 5);
 SEARCH_PARAM(rfpMargin, 80, 50, 100, 5);
+SEARCH_PARAM(rfpHistDivisor, 400, 256, 512, 30);
 
 SEARCH_PARAM(nmpMinDepth, 2, 2, 5, 1);
 SEARCH_PARAM(nmpBaseReduction, 3, 2, 5, 1);


### PR DESCRIPTION
```
Score of sirius-6.0-rfp-hist vs sirius-6.0-recent-hist: 2143 - 1978 - 3654  [0.511] 7775
...      sirius-6.0-rfp-hist playing White: 1680 - 395 - 1813  [0.665] 3888
...      sirius-6.0-rfp-hist playing Black: 463 - 1583 - 1841  [0.356] 3887
...      White vs Black: 3263 - 858 - 3654  [0.655] 7775
Elo difference: 7.4 +/- 5.6, LOS: 99.5 %, DrawRatio: 47.0 %
SPRT: llr 2.96 (100.6%), lbound -2.94, ubound 2.94 - H1 was accepted
```
tc: 8+0.08
book: pohl.epd
sprt bounds: [0, 5]

Bench: 11027546