### PR TITLE
Move Overhead + clamp time to 1ms

### DIFF
--- a/Sirius/src/comm/uci.cpp
+++ b/Sirius/src/comm/uci.cpp
@@ -25,7 +25,8 @@ UCI::UCI()
     };
     m_Options = {
         {"Hash", UCIOption("Hash", {64, 64, 1, 65536}, hashCallback)},
-        {"Threads", UCIOption("Threads", {1, 1, 1, 256}, threadsCallback)}
+        {"Threads", UCIOption("Threads", {1, 1, 1, 256}, threadsCallback)},
+        {"MoveOverhead", UCIOption("MoveOverhead", {10, 10, 1, 100})},
     };
 #ifdef EXTERNAL_TUNE
     for (auto& param : search::searchParams())
@@ -265,6 +266,7 @@ void UCI::goCommand(std::istringstream& stream)
     std::string tok;
     SearchLimits limits = {};
     limits.maxDepth = 1000;
+    limits.overhead = Duration(m_Options["MoveOverhead"].intValue());
     while (stream.tellg() != -1)
     {
         stream >> tok;

--- a/Sirius/src/time_man.cpp
+++ b/Sirius/src/time_man.cpp
@@ -11,7 +11,7 @@ void TimeManager::setLimits(const SearchLimits& limits, Color us)
 {
     if (limits.clock.enabled)
     {
-        Duration time = limits.clock.timeLeft[static_cast<int>(us)];
+        Duration time = std::max(Duration(1), limits.clock.timeLeft[static_cast<int>(us)] - limits.overhead);
         Duration inc = limits.clock.increments[static_cast<int>(us)];
 
         // formulas from stormphrax

--- a/Sirius/src/time_man.h
+++ b/Sirius/src/time_man.h
@@ -19,6 +19,8 @@ struct SearchLimits
         std::array<Duration, 2> increments;
         bool enabled;
     } clock;
+
+    Duration overhead;
 };
 
 class TimeManager


### PR DESCRIPTION
```
Elo   | 3.66 +- 4.30 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 7878 W: 1895 L: 1812 D: 4171
Penta | [70, 893, 1952, 932, 92]
```
https://mcthouacbb.pythonanywhere.com/test/158/

Bench: 6053553