### PR TITLE
Tune correction history weights

### DIFF
--- a/Sirius/src/history.cpp
+++ b/Sirius/src/history.cpp
@@ -78,8 +78,8 @@ int History::correctStaticEval(int staticEval, const Board& board) const
     uint64_t threatsKey = murmurHash3((board.threats() & board.pieces(stm)).value());
     int pawnEntry = m_PawnCorrHist[static_cast<int>(stm)][board.pawnKey().value % PAWN_CORR_HIST_ENTRIES];
     int materialEntry = m_MaterialCorrHist[static_cast<int>(stm)][board.materialKey() % MATERIAL_CORR_HIST_ENTRIES];
-    int nonPawnStmEntry = m_NonPawnCorrHist[static_cast<int>(stm)][static_cast<int>(stm)][board.nonPawnKey(Color::WHITE).value % NON_PAWN_CORR_HIST_ENTRIES];
-    int nonPawnNstmEntry = m_NonPawnCorrHist[static_cast<int>(stm)][static_cast<int>(~stm)][board.nonPawnKey(Color::BLACK).value % NON_PAWN_CORR_HIST_ENTRIES];
+    int nonPawnStmEntry = m_NonPawnCorrHist[static_cast<int>(stm)][static_cast<int>(stm)][board.nonPawnKey(stm).value % NON_PAWN_CORR_HIST_ENTRIES];
+    int nonPawnNstmEntry = m_NonPawnCorrHist[static_cast<int>(stm)][static_cast<int>(~stm)][board.nonPawnKey(~stm).value % NON_PAWN_CORR_HIST_ENTRIES];
     int threatsEntry = m_ThreatsCorrHist[static_cast<int>(stm)][threatsKey % THREATS_CORR_HIST_ENTRIES];
     int minorPieceEntry = m_MinorPieceCorrHist[static_cast<int>(stm)][board.minorPieceKey().value % MINOR_PIECE_CORR_HIST_ENTRIES];
     int majorPieceEntry = m_MajorPieceCorrHist[static_cast<int>(stm)][board.majorPieceKey().value % MAJOR_PIECE_CORR_HIST_ENTRIES];

--- a/Sirius/src/history.cpp
+++ b/Sirius/src/history.cpp
@@ -78,14 +78,22 @@ int History::correctStaticEval(int staticEval, const Board& board) const
     uint64_t threatsKey = murmurHash3((board.threats() & board.pieces(stm)).value());
     int pawnEntry = m_PawnCorrHist[static_cast<int>(stm)][board.pawnKey().value % PAWN_CORR_HIST_ENTRIES];
     int materialEntry = m_MaterialCorrHist[static_cast<int>(stm)][board.materialKey() % MATERIAL_CORR_HIST_ENTRIES];
-    int nonPawnWhiteEntry = m_NonPawnCorrHist[static_cast<int>(stm)][static_cast<int>(Color::WHITE)][board.nonPawnKey(Color::WHITE).value % NON_PAWN_CORR_HIST_ENTRIES];
-    int nonPawnBlackEntry = m_NonPawnCorrHist[static_cast<int>(stm)][static_cast<int>(Color::BLACK)][board.nonPawnKey(Color::BLACK).value % NON_PAWN_CORR_HIST_ENTRIES];
-    int nonPawnEntry = (nonPawnWhiteEntry + nonPawnBlackEntry) / 2;
+    int nonPawnStmEntry = m_NonPawnCorrHist[static_cast<int>(stm)][static_cast<int>(stm)][board.nonPawnKey(Color::WHITE).value % NON_PAWN_CORR_HIST_ENTRIES];
+    int nonPawnNstmEntry = m_NonPawnCorrHist[static_cast<int>(stm)][static_cast<int>(~stm)][board.nonPawnKey(Color::BLACK).value % NON_PAWN_CORR_HIST_ENTRIES];
     int threatsEntry = m_ThreatsCorrHist[static_cast<int>(stm)][threatsKey % THREATS_CORR_HIST_ENTRIES];
     int minorPieceEntry = m_MinorPieceCorrHist[static_cast<int>(stm)][board.minorPieceKey().value % MINOR_PIECE_CORR_HIST_ENTRIES];
     int majorPieceEntry = m_MajorPieceCorrHist[static_cast<int>(stm)][board.majorPieceKey().value % MAJOR_PIECE_CORR_HIST_ENTRIES];
 
-    int corrected = staticEval + (pawnEntry + materialEntry + nonPawnEntry + threatsEntry + minorPieceEntry + majorPieceEntry) / CORR_HIST_SCALE;
+    int correction = 0;
+    correction += search::pawnCorrWeight * pawnEntry;
+    correction += search::materialCorrWeight * materialEntry;
+    correction += search::nonPawnStmCorrWeight * nonPawnStmEntry;
+    correction += search::nonPawnNstmCorrWeight * nonPawnNstmEntry;
+    correction += search::threatsCorrWeight * threatsEntry;
+    correction += search::minorCorrWeight * minorPieceEntry;
+    correction += search::majorCorrWeight * majorPieceEntry;
+
+    int corrected = staticEval + correction / (256 * CORR_HIST_SCALE);
     return std::clamp(corrected, -SCORE_MATE_IN_MAX, SCORE_MATE_IN_MAX);
 }
 

--- a/Sirius/src/search_params.h
+++ b/Sirius/src/search_params.h
@@ -57,6 +57,14 @@ SEARCH_PARAM(histMalusQuadratic, 5, 1, 8, 1);
 SEARCH_PARAM(histMalusLinear, 243, 64, 384, 32);
 SEARCH_PARAM(histMalusOffset, 66, 64, 768, 64);
 
+SEARCH_PARAM(pawnCorrWeight, 256, 96, 768, 64);
+SEARCH_PARAM(materialCorrWeight, 256, 96, 768, 64);
+SEARCH_PARAM(nonPawnStmCorrWeight, 256, 96, 768, 64);
+SEARCH_PARAM(nonPawnNstmCorrWeight, 256, 96, 768, 64);
+SEARCH_PARAM(threatsCorrWeight, 256, 96, 768, 64);
+SEARCH_PARAM(minorCorrWeight, 256, 96, 768, 64);
+SEARCH_PARAM(majorCorrWeight, 256, 96, 768, 64);
+
 SEARCH_PARAM(aspInitDelta, 9, 8, 30, 4);
 SEARCH_PARAM(minAspDepth, 5, 3, 7, 1);
 SEARCH_PARAM(aspWideningFactor, 5, 1, 32, 2);

--- a/Sirius/src/search_params.h
+++ b/Sirius/src/search_params.h
@@ -5,8 +5,6 @@
 #include <deque>
 #include <functional>
 
-#define EXTERNAL_TUNE
-
 namespace search
 {
 
@@ -59,13 +57,13 @@ SEARCH_PARAM(histMalusQuadratic, 5, 1, 8, 1);
 SEARCH_PARAM(histMalusLinear, 243, 64, 384, 32);
 SEARCH_PARAM(histMalusOffset, 66, 64, 768, 64);
 
-SEARCH_PARAM(pawnCorrWeight, 256, 96, 768, 64);
-SEARCH_PARAM(materialCorrWeight, 256, 96, 768, 64);
-SEARCH_PARAM(nonPawnStmCorrWeight, 128, 96, 768, 64);
-SEARCH_PARAM(nonPawnNstmCorrWeight, 128, 96, 768, 64);
-SEARCH_PARAM(threatsCorrWeight, 256, 96, 768, 64);
-SEARCH_PARAM(minorCorrWeight, 256, 96, 768, 64);
-SEARCH_PARAM(majorCorrWeight, 256, 96, 768, 64);
+SEARCH_PARAM(pawnCorrWeight, 353, 96, 768, 64);
+SEARCH_PARAM(materialCorrWeight, 327, 96, 768, 64);
+SEARCH_PARAM(nonPawnStmCorrWeight, 277, 96, 768, 64);
+SEARCH_PARAM(nonPawnNstmCorrWeight, 252, 96, 768, 64);
+SEARCH_PARAM(threatsCorrWeight, 273, 96, 768, 64);
+SEARCH_PARAM(minorCorrWeight, 337, 96, 768, 64);
+SEARCH_PARAM(majorCorrWeight, 353, 96, 768, 64);
 
 SEARCH_PARAM(aspInitDelta, 9, 8, 30, 4);
 SEARCH_PARAM(minAspDepth, 5, 3, 7, 1);

--- a/Sirius/src/search_params.h
+++ b/Sirius/src/search_params.h
@@ -5,6 +5,8 @@
 #include <deque>
 #include <functional>
 
+#define EXTERNAL_TUNE
+
 namespace search
 {
 
@@ -57,13 +59,13 @@ SEARCH_PARAM(histMalusQuadratic, 5, 1, 8, 1);
 SEARCH_PARAM(histMalusLinear, 243, 64, 384, 32);
 SEARCH_PARAM(histMalusOffset, 66, 64, 768, 64);
 
-SEARCH_PARAM(pawnCorrWeight, 353, 96, 768, 64);
-SEARCH_PARAM(materialCorrWeight, 327, 96, 768, 64);
-SEARCH_PARAM(nonPawnStmCorrWeight, 277, 96, 768, 64);
-SEARCH_PARAM(nonPawnNstmCorrWeight, 252, 96, 768, 64);
-SEARCH_PARAM(threatsCorrWeight, 273, 96, 768, 64);
-SEARCH_PARAM(minorCorrWeight, 337, 96, 768, 64);
-SEARCH_PARAM(majorCorrWeight, 353, 96, 768, 64);
+SEARCH_PARAM(pawnCorrWeight, 256, 96, 768, 64);
+SEARCH_PARAM(materialCorrWeight, 256, 96, 768, 64);
+SEARCH_PARAM(nonPawnStmCorrWeight, 256, 96, 768, 64);
+SEARCH_PARAM(nonPawnNstmCorrWeight, 256, 96, 768, 64);
+SEARCH_PARAM(threatsCorrWeight, 256, 96, 768, 64);
+SEARCH_PARAM(minorCorrWeight, 256, 96, 768, 64);
+SEARCH_PARAM(majorCorrWeight, 256, 96, 768, 64);
 
 SEARCH_PARAM(aspInitDelta, 9, 8, 30, 4);
 SEARCH_PARAM(minAspDepth, 5, 3, 7, 1);

--- a/Sirius/src/search_params.h
+++ b/Sirius/src/search_params.h
@@ -5,6 +5,8 @@
 #include <deque>
 #include <functional>
 
+#define EXTERNAL_TUNE
+
 namespace search
 {
 

--- a/Sirius/src/search_params.h
+++ b/Sirius/src/search_params.h
@@ -59,13 +59,13 @@ SEARCH_PARAM(histMalusQuadratic, 5, 1, 8, 1);
 SEARCH_PARAM(histMalusLinear, 243, 64, 384, 32);
 SEARCH_PARAM(histMalusOffset, 66, 64, 768, 64);
 
-SEARCH_PARAM(pawnCorrWeight, 256, 96, 768, 64);
-SEARCH_PARAM(materialCorrWeight, 256, 96, 768, 64);
-SEARCH_PARAM(nonPawnStmCorrWeight, 256, 96, 768, 64);
-SEARCH_PARAM(nonPawnNstmCorrWeight, 256, 96, 768, 64);
-SEARCH_PARAM(threatsCorrWeight, 256, 96, 768, 64);
-SEARCH_PARAM(minorCorrWeight, 256, 96, 768, 64);
-SEARCH_PARAM(majorCorrWeight, 256, 96, 768, 64);
+SEARCH_PARAM(pawnCorrWeight, 311, 96, 768, 64);
+SEARCH_PARAM(materialCorrWeight, 329, 96, 768, 64);
+SEARCH_PARAM(nonPawnStmCorrWeight, 292, 96, 768, 64);
+SEARCH_PARAM(nonPawnNstmCorrWeight, 288, 96, 768, 64);
+SEARCH_PARAM(threatsCorrWeight, 248, 96, 768, 64);
+SEARCH_PARAM(minorCorrWeight, 313, 96, 768, 64);
+SEARCH_PARAM(majorCorrWeight, 308, 96, 768, 64);
 
 SEARCH_PARAM(aspInitDelta, 9, 8, 30, 4);
 SEARCH_PARAM(minAspDepth, 5, 3, 7, 1);

--- a/Sirius/src/search_params.h
+++ b/Sirius/src/search_params.h
@@ -59,13 +59,13 @@ SEARCH_PARAM(histMalusQuadratic, 5, 1, 8, 1);
 SEARCH_PARAM(histMalusLinear, 243, 64, 384, 32);
 SEARCH_PARAM(histMalusOffset, 66, 64, 768, 64);
 
-SEARCH_PARAM(pawnCorrWeight, 311, 96, 768, 64);
-SEARCH_PARAM(materialCorrWeight, 329, 96, 768, 64);
-SEARCH_PARAM(nonPawnStmCorrWeight, 292, 96, 768, 64);
-SEARCH_PARAM(nonPawnNstmCorrWeight, 288, 96, 768, 64);
-SEARCH_PARAM(threatsCorrWeight, 248, 96, 768, 64);
-SEARCH_PARAM(minorCorrWeight, 313, 96, 768, 64);
-SEARCH_PARAM(majorCorrWeight, 308, 96, 768, 64);
+SEARCH_PARAM(pawnCorrWeight, 256, 96, 768, 64);
+SEARCH_PARAM(materialCorrWeight, 256, 96, 768, 64);
+SEARCH_PARAM(nonPawnStmCorrWeight, 128, 96, 768, 64);
+SEARCH_PARAM(nonPawnNstmCorrWeight, 128, 96, 768, 64);
+SEARCH_PARAM(threatsCorrWeight, 256, 96, 768, 64);
+SEARCH_PARAM(minorCorrWeight, 256, 96, 768, 64);
+SEARCH_PARAM(majorCorrWeight, 256, 96, 768, 64);
 
 SEARCH_PARAM(aspInitDelta, 9, 8, 30, 4);
 SEARCH_PARAM(minAspDepth, 5, 3, 7, 1);

--- a/Sirius/src/search_params.h
+++ b/Sirius/src/search_params.h
@@ -5,8 +5,6 @@
 #include <deque>
 #include <functional>
 
-#define EXTERNAL_TUNE
-
 namespace search
 {
 
@@ -59,13 +57,13 @@ SEARCH_PARAM(histMalusQuadratic, 5, 1, 8, 1);
 SEARCH_PARAM(histMalusLinear, 243, 64, 384, 32);
 SEARCH_PARAM(histMalusOffset, 66, 64, 768, 64);
 
-SEARCH_PARAM(pawnCorrWeight, 256, 96, 768, 64);
-SEARCH_PARAM(materialCorrWeight, 256, 96, 768, 64);
-SEARCH_PARAM(nonPawnStmCorrWeight, 256, 96, 768, 64);
-SEARCH_PARAM(nonPawnNstmCorrWeight, 256, 96, 768, 64);
-SEARCH_PARAM(threatsCorrWeight, 256, 96, 768, 64);
-SEARCH_PARAM(minorCorrWeight, 256, 96, 768, 64);
-SEARCH_PARAM(majorCorrWeight, 256, 96, 768, 64);
+SEARCH_PARAM(pawnCorrWeight, 295, 96, 768, 64);
+SEARCH_PARAM(materialCorrWeight, 292, 96, 768, 64);
+SEARCH_PARAM(nonPawnStmCorrWeight, 316, 96, 768, 64);
+SEARCH_PARAM(nonPawnNstmCorrWeight, 277, 96, 768, 64);
+SEARCH_PARAM(threatsCorrWeight, 280, 96, 768, 64);
+SEARCH_PARAM(minorCorrWeight, 306, 96, 768, 64);
+SEARCH_PARAM(majorCorrWeight, 322, 96, 768, 64);
 
 SEARCH_PARAM(aspInitDelta, 9, 8, 30, 4);
 SEARCH_PARAM(minAspDepth, 5, 3, 7, 1);


### PR DESCRIPTION
Removed averaging of non-pawn corrhist, make non-pawn corrhist entries stm relative
```
Elo   | 8.57 +- 5.14 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.01 (-2.94, 2.94) [0.00, 5.00]
Games | N: 5960 W: 1584 L: 1437 D: 2939
Penta | [57, 682, 1386, 767, 88]
```
https://mcthouacbb.pythonanywhere.com/test/306/

Bench: 5747180