### PR TITLE
Adjust bad capture margin based on capture history

### DIFF
--- a/Sirius/src/move_ordering.cpp
+++ b/Sirius/src/move_ordering.cpp
@@ -80,7 +80,8 @@ MoveOrdering::MoveOrdering(const Board& board, MoveList& moves, Move hashMove, c
 
         if (isCapture)
         {
-            score = history.getNoisyStats(ExtMove::from(board, move)) + CAPTURE_SCORE * board.see(move, 0) + mvvLva(board, move);
+            int hist = history.getNoisyStats(ExtMove::from(board, move));
+            score = hist + CAPTURE_SCORE * board.see(move, -hist / 32) + mvvLva(board, move);
         }
         else if (isPromotion)
         {


### PR DESCRIPTION
```
Elo   | 3.73 +- 2.93 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 18168 W: 4603 L: 4408 D: 9157
Penta | [211, 2107, 4254, 2300, 212]
```
https://mcthouacbb.pythonanywhere.com/test/218/

Bench: 5863374