### PR TITLE
Multicut

### DIFF
--- a/Sirius/src/search.cpp
+++ b/Sirius/src/search.cpp
@@ -501,6 +501,8 @@ int Search::search(SearchThread& thread, int depth, SearchStack* stack, int alph
 
             if (score < sBeta)
                 extension = 1;
+            else if (sBeta >= beta)
+                return sBeta;
         }
 
         m_TT.prefetch(board.keyAfter(move));


### PR DESCRIPTION
```
Elo   | 15.10 +- 7.16 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 3062 W: 817 L: 684 D: 1561
Penta | [37, 298, 736, 415, 45]
```
https://mcthouacbb.pythonanywhere.com/test/130/

Bench: 5629354