### PR TITLE
Correction History

### DIFF
--- a/Sirius/src/history.cpp
+++ b/Sirius/src/history.cpp
@@ -54,7 +54,7 @@ int History::correctStaticEval(int staticEval, Color stm, ZKey pawnHash) const
 {
     int bonus = m_CorrHist[static_cast<int>(stm)][pawnHash.value % CORR_HIST_ENTRIES];
     int corrected = staticEval + bonus / CORR_HIST_SCALE;
-    return std::clamp(corrected, SCORE_MATE_IN_MAX, -SCORE_MATE_IN_MAX);
+    return std::clamp(corrected, -SCORE_MATE_IN_MAX, SCORE_MATE_IN_MAX);
 }
 
 void History::updateQuietStats(Bitboard threats, ExtMove move, std::span<CHEntry*> contHistEntries, int bonus)

--- a/Sirius/src/history.h
+++ b/Sirius/src/history.h
@@ -96,6 +96,11 @@ using CHEntry = std::array<std::array<HistoryEntry<HISTORY_MAX>, 64>, 16>;
 using ContHist = std::array<std::array<CHEntry, 64>, 16>;
 using CaptHist = std::array<std::array<std::array<HistoryEntry<HISTORY_MAX>, 64>, 16>, 16>;
 
+constexpr int CORR_HIST_ENTRIES = 16384;
+constexpr int CORR_HIST_SCALE = 256;
+constexpr int MAX_CORR_HIST = CORR_HIST_SCALE * 64;
+using CorrHist = std::array<std::array<int, CORR_HIST_ENTRIES>, 2>;
+
 int historyBonus(int depth);
 
 class History
@@ -115,10 +120,12 @@ public:
 
     int getQuietStats(Bitboard threats, ExtMove move, std::span<const CHEntry* const> contHistEntries) const;
     int getNoisyStats(ExtMove move) const;
+    int correctStaticEval(int staticEval, Color stm, ZKey pawnHash) const;
 
     void clear();
     void updateQuietStats(Bitboard threats, ExtMove move, std::span<CHEntry*> contHistEntries, int bonus);
     void updateNoisyStats(ExtMove move, int bonus);
+    void updateCorrHist(int bonus, int depth, Color stm, ZKey pawnHash);
 private:
     int getMainHist(Bitboard threats, ExtMove move) const;
     int getContHist(const CHEntry* entry, ExtMove move) const;
@@ -131,4 +138,5 @@ private:
     MainHist m_MainHist;
     ContHist m_ContHist;
     CaptHist m_CaptHist;
+    CorrHist m_CorrHist;
 };

--- a/Sirius/src/search.cpp
+++ b/Sirius/src/search.cpp
@@ -586,9 +586,9 @@ int Search::search(SearchThread& thread, int depth, SearchStack* stack, int alph
         return SCORE_DRAW;
     }
 
-    if (!inCheck && moveIsQuiet(board, stack->bestMove) &&
-        !(bound == TTEntry::Bound::LOWER_BOUND && bestScore <= stack->staticEval) &&
-        !(bound == TTEntry::Bound::UPPER_BOUND && bestScore >= stack->staticEval))
+    if (!inCheck && (stack->bestMove == Move() || moveIsQuiet(board, stack->bestMove)) &&
+        !(bound == TTEntry::Bound::LOWER_BOUND && stack->staticEval >= bestScore) &&
+        !(bound == TTEntry::Bound::UPPER_BOUND && stack->staticEval <= bestScore))
         history.updateCorrHist(bestScore - stack->staticEval, depth, board.sideToMove(), board.pawnKey());
 
     m_TT.store(ttIdx, board.zkey(), depth, rootPly, bestScore, stack->bestMove, bound);

--- a/Sirius/src/search.cpp
+++ b/Sirius/src/search.cpp
@@ -365,7 +365,7 @@ int Search::search(SearchThread& thread, int depth, SearchStack* stack, int alph
     stack->staticEval = inCheck ? SCORE_NONE : eval::evaluate(board);
     bool improving = !inCheck && rootPly > 1 && stack->staticEval > stack[-2].staticEval;
 
-    int posEval = stack->staticEval;
+    int posEval = history.correctStaticEval(stack->staticEval, board.sideToMove(), board.pawnKey());
     if (!inCheck && ttHit && (
         ttBound == TTEntry::Bound::EXACT ||
         (ttBound == TTEntry::Bound::LOWER_BOUND && ttScore >= posEval) ||
@@ -573,8 +573,8 @@ int Search::search(SearchThread& thread, int depth, SearchStack* stack, int alph
                     if (noisyMove != move)
                         history.updateNoisyStats(ExtMove::from(board, noisyMove), -bonus);
                 }
-                m_TT.store(ttIdx, board.zkey(), depth, rootPly, bestScore, move, TTEntry::Bound::LOWER_BOUND);
-                return bestScore;
+                bound = TTEntry::Bound::LOWER_BOUND;
+                break;
             }
         }
     }
@@ -585,6 +585,11 @@ int Search::search(SearchThread& thread, int depth, SearchStack* stack, int alph
             return -SCORE_MATE + rootPly;
         return SCORE_DRAW;
     }
+
+    if (!inCheck && moveIsQuiet(board, stack->bestMove) &&
+        !(bound == TTEntry::Bound::LOWER_BOUND && bestScore <= stack->staticEval) &&
+        !(bound == TTEntry::Bound::UPPER_BOUND && bestScore >= stack->staticEval))
+        history.updateCorrHist(bestScore - stack->staticEval, depth, board.sideToMove(), board.pawnKey());
 
     m_TT.store(ttIdx, board.zkey(), depth, rootPly, bestScore, stack->bestMove, bound);
 


### PR DESCRIPTION
```
Score of sirius-6.0-corr-hist vs sirius-6.0-threat-history: 916 - 792 - 1463  [0.520] 3171
...      sirius-6.0-corr-hist playing White: 705 - 161 - 720  [0.672] 1586
...      sirius-6.0-corr-hist playing Black: 211 - 631 - 743  [0.368] 1585
...      White vs Black: 1336 - 372 - 1463  [0.652] 3171
Elo difference: 13.6 +/- 8.9, LOS: 99.9 %, DrawRatio: 46.1 %
SPRT: llr 2.95 (100.3%), lbound -2.94, ubound 2.94 - H1 was accepted
```
tc: 8+0.08
book: pohl.epd
sprt bounds: [-1, 4]

Bench: 9183222