### PR TITLE
Do deeper/shallower

### DIFF
--- a/Sirius/src/search.cpp
+++ b/Sirius/src/search.cpp
@@ -573,7 +573,12 @@ int Search::search(SearchThread& thread, int depth, SearchStack* stack, int alph
             int reduced = std::min(std::max(newDepth - reduction, 1), newDepth);
             score = -search(thread, reduced, stack + 1, -alpha - 1, -alpha, false, true);
             if (score > alpha && reduced < newDepth)
+            {
+                bool doDeeper = score > bestScore + 35 + 2 * newDepth;
+                bool doShallower = score < bestScore + 8;
+                newDepth += doDeeper - doShallower;
                 score = -search(thread, newDepth, stack + 1, -alpha - 1, -alpha, false, !cutnode);
+            }
         }
         else if (!pvNode || movesPlayed > 1)
             score = -search(thread, newDepth, stack + 1, -alpha - 1, -alpha, false, !cutnode);


### PR DESCRIPTION
```
Elo   | 6.77 +- 4.50 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 7854 W: 2009 L: 1856 D: 3989
Penta | [68, 943, 1809, 982, 125]
```
https://mcthouacbb.pythonanywhere.com/test/184/

Bench: 5365599