### PR TITLE
Staged move generation

### DIFF
--- a/Sirius/src/board.h
+++ b/Sirius/src/board.h
@@ -171,6 +171,7 @@ public:
     Bitboard threats() const;
 
     bool see(Move move, int margin) const;
+    bool isPseudoLegal(Move move) const;
     bool isLegal(Move move) const;
     ZKey keyAfter(Move move) const;
 private:

--- a/Sirius/src/misc.cpp
+++ b/Sirius/src/misc.cpp
@@ -160,6 +160,70 @@ void testNoisyGen(Board& board, int depth)
     }
 }
 
+void testIsPseudoLegal(Board& board, int depth)
+{
+    if (depth == 0)
+    {
+        MoveList moves;
+        genMoves<MoveGenType::NOISY_QUIET>(board, moves);
+
+        for (Move move : moves)
+        {
+            if (!board.isPseudoLegal(move))
+            {
+                std::cout << board.fenStr() << std::endl;
+                std::cout << comm::convMoveToPCN(move) << std::endl;
+                throw std::runtime_error("bruh");
+            }
+        }
+
+        for (int from = 0; from < 64; from++)
+        {
+            for (int to = 0; to < 64; to++)
+            {
+                Move move(Square(from), Square(to), MoveType::NONE);
+                if (std::find(moves.begin(), moves.end(), move) == moves.end() && board.isPseudoLegal(move))
+                    throw std::runtime_error("bruh2");
+
+                move = Move(Square(from), Square(to), MoveType::ENPASSANT);
+                if (std::find(moves.begin(), moves.end(), move) == moves.end() && board.isPseudoLegal(move))
+                    throw std::runtime_error("bruh2");
+
+                move = Move(Square(from), Square(to), MoveType::CASTLE);
+                if (std::find(moves.begin(), moves.end(), move) == moves.end() && board.isPseudoLegal(move))
+                    throw std::runtime_error("bruh2");
+
+                move = Move(Square(from), Square(to), MoveType::PROMOTION, Promotion::KNIGHT);
+                if (std::find(moves.begin(), moves.end(), move) == moves.end() && board.isPseudoLegal(move))
+                    throw std::runtime_error("bruh2");
+
+                move = Move(Square(from), Square(to), MoveType::PROMOTION, Promotion::BISHOP);
+                if (std::find(moves.begin(), moves.end(), move) == moves.end() && board.isPseudoLegal(move))
+                    throw std::runtime_error("bruh2");
+
+                move = Move(Square(from), Square(to), MoveType::PROMOTION, Promotion::ROOK);
+                if (std::find(moves.begin(), moves.end(), move) == moves.end() && board.isPseudoLegal(move))
+                    throw std::runtime_error("bruh2");
+
+                move = Move(Square(from), Square(to), MoveType::PROMOTION, Promotion::QUEEN);
+                if (std::find(moves.begin(), moves.end(), move) == moves.end() && board.isPseudoLegal(move))
+                    throw std::runtime_error("bruh2");
+            }
+        }
+        return;
+    }
+
+    MoveList moves;
+    genMoves<MoveGenType::LEGAL>(board, moves);
+
+    for (Move move : moves)
+    {
+        board.makeMove(move);
+        testIsPseudoLegal(board, depth - 1);
+        board.unmakeMove();
+    }
+}
+
 void testQuietGen(Board& board, int depth)
 {
     if (depth == 0)

--- a/Sirius/src/misc.h
+++ b/Sirius/src/misc.h
@@ -10,7 +10,8 @@ void testSAN(Board& board, int depth);
 
 void testKeyAfter(Board& board, int depth);
 
-void testQuiescence(Board& board, int depth);
+void testNoisyGen(Board& board, int depth);
+void testQuietGen(Board& board, int depth);
 
 void testSEE();
 

--- a/Sirius/src/misc.h
+++ b/Sirius/src/misc.h
@@ -13,6 +13,8 @@ void testKeyAfter(Board& board, int depth);
 void testNoisyGen(Board& board, int depth);
 void testQuietGen(Board& board, int depth);
 
+void testIsPseudoLegal(Board& board, int depth);
+
 void testSEE();
 
 void runTests(Board& board, bool fast);

--- a/Sirius/src/move_ordering.cpp
+++ b/Sirius/src/move_ordering.cpp
@@ -37,9 +37,6 @@ bool moveIsCapture(const Board& board, Move move)
 
 int MoveOrdering::scoreMove(Move move) const
 {
-    if (move == m_TTMove)
-        return 10000000;
-
     bool isCapture = moveIsCapture(m_Board, move);
     bool isPromotion = move.type() == MoveType::PROMOTION;
 
@@ -60,9 +57,6 @@ int MoveOrdering::scoreMove(Move move) const
 
 int MoveOrdering::scoreMoveQSearch(Move move) const
 {
-    if (move == m_TTMove)
-        return 10000000;
-
     bool isCapture = moveIsCapture(m_Board, move);
     bool isPromotion = move.type() == MoveType::PROMOTION;
     int score = m_History.getNoisyStats(ExtMove::from(m_Board, move));

--- a/Sirius/src/move_ordering.cpp
+++ b/Sirius/src/move_ordering.cpp
@@ -75,24 +75,31 @@ int MoveOrdering::scoreMoveQSearch(Move move) const
 }
 
 MoveOrdering::MoveOrdering(const Board& board, MoveList& moves, Move ttMove, const History& history)
-    : m_Board(board), m_Moves(moves), m_TTMove(ttMove), m_History(history)
+    : m_Board(board), m_Moves(moves), m_TTMove(ttMove), m_History(history), m_Curr(0)
 {
     for (uint32_t i = 0; i < m_Moves.size(); i++)
         m_MoveScores[i] = scoreMoveQSearch(m_Moves[i]);
 }
 
 MoveOrdering::MoveOrdering(const Board& board, MoveList& moves, Move ttMove, const std::array<Move, 2>& killers, std::span<const CHEntry* const> contHistEntries, const History& history)
-    : m_Board(board), m_Moves(moves), m_TTMove(ttMove), m_History(history), m_ContHistEntries(contHistEntries), m_Killers(killers)
+    : m_Board(board), m_Moves(moves), m_TTMove(ttMove), m_History(history), m_ContHistEntries(contHistEntries), m_Killers(killers), m_Curr(0)
 {
     for (uint32_t i = 0; i < m_Moves.size(); i++)
         m_MoveScores[i] = scoreMove(m_Moves[i]);
 }
 
-ScoredMove MoveOrdering::selectMove(uint32_t index)
+ScoredMove MoveOrdering::selectMove()
+{
+    if (m_Curr >= m_Moves.size())
+        return {Move(), NO_MOVE};
+    return selectHighest();
+}
+
+ScoredMove MoveOrdering::selectHighest()
 {
     int bestScore = INT_MIN;
-    uint32_t bestIndex = index;
-    for (uint32_t i = index; i < m_Moves.size(); i++)
+    uint32_t bestIndex = m_Curr;
+    for (uint32_t i = m_Curr; i < m_Moves.size(); i++)
     {
         if (m_MoveScores[i] > bestScore)
         {
@@ -101,8 +108,8 @@ ScoredMove MoveOrdering::selectMove(uint32_t index)
         }
     }
 
-    std::swap(m_Moves[bestIndex], m_Moves[index]);
-    std::swap(m_MoveScores[bestIndex], m_MoveScores[index]);
+    std::swap(m_Moves[bestIndex], m_Moves[m_Curr]);
+    std::swap(m_MoveScores[bestIndex], m_MoveScores[m_Curr]);
 
-    return {m_Moves[index], m_MoveScores[index]};
+    return {m_Moves[m_Curr], m_MoveScores[m_Curr++]};
 }

--- a/Sirius/src/move_ordering.cpp
+++ b/Sirius/src/move_ordering.cpp
@@ -68,13 +68,13 @@ int MoveOrdering::scoreMoveQSearch(Move move) const
     return score;
 }
 
-MoveOrdering::MoveOrdering(const Board& board, MoveList& moves, Move ttMove, const History& history)
-    : m_Board(board), m_Moves(moves), m_TTMove(ttMove), m_History(history), m_Curr(0), m_Stage(MovePickStage::QS_TT_MOVE)
+MoveOrdering::MoveOrdering(const Board& board, Move ttMove, const History& history)
+    : m_Board(board), m_TTMove(ttMove), m_History(history), m_Curr(0), m_Stage(MovePickStage::QS_TT_MOVE)
 {
 }
 
-MoveOrdering::MoveOrdering(const Board& board, MoveList& moves, Move ttMove, const std::array<Move, 2>& killers, std::span<const CHEntry* const> contHistEntries, const History& history)
-    : m_Board(board), m_Moves(moves), m_TTMove(ttMove),
+MoveOrdering::MoveOrdering(const Board& board, Move ttMove, const std::array<Move, 2>& killers, std::span<const CHEntry* const> contHistEntries, const History& history)
+    : m_Board(board), m_TTMove(ttMove),
     m_History(history), m_ContHistEntries(contHistEntries), m_Killers(killers),
     m_Curr(0), m_Stage(MovePickStage::TT_MOVE)
 {
@@ -93,6 +93,7 @@ ScoredMove MoveOrdering::selectMove()
             // fallthrough
         case GEN_NOISY_QUIETS:
             ++m_Stage;
+            genMoves<MoveGenType::NOISY_QUIET>(m_Board, m_Moves);
             for (uint32_t i = 0; i < m_Moves.size(); i++)
                 m_MoveScores[i] = scoreMove(m_Moves[i]);
 
@@ -115,6 +116,7 @@ ScoredMove MoveOrdering::selectMove()
             // fallthrough
         case QS_GEN_NOISIES:
             ++m_Stage;
+            genMoves<MoveGenType::NOISY>(m_Board, m_Moves);
             for (uint32_t i = 0; i < m_Moves.size(); i++)
                 m_MoveScores[i] = scoreMoveQSearch(m_Moves[i]);
 

--- a/Sirius/src/move_ordering.h
+++ b/Sirius/src/move_ordering.h
@@ -40,8 +40,8 @@ public:
     static constexpr int PROMOTION_SCORE = 400000;
     static constexpr int CAPTURE_SCORE = 500000;
 
-    MoveOrdering(const Board& board, MoveList& moves, Move ttMove, const History& history);
-    MoveOrdering(const Board& board, MoveList& moves, Move hashMove, const std::array<Move, 2>& killers, std::span<const CHEntry* const> contHistEntries, const History& history);
+    MoveOrdering(const Board& board, Move ttMove, const History& history);
+    MoveOrdering(const Board& board, Move hashMove, const std::array<Move, 2>& killers, std::span<const CHEntry* const> contHistEntries, const History& history);
 
     ScoredMove selectMove();
     ScoredMove selectHighest();
@@ -50,7 +50,7 @@ private:
     int scoreMoveQSearch(Move move) const;
 
     const Board& m_Board;
-    MoveList& m_Moves;
+    MoveList m_Moves;
     Move m_TTMove;
     const History& m_History;
     std::span<const CHEntry* const> m_ContHistEntries;

--- a/Sirius/src/move_ordering.h
+++ b/Sirius/src/move_ordering.h
@@ -21,11 +21,20 @@ public:
     static constexpr int PROMOTION_SCORE = 400000;
     static constexpr int CAPTURE_SCORE = 500000;
 
-    MoveOrdering(const Board& board, MoveList& moves, Move hashMove, const History& history);
+    MoveOrdering(const Board& board, MoveList& moves, Move ttMove, const History& history);
     MoveOrdering(const Board& board, MoveList& moves, Move hashMove, const std::array<Move, 2>& killers, std::span<const CHEntry* const> contHistEntries, const History& history);
 
     ScoredMove selectMove(uint32_t index);
 private:
+    int scoreMove(Move move) const;
+    int scoreMoveQSearch(Move move) const;
+
+    const Board& m_Board;
     MoveList& m_Moves;
+    Move m_TTMove;
+    const History& m_History;
+    std::span<const CHEntry* const> m_ContHistEntries;
+    std::array<Move, 2> m_Killers;
+
     std::array<int, 256> m_MoveScores;
 };

--- a/Sirius/src/move_ordering.h
+++ b/Sirius/src/move_ordering.h
@@ -14,9 +14,19 @@ struct ScoredMove
 bool moveIsQuiet(const Board& board, Move move);
 bool moveIsCapture(const Board& board, Move move);
 
+enum class MovePickStage
+{
+    TT_MOVE,
+    REST,
+
+    QS_TT_MOVE,
+    QS_REST
+};
+
 class MoveOrdering
 {
 public:
+    static constexpr int NO_MOVE = -8000000;
     static constexpr int KILLER_SCORE = 300000;
     static constexpr int PROMOTION_SCORE = 400000;
     static constexpr int CAPTURE_SCORE = 500000;
@@ -24,7 +34,8 @@ public:
     MoveOrdering(const Board& board, MoveList& moves, Move ttMove, const History& history);
     MoveOrdering(const Board& board, MoveList& moves, Move hashMove, const std::array<Move, 2>& killers, std::span<const CHEntry* const> contHistEntries, const History& history);
 
-    ScoredMove selectMove(uint32_t index);
+    ScoredMove selectMove();
+    ScoredMove selectHighest();
 private:
     int scoreMove(Move move) const;
     int scoreMoveQSearch(Move move) const;
@@ -37,4 +48,6 @@ private:
     std::array<Move, 2> m_Killers;
 
     std::array<int, 256> m_MoveScores;
+
+    uint32_t m_Curr;
 };

--- a/Sirius/src/move_ordering.h
+++ b/Sirius/src/move_ordering.h
@@ -17,8 +17,10 @@ bool moveIsCapture(const Board& board, Move move);
 enum class MovePickStage
 {
     TT_MOVE,
-    GEN_NOISY_QUIETS,
-    NOISY_QUIETS,
+    GEN_NOISY,
+    GOOD_NOISY,
+    GEN_QUIETS,
+    BAD_NOISY_QUIETS,
 
     QS_TT_MOVE,
     QS_GEN_NOISIES,
@@ -46,7 +48,8 @@ public:
     ScoredMove selectMove();
     ScoredMove selectHighest();
 private:
-    int scoreMove(Move move) const;
+    int scoreNoisy(Move move) const;
+    int scoreQuiet(Move move) const;
     int scoreMoveQSearch(Move move) const;
 
     const Board& m_Board;
@@ -59,5 +62,6 @@ private:
     std::array<int, 256> m_MoveScores;
 
     uint32_t m_Curr;
+    uint32_t m_NoisyEnd;
     MovePickStage m_Stage;
 };

--- a/Sirius/src/move_ordering.h
+++ b/Sirius/src/move_ordering.h
@@ -17,10 +17,12 @@ bool moveIsCapture(const Board& board, Move move);
 enum class MovePickStage
 {
     TT_MOVE,
-    REST,
+    GEN_NOISY_QUIETS,
+    NOISY_QUIETS,
 
     QS_TT_MOVE,
-    QS_REST
+    QS_GEN_NOISIES,
+    QS_NOISIES
 };
 
 inline MovePickStage operator++(MovePickStage& stage)

--- a/Sirius/src/move_ordering.h
+++ b/Sirius/src/move_ordering.h
@@ -23,6 +23,13 @@ enum class MovePickStage
     QS_REST
 };
 
+inline MovePickStage operator++(MovePickStage& stage)
+{
+    assert(stage != MovePickStage::QS_REST);
+    stage = static_cast<MovePickStage>(static_cast<int>(stage) + 1);
+    return stage;
+}
+
 class MoveOrdering
 {
 public:
@@ -50,4 +57,5 @@ private:
     std::array<int, 256> m_MoveScores;
 
     uint32_t m_Curr;
+    MovePickStage m_Stage;
 };

--- a/Sirius/src/movegen.cpp
+++ b/Sirius/src/movegen.cpp
@@ -7,7 +7,6 @@ void genMoves(const Board& board, MoveList& moves);
 template<MoveGenType type>
 void genMoves(const Board& board, MoveList& moves)
 {
-    assert(moves.size() == 0);
     if (board.sideToMove() == Color::WHITE)
     {
         genMoves<type, Color::WHITE>(board, moves);

--- a/Sirius/src/movegen.cpp
+++ b/Sirius/src/movegen.cpp
@@ -33,6 +33,7 @@ void genMoves<MoveGenType::LEGAL>(const Board& board, MoveList& moves)
 
 template void genMoves<MoveGenType::NOISY>(const Board& board, MoveList& moves);
 template void genMoves<MoveGenType::NOISY_QUIET>(const Board& board, MoveList& moves);
+template void genMoves<MoveGenType::QUIET>(const Board& board, MoveList& moves);
 
 template<MoveGenType type, Color color>
 void genKingMoves(const Board& board, MoveList& moves);
@@ -56,6 +57,8 @@ void genMoves(const Board& board, MoveList& moves)
         genPawnMoves<type, color>(board, moves, moveMask);
         if constexpr (type == MoveGenType::NOISY)
             moveMask &= board.pieces(~color);
+        else if constexpr (type == MoveGenType::QUIET)
+            moveMask &= ~board.pieces(~color);
         genPieceMoves<type, color, PieceType::KNIGHT>(board, moves, moveMask);
         genPieceMoves<type, color, PieceType::BISHOP>(board, moves, moveMask);
         genPieceMoves<type, color, PieceType::ROOK>(board, moves, moveMask);
@@ -75,13 +78,15 @@ void genKingMoves(const Board& board, MoveList& moves)
     kingAttacks &= ~usBB;
     if constexpr (type == MoveGenType::NOISY)
         kingAttacks &= oppBB;
+    else if constexpr (type == MoveGenType::QUIET)
+        kingAttacks &= ~oppBB;
     while (kingAttacks.any())
     {
         Square dst = kingAttacks.poplsb();
         moves.push_back(Move(kingSq, dst, MoveType::NONE));
     }
 
-    if constexpr (type == MoveGenType::NOISY_QUIET)
+    if constexpr (type == MoveGenType::NOISY_QUIET || type == MoveGenType::QUIET)
     {
         if (board.checkers().empty())
         {
@@ -178,6 +183,35 @@ void genPawnMoves(const Board& board, MoveList& moves, Bitboard moveMask)
             moves.push_back(Move(promotion - attacks::pawnPushOffset<color>(), promotion, MoveType::PROMOTION, Promotion::BISHOP));
             moves.push_back(Move(promotion - attacks::pawnPushOffset<color>(), promotion, MoveType::PROMOTION, Promotion::KNIGHT));
         }
+    }
+    else if constexpr (type == MoveGenType::QUIET)
+    {
+        Bitboard pawnPushes = attacks::pawnPushes<color>(pawns);
+        pawnPushes &= ~allPieces;
+
+        Bitboard doublePushes = attacks::pawnPushes<color>(pawnPushes & Bitboard::nthRank<color, 2>());
+        doublePushes &= ~allPieces;
+        doublePushes &= moveMask;
+
+        pawnPushes &= moveMask;
+
+        Bitboard promotions = pawnPushes & Bitboard::nthRank<color, 7>();
+        pawnPushes ^= promotions;
+
+        while (pawnPushes.any())
+        {
+            Square push = pawnPushes.poplsb();
+            moves.push_back(Move(push - attacks::pawnPushOffset<color>(), push, MoveType::NONE));
+        }
+
+        while (doublePushes.any())
+        {
+            Square dPush = doublePushes.poplsb();
+            moves.push_back(Move(dPush - 2 * attacks::pawnPushOffset<color>(), dPush, MoveType::NONE));
+        }
+
+        // rest of the pawn movegen is captures/promos
+        return;
     }
 
 

--- a/Sirius/src/movegen.h
+++ b/Sirius/src/movegen.h
@@ -7,7 +7,8 @@ enum class MoveGenType
 {
     LEGAL,
     NOISY_QUIET,
-    NOISY
+    NOISY,
+    QUIET
 };
 
 using MoveList = StaticVector<Move, 256>;

--- a/Sirius/src/search.cpp
+++ b/Sirius/src/search.cpp
@@ -429,9 +429,6 @@ int Search::search(SearchThread& thread, int depth, SearchStack* stack, int alph
         }
     }
 
-    MoveList moves;
-    genMoves<MoveGenType::NOISY_QUIET>(board, moves);
-
     std::array<CHEntry*, 3> contHistEntries = {
         rootPly > 0 ? stack[-1].contHistEntry : nullptr,
         rootPly > 1 ? stack[-2].contHistEntry : nullptr,
@@ -440,7 +437,6 @@ int Search::search(SearchThread& thread, int depth, SearchStack* stack, int alph
 
     MoveOrdering ordering(
         board,
-        moves,
         ttData.move,
         stack->killers,
         contHistEntries,
@@ -743,10 +739,7 @@ int Search::qsearch(SearchThread& thread, SearchStack* stack, int alpha, int bet
     if (rootPly >= MAX_PLY)
         return alpha;
 
-    MoveList captures;
-    genMoves<MoveGenType::NOISY>(board, captures);
-
-    MoveOrdering ordering(board, captures, ttData.move, thread.history);
+    MoveOrdering ordering(board, ttData.move, thread.history);
 
     TTEntry::Bound bound = TTEntry::Bound::UPPER_BOUND;
     stack->bestMove = Move();

--- a/Sirius/src/search.cpp
+++ b/Sirius/src/search.cpp
@@ -465,9 +465,10 @@ int Search::search(SearchThread& thread, int depth, SearchStack* stack, int alph
     if (!root)
         stack->multiExts = stack[-1].multiExts;
 
-    for (int moveIdx = 0; moveIdx < static_cast<int>(moves.size()); moveIdx++)
+    ScoredMove scoredMove = {};
+    while ((scoredMove = ordering.selectMove()).score != MoveOrdering::NO_MOVE)
     {
-        auto [move, moveScore] = ordering.selectMove(static_cast<uint32_t>(moveIdx));
+        auto [move, moveScore] = scoredMove;
         if (move == stack->excludedMove)
             continue;
         if (!board.isLegal(move))
@@ -750,11 +751,13 @@ int Search::qsearch(SearchThread& thread, SearchStack* stack, int alpha, int bet
     TTEntry::Bound bound = TTEntry::Bound::UPPER_BOUND;
     stack->bestMove = Move();
     int movesPlayed = 0;
-    for (int moveIdx = 0; moveIdx < static_cast<int>(captures.size()); moveIdx++)
+
+    ScoredMove scoredMove = {};
+    while ((scoredMove = ordering.selectMove()).score != MoveOrdering::NO_MOVE)
     {
         if (!inCheck && movesPlayed >= 2)
             break;
-        auto [move, moveScore] = ordering.selectMove(moveIdx);
+        auto [move, moveScore] = scoredMove;
         if (!board.isLegal(move))
             continue;
         if (!board.see(move, 0))


### PR DESCRIPTION
TT move staging
```
Elo   | 7.22 +- 4.67 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 5.00]
Games | N: 7366 W: 1907 L: 1754 D: 3705
Penta | [80, 857, 1681, 960, 105]
```
https://mcthouacbb.pythonanywhere.com/test/224/

Quiet/capture split
```
Elo   | 9.43 +- 5.45 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
Games | N: 5162 W: 1365 L: 1225 D: 2572
Penta | [49, 567, 1232, 661, 72]
```
https://mcthouacbb.pythonanywhere.com/test/228/

Combined
```
Elo   | 13.07 +- 6.62 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 3564 W: 964 L: 830 D: 1770
Penta | [30, 389, 836, 471, 56]
```
https://mcthouacbb.pythonanywhere.com/test/232/

TODO
- Stage killers(tried already but didn't pass, probably some bug)
- Do SEE for good/bad captures lazily

Bench: 6019604