### PR TITLE
Fix smp time losses

### DIFF
--- a/Sirius/src/search.cpp
+++ b/Sirius/src/search.cpp
@@ -323,7 +323,7 @@ BenchData Search::benchSearch(int depth, const Board& board)
 
 int Search::search(SearchThread& thread, int depth, SearchStack* stack, int alpha, int beta, bool pvNode, bool cutnode)
 {
-    if (m_TimeMan.stopHard(thread.limits, thread.nodes))
+    if (thread.isMainThread() && m_TimeMan.stopHard(thread.limits, thread.nodes))
     {
         m_ShouldStop = true;
         return alpha;


### PR DESCRIPTION
Was doing hard tm on non main threads, which caused ub and sometimes allowed the search to continue forever.
```
Elo   | 72.25 +- 8.97 (95%)
Conf  | 8.0+0.08s Threads=2 Hash=64MB
Games | N: 2000 W: 710 L: 300 D: 990
Penta | [6, 116, 400, 418, 60]
```
https://mcthouacbb.pythonanywhere.com/test/275/
2 threads v 1 thread

```
Elo   | 135.76 +- 18.80 (95%)
Conf  | 8.0+0.08s Threads=4 Hash=64MB
Games | N: 500 W: 229 L: 43 D: 228
Penta | [0, 11, 75, 131, 33]
```
https://mcthouacbb.pythonanywhere.com/test/277/
4 threads v 1 thread
```
Elo   | 2.04 +- 4.44 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 1.90 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 7504 W: 1944 L: 1900 D: 3660
Penta | [82, 837, 1879, 863, 91]
```
https://mcthouacbb.pythonanywhere.com/test/276/

STC non-reg(not finished but this definitely doesn't lose elo)

0 timelosses across all 3 tests.
Bench: 5845696