### PR TITLE
Fix msvc compiling

### DIFF
--- a/CMakeUserPresets.json
+++ b/CMakeUserPresets.json
@@ -31,7 +31,7 @@
             "generator": "Visual Studio 17 2022",
             "binaryDir": "${sourceDir}/build",
             "cacheVariables": {
-                "CMAKE_CXX_FLAGS_INIT": "/W4 /WX /Gy",
+                "CMAKE_CXX_FLAGS_INIT": "/W4 /Gy",
                 "CMAKE_CXX_FLAGS_DEBUG_INIT": "/fsanitize=address",
                 "CMAKE_CXX_FLAGS_RELEASE_INIT": ""
             },

--- a/Sirius/src/defs.h
+++ b/Sirius/src/defs.h
@@ -173,19 +173,10 @@ constexpr int Square::operator-(Square other) const
     return value() - other.value();
 }
 
-// for some reason msvc complains that there is unreachable code here
-// even though there clearly isn't
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable: 4702)
-#endif
 constexpr int Square::value() const
 {
     return static_cast<int>(m_Value);
 }
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif
 
 constexpr int Square::rank() const
 {


### PR DESCRIPTION
msvc gives a random unreachable code warning in a function that clearly is not unreachable
so I'm removing treating msvc warnings as errors for the time being
Bench: 6189429