### PR TITLE
Correction history indexed by major pieces and king

### DIFF
--- a/Sirius/src/board.h
+++ b/Sirius/src/board.h
@@ -32,6 +32,7 @@ struct BoardState
     ZKey zkey;
     std::array<ZKey, 2> nonPawnKey;
     ZKey minorPieceKey;
+    ZKey majorPieceKey;
     ZKey pawnKey;
     CheckInfo checkInfo;
     Bitboard threats;
@@ -52,6 +53,8 @@ struct BoardState
             nonPawnKey[static_cast<int>(color)].addPiece(pieceType, color, pos);
             if (pieceType == PieceType::BISHOP || pieceType == PieceType::KNIGHT || pieceType == PieceType::KING)
                 minorPieceKey.addPiece(pieceType, color, pos);
+            if (pieceType == PieceType::ROOK || pieceType == PieceType::QUEEN || pieceType == PieceType::KING)
+                majorPieceKey.addPiece(pieceType, color, pos);
         }
     }
 
@@ -72,6 +75,8 @@ struct BoardState
             nonPawnKey[static_cast<int>(color)].addPiece(pieceType, color, pos);
             if (pieceType == PieceType::BISHOP || pieceType == PieceType::KNIGHT || pieceType == PieceType::KING)
                 minorPieceKey.addPiece(pieceType, color, pos);
+            if (pieceType == PieceType::ROOK || pieceType == PieceType::QUEEN || pieceType == PieceType::KING)
+                majorPieceKey.addPiece(pieceType, color, pos);
         }
     }
 
@@ -93,6 +98,8 @@ struct BoardState
             nonPawnKey[static_cast<int>(color)].removePiece(pieceType, color, pos);
             if (pieceType == PieceType::BISHOP || pieceType == PieceType::KNIGHT || pieceType == PieceType::KING)
                 minorPieceKey.removePiece(pieceType, color, pos);
+            if (pieceType == PieceType::ROOK || pieceType == PieceType::QUEEN || pieceType == PieceType::KING)
+                majorPieceKey.removePiece(pieceType, color, pos);
         }
     }
 
@@ -118,6 +125,8 @@ struct BoardState
             nonPawnKey[static_cast<int>(color)].movePiece(pieceType, color, src, dst);
             if (pieceType == PieceType::BISHOP || pieceType == PieceType::KNIGHT || pieceType == PieceType::KING)
                 minorPieceKey.movePiece(pieceType, color, src, dst);
+            if (pieceType == PieceType::ROOK || pieceType == PieceType::QUEEN || pieceType == PieceType::KING)
+                majorPieceKey.movePiece(pieceType, color, src, dst);
         }
     }
 };
@@ -159,6 +168,7 @@ public:
     ZKey pawnKey() const;
     ZKey nonPawnKey(Color color) const;
     ZKey minorPieceKey() const;
+    ZKey majorPieceKey() const;
     uint64_t materialKey() const;
 
     bool isDraw(int searchPly);
@@ -317,6 +327,11 @@ inline ZKey Board::nonPawnKey(Color color) const
 inline ZKey Board::minorPieceKey() const
 {
     return currState().minorPieceKey;
+}
+
+inline ZKey Board::majorPieceKey() const
+{
+    return currState().majorPieceKey;
 }
 
 // yoinked from motor, which I think yoinked from Caissa

--- a/Sirius/src/history.cpp
+++ b/Sirius/src/history.cpp
@@ -54,6 +54,8 @@ void History::clear()
     fillHistTable(m_MaterialCorrHist, 0);
     fillHistTable(m_NonPawnCorrHist, 0);
     fillHistTable(m_ThreatsCorrHist, 0);
+    fillHistTable(m_MinorPieceCorrHist, 0);
+    fillHistTable(m_MajorPieceCorrHist, 0);
 }
 
 int History::getQuietStats(Bitboard threats, ExtMove move, std::span<const CHEntry* const> contHistEntries) const
@@ -81,8 +83,9 @@ int History::correctStaticEval(int staticEval, const Board& board) const
     int nonPawnEntry = (nonPawnWhiteEntry + nonPawnBlackEntry) / 2;
     int threatsEntry = m_ThreatsCorrHist[static_cast<int>(stm)][threatsKey % THREATS_CORR_HIST_ENTRIES];
     int minorPieceEntry = m_MinorPieceCorrHist[static_cast<int>(stm)][board.minorPieceKey().value % MINOR_PIECE_CORR_HIST_ENTRIES];
+    int majorPieceEntry = m_MajorPieceCorrHist[static_cast<int>(stm)][board.majorPieceKey().value % MAJOR_PIECE_CORR_HIST_ENTRIES];
 
-    int corrected = staticEval + (pawnEntry + materialEntry + nonPawnEntry + threatsEntry + minorPieceEntry) / CORR_HIST_SCALE;
+    int corrected = staticEval + (pawnEntry + materialEntry + nonPawnEntry + threatsEntry + minorPieceEntry + majorPieceEntry) / CORR_HIST_SCALE;
     return std::clamp(corrected, -SCORE_MATE_IN_MAX, SCORE_MATE_IN_MAX);
 }
 
@@ -123,6 +126,9 @@ void History::updateCorrHist(int bonus, int depth, const Board& board)
 
     auto& minorPieceEntry = m_MinorPieceCorrHist[static_cast<int>(stm)][board.minorPieceKey().value % MINOR_PIECE_CORR_HIST_ENTRIES];
     minorPieceEntry.update(scaledBonus, weight);
+
+    auto& majorPieceEntry = m_MajorPieceCorrHist[static_cast<int>(stm)][board.majorPieceKey().value % MAJOR_PIECE_CORR_HIST_ENTRIES];
+    majorPieceEntry.update(scaledBonus, weight);
 }
 
 int History::getMainHist(Bitboard threats, ExtMove move) const

--- a/Sirius/src/history.h
+++ b/Sirius/src/history.h
@@ -137,11 +137,13 @@ constexpr int MATERIAL_CORR_HIST_ENTRIES = 32768;
 constexpr int NON_PAWN_CORR_HIST_ENTRIES = 16384;
 constexpr int THREATS_CORR_HIST_ENTRIES = 16384;
 constexpr int MINOR_PIECE_CORR_HIST_ENTRIES = 16384;
+constexpr int MAJOR_PIECE_CORR_HIST_ENTRIES = 16384;
 using PawnCorrHist = std::array<std::array<CorrHistEntry<MAX_CORR_HIST>, PAWN_CORR_HIST_ENTRIES>, 2>;
 using MaterialCorrHist = std::array<std::array<CorrHistEntry<MAX_CORR_HIST>, MATERIAL_CORR_HIST_ENTRIES>, 2>;
 using NonPawnCorrHist = std::array<std::array<std::array<CorrHistEntry<MAX_CORR_HIST>, NON_PAWN_CORR_HIST_ENTRIES>, 2>, 2>;
 using ThreatsCorrHist = std::array<std::array<CorrHistEntry<MAX_CORR_HIST>, THREATS_CORR_HIST_ENTRIES>, 2>;
 using MinorPieceCorrHist = std::array<std::array<CorrHistEntry<MAX_CORR_HIST>, MINOR_PIECE_CORR_HIST_ENTRIES>, 2>;
+using MajorPieceCorrHist = std::array<std::array<CorrHistEntry<MAX_CORR_HIST>, MAJOR_PIECE_CORR_HIST_ENTRIES>, 2>;
 
 int historyBonus(int depth);
 int historyMalus(int depth);
@@ -186,4 +188,5 @@ private:
     NonPawnCorrHist m_NonPawnCorrHist;
     ThreatsCorrHist m_ThreatsCorrHist;
     MinorPieceCorrHist m_MinorPieceCorrHist;
+    MajorPieceCorrHist m_MajorPieceCorrHist;
 };


### PR DESCRIPTION
```
Elo   | 3.79 +- 2.95 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.00 (-2.94, 2.94) [0.00, 5.00]
Games | N: 18260 W: 4776 L: 4577 D: 8907
Penta | [225, 2102, 4310, 2235, 258]
```
https://mcthouacbb.pythonanywhere.com/test/236/

Bench: 6110402