### PR TITLE
Double extensions

### DIFF
--- a/Sirius/src/search.h
+++ b/Sirius/src/search.h
@@ -21,6 +21,7 @@ struct SearchStack
     int pvLength;
 
     Move excludedMove;
+    int multiExts;
 
     Move bestMove;
     std::array<Move, 2> killers;

--- a/Sirius/src/search_params.h
+++ b/Sirius/src/search_params.h
@@ -91,6 +91,8 @@ SEARCH_PARAM(histPruningMargin, 1729, 512, 4096, 128);
 SEARCH_PARAM(seMinDepth, 7, 4, 9, 1);
 SEARCH_PARAM(seTTDepthMargin, 3, 2, 5, 1);
 SEARCH_PARAM(sBetaScale, 16, 8, 32, 1);
+SEARCH_PARAM(maxMultiExts, 6, 3, 12, 1);
+SEARCH_PARAM(doubleExtMargin, 15, 0, 40, 2);
 
 SEARCH_PARAM(lmrMinDepth, 3, 2, 5, 1);
 SEARCH_PARAM(lmrMinMovesNonPv, 3, 1, 6, 1);


### PR DESCRIPTION
```
Elo   | 19.44 +- 8.19 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
Games | N: 2308 W: 608 L: 479 D: 1221
Penta | [17, 237, 536, 328, 36]
```
https://mcthouacbb.pythonanywhere.com/test/131/

Bench: 6189429