### PR TITLE
Best move stability

### DIFF
--- a/Sirius/src/time_man.h
+++ b/Sirius/src/time_man.h
@@ -32,7 +32,7 @@ public:
     void startSearch();
     void updateNodes(Move move, uint64_t nodes);
     bool stopHard(const SearchLimits& searchLimits, uint64_t nodes);
-    bool stopSoft(Move bestMove, uint64_t totalNodes, const SearchLimits& searchLimits) const;
+    bool stopSoft(Move bestMove, uint64_t totalNodes, const SearchLimits& searchLimits);
 private:
     static constexpr uint32_t TIME_CHECK_INTERVAL = 2048;
 
@@ -43,4 +43,6 @@ private:
     uint32_t checkCounter;
 
     std::array<uint64_t, 4096> m_NodeCounts;
+    Move m_PrevBestMove;
+    uint32_t m_Stability;
 };


### PR DESCRIPTION
```
Elo   | 5.10 +- 3.77 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 12274 W: 3295 L: 3115 D: 5864
Penta | [194, 1413, 2770, 1539, 221]
```
https://mcthouacbb.pythonanywhere.com/test/62/

Bench: 3387921