### PR TITLE
Correction history indexed by minor pieces and kings

### DIFF
--- a/Sirius/src/board.cpp
+++ b/Sirius/src/board.cpp
@@ -27,6 +27,7 @@ void Board::setToFen(const std::string_view& fen)
     currState().pawnKey.value = 0;
     currState().nonPawnKey[static_cast<int>(Color::WHITE)].value = 0;
     currState().nonPawnKey[static_cast<int>(Color::BLACK)].value = 0;
+    currState().minorPieceKey.value = 0;
 
     int i = 0;
     int sq = 56;
@@ -170,6 +171,7 @@ void Board::setToEpd(const std::string_view& epd)
     currState().pawnKey.value = 0;
     currState().nonPawnKey[static_cast<int>(Color::WHITE)].value = 0;
     currState().nonPawnKey[static_cast<int>(Color::BLACK)].value = 0;
+    currState().minorPieceKey.value = 0;
 
     int i = 0;
     int sq = 56;

--- a/Sirius/src/board.h
+++ b/Sirius/src/board.h
@@ -31,6 +31,7 @@ struct BoardState
     int lastRepetition;
     ZKey zkey;
     std::array<ZKey, 2> nonPawnKey;
+    ZKey minorPieceKey;
     ZKey pawnKey;
     CheckInfo checkInfo;
     Bitboard threats;
@@ -63,7 +64,11 @@ struct BoardState
         if (pieceType == PieceType::PAWN)
             pawnKey.addPiece(pieceType, color, pos);
         else
+        {
             nonPawnKey[static_cast<int>(color)].addPiece(pieceType, color, pos);
+            if (pieceType == PieceType::BISHOP || pieceType == PieceType::KNIGHT || pieceType == PieceType::KING)
+                minorPieceKey.addPiece(pieceType, color, pos);
+        }
     }
 
     void removePiece(Square pos)
@@ -80,7 +85,11 @@ struct BoardState
         if (pieceType == PieceType::PAWN)
             pawnKey.removePiece(pieceType, color, pos);
         else
+        {
             nonPawnKey[static_cast<int>(color)].removePiece(pieceType, color, pos);
+            if (pieceType == PieceType::BISHOP || pieceType == PieceType::KNIGHT || pieceType == PieceType::KING)
+                minorPieceKey.removePiece(pieceType, color, pos);
+        }
     }
 
     void movePiece(Square src, Square dst)
@@ -101,7 +110,11 @@ struct BoardState
         if (pieceType == PieceType::PAWN)
             pawnKey.movePiece(pieceType, color, src, dst);
         else
+        {
             nonPawnKey[static_cast<int>(color)].movePiece(pieceType, color, src, dst);
+            if (pieceType == PieceType::BISHOP || pieceType == PieceType::KNIGHT || pieceType == PieceType::KING)
+                minorPieceKey.movePiece(pieceType, color, src, dst);
+        }
     }
 };
 
@@ -141,6 +154,7 @@ public:
     ZKey zkey() const;
     ZKey pawnKey() const;
     ZKey nonPawnKey(Color color) const;
+    ZKey minorPieceKey() const;
     uint64_t materialKey() const;
 
     bool isDraw(int searchPly);
@@ -294,6 +308,11 @@ inline ZKey Board::pawnKey() const
 inline ZKey Board::nonPawnKey(Color color) const
 {
     return currState().nonPawnKey[static_cast<int>(color)];
+}
+
+inline ZKey Board::minorPieceKey() const
+{
+    return currState().minorPieceKey;
 }
 
 // yoinked from motor, which I think yoinked from Caissa

--- a/Sirius/src/history.cpp
+++ b/Sirius/src/history.cpp
@@ -80,8 +80,9 @@ int History::correctStaticEval(int staticEval, const Board& board) const
     int nonPawnBlackEntry = m_NonPawnCorrHist[static_cast<int>(stm)][static_cast<int>(Color::BLACK)][board.nonPawnKey(Color::BLACK).value % NON_PAWN_CORR_HIST_ENTRIES];
     int nonPawnEntry = (nonPawnWhiteEntry + nonPawnBlackEntry) / 2;
     int threatsEntry = m_ThreatsCorrHist[static_cast<int>(stm)][threatsKey % THREATS_CORR_HIST_ENTRIES];
-    
-    int corrected = staticEval + (pawnEntry + materialEntry + nonPawnEntry + threatsEntry) / CORR_HIST_SCALE;
+    int minorPieceEntry = m_MinorPieceCorrHist[static_cast<int>(stm)][board.minorPieceKey().value % MINOR_PIECE_CORR_HIST_ENTRIES];
+
+    int corrected = staticEval + (pawnEntry + materialEntry + nonPawnEntry + threatsEntry + minorPieceEntry) / CORR_HIST_SCALE;
     return std::clamp(corrected, -SCORE_MATE_IN_MAX, SCORE_MATE_IN_MAX);
 }
 
@@ -119,6 +120,9 @@ void History::updateCorrHist(int bonus, int depth, const Board& board)
 
     auto& threatsEntry = m_ThreatsCorrHist[static_cast<int>(stm)][threatsKey % THREATS_CORR_HIST_ENTRIES];
     threatsEntry.update(scaledBonus, weight);
+
+    auto& minorPieceEntry = m_MinorPieceCorrHist[static_cast<int>(stm)][board.minorPieceKey().value % MINOR_PIECE_CORR_HIST_ENTRIES];
+    minorPieceEntry.update(scaledBonus, weight);
 }
 
 int History::getMainHist(Bitboard threats, ExtMove move) const

--- a/Sirius/src/history.h
+++ b/Sirius/src/history.h
@@ -136,10 +136,12 @@ constexpr int PAWN_CORR_HIST_ENTRIES = 16384;
 constexpr int MATERIAL_CORR_HIST_ENTRIES = 32768;
 constexpr int NON_PAWN_CORR_HIST_ENTRIES = 16384;
 constexpr int THREATS_CORR_HIST_ENTRIES = 16384;
+constexpr int MINOR_PIECE_CORR_HIST_ENTRIES = 16384;
 using PawnCorrHist = std::array<std::array<CorrHistEntry<MAX_CORR_HIST>, PAWN_CORR_HIST_ENTRIES>, 2>;
 using MaterialCorrHist = std::array<std::array<CorrHistEntry<MAX_CORR_HIST>, MATERIAL_CORR_HIST_ENTRIES>, 2>;
 using NonPawnCorrHist = std::array<std::array<std::array<CorrHistEntry<MAX_CORR_HIST>, NON_PAWN_CORR_HIST_ENTRIES>, 2>, 2>;
 using ThreatsCorrHist = std::array<std::array<CorrHistEntry<MAX_CORR_HIST>, THREATS_CORR_HIST_ENTRIES>, 2>;
+using MinorPieceCorrHist = std::array<std::array<CorrHistEntry<MAX_CORR_HIST>, MINOR_PIECE_CORR_HIST_ENTRIES>, 2>;
 
 int historyBonus(int depth);
 int historyMalus(int depth);
@@ -183,4 +185,5 @@ private:
     MaterialCorrHist m_MaterialCorrHist;
     NonPawnCorrHist m_NonPawnCorrHist;
     ThreatsCorrHist m_ThreatsCorrHist;
+    MinorPieceCorrHist m_MinorPieceCorrHist;
 };


### PR DESCRIPTION
Correction history indexed by minor pieces and kings
```
Elo   | 7.43 +- 4.78 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 7066 W: 1870 L: 1719 D: 3477
Penta | [77, 811, 1642, 890, 113]
```
https://mcthouacbb.pythonanywhere.com/test/235/

Bench: 5765185