### PR TITLE
Less reduction when eval is very different from raw static eval

### DIFF
--- a/Sirius/src/search.cpp
+++ b/Sirius/src/search.cpp
@@ -579,6 +579,7 @@ int Search::search(SearchThread& thread, int depth, SearchStack* stack, int alph
             reduction -= ttPV;
             reduction -= givesCheck;
             reduction -= inCheck;
+            reduction -= std::abs(stack->eval - rawStaticEval) > 80;
             reduction += cutnode;
             reduction += stack[1].failHighCount >= static_cast<uint32_t>(lmrFailHighCountMargin);
 


### PR DESCRIPTION
```
Elo   | 6.83 +- 4.55 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 8094 W: 2200 L: 2041 D: 3853
Penta | [111, 924, 1837, 1045, 130]
```
https://mcthouacbb.pythonanywhere.com/test/307/

Bench: 6025327