### PR TITLE
Qsearch futility pruning

### DIFF
--- a/Sirius/src/search.cpp
+++ b/Sirius/src/search.cpp
@@ -639,6 +639,7 @@ int Search::qsearch(SearchThread& thread, SearchStack* stack, int alpha, int bet
         alpha = posEval;
 
     int bestScore = inCheck ? -SCORE_MATE : posEval;
+    int futility = inCheck ? -SCORE_MATE : posEval + 60;
 
     if (rootPly >= MAX_PLY)
         return alpha;
@@ -657,6 +658,11 @@ int Search::qsearch(SearchThread& thread, SearchStack* stack, int alpha, int bet
             continue;
         if (!board.see(move, 0))
             continue;
+        if (!inCheck && futility <= alpha && !board.see(move, 1))
+        {
+            bestScore = std::max(bestScore, futility);
+            continue;
+        }
         board.makeMove(move);
         thread.nodes.fetch_add(1, std::memory_order_relaxed);
         rootPly++;


### PR DESCRIPTION
```
Score of sirius-6.0-qs-fp vs sirius-6.0-cutnode-lmr: 1231 - 1091 - 2073  [0.516] 4395
...      sirius-6.0-qs-fp playing White: 965 - 218 - 1015  [0.670] 2198
...      sirius-6.0-qs-fp playing Black: 266 - 873 - 1058  [0.362] 2197
...      White vs Black: 1838 - 484 - 2073  [0.654] 4395
Elo difference: 11.1 +/- 7.5, LOS: 99.8 %, DrawRatio: 47.2 %
SPRT: llr 2.96 (100.4%), lbound -2.94, ubound 2.94 - H1 was accepted
```
tc: 8+0.08
book: pohl.epd
sprt bounds: [0, 5]

Bench: 10041622