### PR TITLE
Cutnode lmr

### DIFF
--- a/Sirius/src/search.h
+++ b/Sirius/src/search.h
@@ -121,7 +121,7 @@ private:
     int iterDeep(SearchThread& thread, bool report, bool normalSearch);
     int aspWindows(SearchThread& thread, int depth, Move& bestMove, int prevScore);
 
-    int search(SearchThread& thread, int depth, SearchStack* stack, int alpha, int beta, bool isPV);
+    int search(SearchThread& thread, int depth, SearchStack* stack, int alpha, int beta, bool isPV, bool cutnode);
     int qsearch(SearchThread& thread, SearchStack* stack, int alpha, int beta);
 
     Board& m_Board;


### PR DESCRIPTION
```
Score of sirius-6.0-cutnode-lmr vs sirius-6.0-rfp-hist: 1922 - 1762 - 3169  [0.512] 6853
...      sirius-6.0-cutnode-lmr playing White: 1492 - 351 - 1584  [0.666] 3427
...      sirius-6.0-cutnode-lmr playing Black: 430 - 1411 - 1585  [0.357] 3426
...      White vs Black: 2903 - 781 - 3169  [0.655] 6853
Elo difference: 8.1 +/- 6.0, LOS: 99.6 %, DrawRatio: 46.2 %
SPRT: llr 2.97 (100.7%), lbound -2.94, ubound 2.94 - H1 was accepted
```
tc: 8+0.08
book: pohl.epd
sprt bounds: [0, 5]

Bench: 11103895