### PR TITLE
lmr in check and reduce less in check

### DIFF
--- a/Sirius/src/search.cpp
+++ b/Sirius/src/search.cpp
@@ -490,14 +490,14 @@ int Search::search(SearchThread& thread, int depth, SearchStack* stack, int alph
 
         if (movesPlayed >= (pvNode ? lmrMinMovesPv : lmrMinMovesNonPv) &&
             depth >= lmrMinDepth &&
-            quietLosing &&
-            !inCheck)
+            quietLosing)
         {
             int reduction = baseLMR;
 
             reduction += !improving;
             reduction -= pvNode;
             reduction -= givesCheck;
+            reduction -= inCheck;
             reduction += cutnode;
             reduction += stack[1].failHighCount >= static_cast<uint32_t>(lmrFailHighCountMargin);
 


### PR DESCRIPTION
```
Elo   | 7.36 +- 4.78 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 7322 W: 1933 L: 1778 D: 3611
Penta | [89, 858, 1645, 947, 122]
```
https://mcthouacbb.pythonanywhere.com/test/95/

Bench: 3204702