### PR TITLE
Adjust lmr by capture history

### DIFF
--- a/Sirius/src/search.cpp
+++ b/Sirius/src/search.cpp
@@ -476,6 +476,8 @@ int Search::search(SearchThread& thread, int depth, SearchStack* stack, int alph
         int histScore = quiet ? history.getQuietStats(threats, ExtMove::from(board, move), contHistEntries) : history.getNoisyStats(ExtMove::from(board, move));
         if (quiet)
             baseLMR -= histScore / lmrHistDivisor;
+        else
+            baseLMR -= histScore / 6144;
 
         if (!root && quietLosing && bestScore > -SCORE_WIN)
         {

--- a/Sirius/src/search.cpp
+++ b/Sirius/src/search.cpp
@@ -474,10 +474,7 @@ int Search::search(SearchThread& thread, int depth, SearchStack* stack, int alph
 
         int baseLMR = lmrTable[std::min(depth, 63)][std::min(movesPlayed, 63)];
         int histScore = quiet ? history.getQuietStats(threats, ExtMove::from(board, move), contHistEntries) : history.getNoisyStats(ExtMove::from(board, move));
-        if (quiet)
-            baseLMR -= histScore / lmrHistDivisor;
-        else
-            baseLMR -= histScore / 6144;
+        baseLMR -= histScore / (quiet ? lmrQuietHistDivisor : lmrNoisyHistDivisor);
 
         if (!root && quietLosing && bestScore > -SCORE_WIN)
         {

--- a/Sirius/src/search_params.h
+++ b/Sirius/src/search_params.h
@@ -108,7 +108,8 @@ SEARCH_PARAM(lmrFailHighCountMargin, 2, 2, 12, 1);
 
 SEARCH_PARAM_CALLBACK(lmrBase, 65, -50, 200, 10, updateLmrTable);
 SEARCH_PARAM_CALLBACK(lmrDivisor, 224, 180, 320, 10, updateLmrTable);
-SEARCH_PARAM(lmrHistDivisor, 8735, 4096, 16384, 512);
+SEARCH_PARAM(lmrQuietHistDivisor, 8735, 4096, 16384, 512);
+SEARCH_PARAM(lmrNoisyHistDivisor, 6144, 2048, 16384, 512);
 
 SEARCH_PARAM(qsFpMargin, 60, 0, 250, 16);
 


### PR DESCRIPTION
Tested against old commit but there were no lmr related patches since
```
Elo   | 2.70 +- 2.15 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 5.00]
Games | N: 34402 W: 8813 L: 8546 D: 17043
Penta | [398, 4144, 7907, 4297, 455]
```
https://mcthouacbb.pythonanywhere.com/test/233/

Bench: 5988942