### PR TITLE
Increase lmr for noisy tt move

### DIFF
--- a/Sirius/src/search.cpp
+++ b/Sirius/src/search.cpp
@@ -427,6 +427,7 @@ int Search::search(SearchThread& thread, int depth, SearchStack* stack, int alph
 
     int bestScore = -SCORE_MAX;
     int movesPlayed = 0;
+    bool noisyTTMove = ttData.move != Move() && !moveIsQuiet(board, ttData.move);
 
     for (int moveIdx = 0; moveIdx < static_cast<int>(moves.size()); moveIdx++)
     {
@@ -495,6 +496,7 @@ int Search::search(SearchThread& thread, int depth, SearchStack* stack, int alph
             int reduction = baseLMR;
 
             reduction += !improving;
+            reduction += noisyTTMove;
             reduction -= pvNode;
             reduction -= givesCheck;
             reduction -= inCheck;


### PR DESCRIPTION
```
Elo   | 3.11 +- 2.51 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 27340 W: 7076 L: 6831 D: 13433
Penta | [451, 3157, 6215, 3390, 457]
```
https://mcthouacbb.pythonanywhere.com/test/111/

Bench: 2988953