### PR TITLE
Static eval in tt

### DIFF
--- a/Sirius/src/tt.cpp
+++ b/Sirius/src/tt.cpp
@@ -100,6 +100,7 @@ bool TT::probe(ZKey key, int ply, ProbedTTData& ttData)
     auto entry = bucket.entries[entryIdx];
 
     ttData.score = retrieveScore(entry.score, ply);
+    ttData.staticEval = entry.staticEval;
     ttData.move = entry.bestMove;
     ttData.depth = entry.depth;
     ttData.bound = entry.bound();
@@ -107,7 +108,7 @@ bool TT::probe(ZKey key, int ply, ProbedTTData& ttData)
     return true;
 }
 
-void TT::store(ZKey key, int depth, int ply, int score, Move move, TTEntry::Bound bound)
+void TT::store(ZKey key, int depth, int ply, int score, int staticEval, Move move, TTEntry::Bound bound)
 {
     // 16 bit keys to save space
     // idea from JW
@@ -149,6 +150,7 @@ void TT::store(ZKey key, int depth, int ply, int score, Move move, TTEntry::Boun
         depth >= replace.depth - 2)
     {
         replace.key16 = key16;
+        replace.staticEval = staticEval;
         replace.depth = static_cast<uint8_t>(depth);
         replace.score = static_cast<int16_t>(storeScore(score, ply));
         replace.genBound = TTEntry::makeGenBound(static_cast<uint8_t>(m_CurrAge), bound);

--- a/Sirius/src/tt.h
+++ b/Sirius/src/tt.h
@@ -13,6 +13,7 @@ struct TTEntry
 {
     uint16_t key16;
     int16_t score;
+    int16_t staticEval;
     Move bestMove;
     uint8_t depth;
     // 2 bits bound(lower), 6 bits gen(upper)
@@ -42,9 +43,10 @@ struct TTEntry
     }
 };
 
-static_assert(sizeof(TTEntry) == 8, "TTEntry must be 8 bytes");
+static_assert(sizeof(TTEntry) == 10, "TTEntry must be 10 bytes");
+static_assert(alignof(TTEntry) == 2, "TTEntry must have 2 byte alignment");
 
-static constexpr int ENTRY_COUNT = 4;
+static constexpr int ENTRY_COUNT = 3;
 
 struct alignas(32) TTBucket
 {
@@ -54,6 +56,7 @@ struct alignas(32) TTBucket
 struct ProbedTTData
 {
     int score;
+    int staticEval;
     Move move;
     int depth;
     TTEntry::Bound bound;
@@ -73,7 +76,7 @@ public:
     TT& operator=(const TT&) = delete;
 
     bool probe(ZKey key, int ply, ProbedTTData& ttData);
-    void store(ZKey key, int ply, int depth, int score, Move move, TTEntry::Bound type);
+    void store(ZKey key, int ply, int depth, int score, int staticEval, Move move, TTEntry::Bound type);
     int quality(int age, int depth) const;
     void prefetch(ZKey key) const;
 

--- a/Sirius/src/tt.h
+++ b/Sirius/src/tt.h
@@ -48,23 +48,7 @@ static constexpr int ENTRY_COUNT = 4;
 
 struct alignas(32) TTBucket
 {
-    std::array<std::atomic_uint64_t, ENTRY_COUNT> entries;
-
-    TTBucket() = default;
-
-    TTBucket(const TTBucket& other)
-    {
-        *this = other;
-    }
-
-    TTBucket& operator=(const TTBucket& other)
-    {
-        for (int i = 0; i < ENTRY_COUNT; i++)
-        {
-            entries[i].store(other.entries[i].load(std::memory_order_relaxed), std::memory_order_relaxed);
-        }
-        return *this;
-    }
+    std::array<TTEntry, ENTRY_COUNT> entries;
 };
 
 struct ProbedTTData


### PR DESCRIPTION
Speedup tool
```
       1555349.714         18454.429|       1503455.095         18132.499|       3.464 %  +/-  4.766 %
       1555452.091         18016.079|       1503291.545         17712.127|       3.481 %  +/-  4.658 %
```

```
Elo   | 8.84 +- 5.29 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 5622 W: 1410 L: 1267 D: 2945
Penta | [65, 612, 1325, 733, 76]
```
https://mcthouacbb.pythonanywhere.com/test/134/

Changed bucket structure doesn't make engine play worse.

Bench: 6001044