### PR TITLE
Threat history

### DIFF
--- a/Sirius/src/board.h
+++ b/Sirius/src/board.h
@@ -33,6 +33,7 @@ struct BoardState
     ZKey zkey;
     ZKey pawnKey;
     CheckInfo checkInfo;
+    Bitboard threats;
     eval::EvalState evalState;
 };
 
@@ -88,6 +89,7 @@ public:
 
     Bitboard checkers() const;
     Bitboard checkBlockers(Color color) const;
+    Bitboard threats() const;
 
     bool see(Move move, int margin) const;
     bool isLegal(Move move) const;
@@ -100,6 +102,7 @@ private:
     Bitboard pinners(Color color) const;
 
     void updateCheckInfo();
+    void calcThreats();
     void calcRepetitions();
     void addPiece(int pos, Color color, PieceType piece);
     void addPiece(int pos, Piece piece);
@@ -242,6 +245,11 @@ inline Bitboard Board::pinners(Color color) const
 inline Bitboard Board::checkBlockers(Color color) const
 {
     return currState().checkInfo.blockers[static_cast<int>(color)];
+}
+
+inline Bitboard Board::threats() const
+{
+    return currState().threats;
 }
 
 inline int Board::seePieceValue(PieceType type) const

--- a/Sirius/src/history.h
+++ b/Sirius/src/history.h
@@ -91,7 +91,7 @@ inline void HistoryEntry<MAX_VAL>::update(int bonus)
 
 static constexpr int HISTORY_MAX = 16384;
 
-using MainHist = std::array<std::array<HistoryEntry<HISTORY_MAX>, 4096>, 2>;
+using MainHist = std::array<std::array<std::array<std::array<HistoryEntry<HISTORY_MAX>, 2>, 2>, 4096>, 2>;
 using CHEntry = std::array<std::array<HistoryEntry<HISTORY_MAX>, 64>, 16>;
 using ContHist = std::array<std::array<CHEntry, 64>, 16>;
 using CaptHist = std::array<std::array<std::array<HistoryEntry<HISTORY_MAX>, 64>, 16>, 16>;
@@ -113,18 +113,18 @@ public:
         return m_ContHist[static_cast<int>(move.movingPiece())][move.dstPos()];
     }
 
-    int getQuietStats(ExtMove move, std::span<const CHEntry* const> contHistEntries) const;
+    int getQuietStats(Bitboard threats, ExtMove move, std::span<const CHEntry* const> contHistEntries) const;
     int getNoisyStats(ExtMove move) const;
 
     void clear();
-    void updateQuietStats(ExtMove move, std::span<CHEntry*> contHistEntries, int bonus);
+    void updateQuietStats(Bitboard threats, ExtMove move, std::span<CHEntry*> contHistEntries, int bonus);
     void updateNoisyStats(ExtMove move, int bonus);
 private:
-    int getMainHist(ExtMove move) const;
+    int getMainHist(Bitboard threats, ExtMove move) const;
     int getContHist(const CHEntry* entry, ExtMove move) const;
     int getCaptHist(ExtMove move) const;
 
-    void updateMainHist(ExtMove move, int bonus);
+    void updateMainHist(Bitboard threats, ExtMove move, int bonus);
     void updateContHist(CHEntry* entry, ExtMove move, int bonus);
     void updateCaptHist(ExtMove move, int bonus);
 

--- a/Sirius/src/move_ordering.cpp
+++ b/Sirius/src/move_ordering.cpp
@@ -89,7 +89,7 @@ MoveOrdering::MoveOrdering(const Board& board, MoveList& moves, Move hashMove, c
         else if (move == killers[0] || move == killers[1])
             score = KILLER_SCORE + (move == killers[0]);
         else
-            score = history.getQuietStats(ExtMove::from(board, move), contHistEntries);
+            score = history.getQuietStats(board.threats(), ExtMove::from(board, move), contHistEntries);
         m_MoveScores[i] = score;
     }
 }

--- a/Sirius/src/search.cpp
+++ b/Sirius/src/search.cpp
@@ -423,6 +423,8 @@ int Search::search(SearchThread& thread, int depth, SearchStack* stack, int alph
     MoveList quietsTried;
     MoveList noisiesTried;
 
+    Bitboard threats = board.threats();
+
     int bestScore = -SCORE_MAX;
     int movesPlayed = 0;
 
@@ -435,7 +437,7 @@ int Search::search(SearchThread& thread, int depth, SearchStack* stack, int alph
         bool quietLosing = moveScore < MoveOrdering::KILLER_SCORE;
 
         int baseLMR = lmrTable[std::min(depth, 63)][std::min(movesPlayed, 63)];
-        int histScore = quiet ? history.getQuietStats(ExtMove::from(board, move), contHistEntries) : history.getNoisyStats(ExtMove::from(board, move));
+        int histScore = quiet ? history.getQuietStats(threats, ExtMove::from(board, move), contHistEntries) : history.getNoisyStats(ExtMove::from(board, move));
         if (quiet)
             baseLMR -= histScore / lmrHistDivisor;
 
@@ -554,11 +556,11 @@ int Search::search(SearchThread& thread, int depth, SearchStack* stack, int alph
                 int bonus = historyBonus(depth);
                 if (quiet)
                 {
-                    history.updateQuietStats(ExtMove::from(board, move), contHistEntries, bonus);
+                    history.updateQuietStats(threats, ExtMove::from(board, move), contHistEntries, bonus);
                     for (Move quietMove : quietsTried)
                     {
                         if (quietMove != move)
-                            history.updateQuietStats(ExtMove::from(board, quietMove), contHistEntries, -bonus);
+                            history.updateQuietStats(threats, ExtMove::from(board, quietMove), contHistEntries, -bonus);
                     }
                 }
                 else


### PR DESCRIPTION
```
Score of sirius-6.0-threat-history vs sirius-6.0-pvs-impl: 1235 - 1094 - 2035  [0.516] 4364
...      sirius-6.0-threat-history playing White: 994 - 229 - 959  [0.675] 2182
...      sirius-6.0-threat-history playing Black: 241 - 865 - 1076  [0.357] 2182
...      White vs Black: 1859 - 470 - 2035  [0.659] 4364
Elo difference: 11.2 +/- 7.5, LOS: 99.8 %, DrawRatio: 46.6 %
SPRT: llr 2.96 (100.5%), lbound -2.94, ubound 2.94 - H1 was accepted
```
tc: 8+0.08
book: pohl.epd
sprt bounds: [0, 5]

Bench: 9184957