### PR TITLE
Adjust noisy see margin by capture history

### DIFF
--- a/Sirius/src/search.cpp
+++ b/Sirius/src/search.cpp
@@ -485,9 +485,12 @@ int Search::search(SearchThread& thread, int depth, SearchStack* stack, int alph
                 movesPlayed >= lmpMinMovesBase + depth * depth / (improving ? 1 : 2))
                 break;
 
+            int seeMargin = quiet ?
+                depth * seePruneMarginQuiet :
+                depth * seePruneMarginNoisy - std::clamp(histScore / 32, -seeCaptHistMax * depth, seeCaptHistMax * depth);
             if (!pvNode &&
                 depth <= maxSeePruneDepth &&
-                !board.see(move, depth * (quiet ? seePruneMarginQuiet : seePruneMarginNoisy)))
+                !board.see(move, seeMargin))
                 continue;
 
             if (quiet &&

--- a/Sirius/src/search_params.h
+++ b/Sirius/src/search_params.h
@@ -84,6 +84,8 @@ SEARCH_PARAM(lmpMinMovesBase, 2, 2, 7, 1);
 SEARCH_PARAM(maxSeePruneDepth, 7, 6, 11, 1);
 SEARCH_PARAM(seePruneMarginNoisy, -99, -120, -30, 6);
 SEARCH_PARAM(seePruneMarginQuiet, -66, -120, -30, 6);
+SEARCH_PARAM(seeCaptHistMax, 100, 50, 200, 6);
+SEARCH_PARAM(seeCaptHistDivisor, 32, 16, 96, 2);
 
 SEARCH_PARAM(maxHistPruningDepth, 5, 2, 8, 1);
 SEARCH_PARAM(histPruningMargin, 1729, 512, 4096, 128);


### PR DESCRIPTION
```
Elo   | 5.94 +- 4.11 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 9248 W: 2241 L: 2083 D: 4924
Penta | [111, 1033, 2183, 1181, 116]
```
https://mcthouacbb.pythonanywhere.com/test/160/

Bench: 6248657