### PR TITLE
Negative extension when ttScore >= beta

### DIFF
--- a/Sirius/src/search.cpp
+++ b/Sirius/src/search.cpp
@@ -512,6 +512,8 @@ int Search::search(SearchThread& thread, int depth, SearchStack* stack, int alph
             }
             else if (sBeta >= beta)
                 return sBeta;
+            else if (ttData.score >= beta)
+                extension = -1;
         }
 
         stack->multiExts += extension >= 2;


### PR DESCRIPTION
```
Elo   | 4.24 +- 3.22 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.99 (-2.94, 2.94) [0.00, 5.00]
Games | N: 14998 W: 3592 L: 3409 D: 7997
Penta | [166, 1741, 3521, 1886, 185]
```
https://mcthouacbb.pythonanywhere.com/test/132/

Bench: 6078233