### PR TITLE
qs lmp

### DIFF
--- a/Sirius/src/search.cpp
+++ b/Sirius/src/search.cpp
@@ -727,8 +727,11 @@ int Search::qsearch(SearchThread& thread, SearchStack* stack, int alpha, int bet
 
     TTEntry::Bound bound = TTEntry::Bound::UPPER_BOUND;
     stack->bestMove = Move();
+    int movesPlayed = 0;
     for (int moveIdx = 0; moveIdx < static_cast<int>(captures.size()); moveIdx++)
     {
+        if (!inCheck && movesPlayed >= 2)
+            break;
         auto [move, moveScore] = ordering.selectMove(moveIdx);
         if (!board.isLegal(move))
             continue;
@@ -739,6 +742,7 @@ int Search::qsearch(SearchThread& thread, SearchStack* stack, int alpha, int bet
             bestScore = std::max(bestScore, futility);
             continue;
         }
+        movesPlayed++;
         board.makeMove(move, thread.evalState);
         thread.nodes.fetch_add(1, std::memory_order_relaxed);
         rootPly++;


### PR DESCRIPTION
```
Elo   | 3.37 +- 2.65 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.04 (-2.94, 2.94) [0.00, 5.00]
Games | N: 21776 W: 5126 L: 4915 D: 11735
Penta | [226, 2547, 5157, 2706, 252]
```
https://mcthouacbb.pythonanywhere.com/test/155/

Bench: 5744322

Was tested against the previous commit but I'm too lazy to rebase this and retest