### PR TITLE
Make nmp eval margin higher at low depths and vice versa

### DIFF
--- a/Sirius/src/search.cpp
+++ b/Sirius/src/search.cpp
@@ -404,7 +404,9 @@ int Search::search(SearchThread& thread, int depth, SearchStack* stack, int alph
 
         // null move pruning
         Bitboard nonPawns = board.pieces(board.sideToMove()) ^ board.pieces(board.sideToMove(), PieceType::PAWN);
-        if (board.pliesFromNull() > 0 && depth >= nmpMinDepth && stack->eval >= beta && nonPawns.multiple())
+        if (board.pliesFromNull() > 0 && depth >= nmpMinDepth &&
+            stack->eval >= beta && stack->staticEval >= beta + 175 - 25 * depth &&
+            nonPawns.multiple())
         {
             int r = nmpBaseReduction + depth / nmpDepthReductionScale + std::min((stack->eval - beta) / nmpEvalReductionScale, nmpMaxEvalReduction);
             board.makeNullMove();


### PR DESCRIPTION
```
Elo   | 25.62 +- 9.38 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.00 (-2.94, 2.94) [0.00, 5.00]
Games | N: 1698 W: 464 L: 339 D: 895
Penta | [8, 157, 421, 228, 35]
```
https://mcthouacbb.pythonanywhere.com/test/193/

Bench: 6042395