### PR TITLE
Probcut

### DIFF
--- a/Sirius/src/search.cpp
+++ b/Sirius/src/search.cpp
@@ -435,13 +435,14 @@ int Search::search(SearchThread& thread, int depth, SearchStack* stack, int alph
         int probcutBeta = beta + 200;
         if (depth >= 5 &&
             !isMateScore(beta) &&
-            (!ttHit || ttData.value >= probcutBeta || ttData.depth + 3 < depth))
+            (!ttHit || ttData.score >= probcutBeta || ttData.depth + 3 < depth))
         {
             MoveOrdering ordering(board, ttData.move, thread.history);
-            ScoredMove move = {};
+            ScoredMove scoredMove = {};
             int seeThreshold = probcutBeta - stack->staticEval;
             while ((scoredMove = ordering.selectMove()).score != MoveOrdering::NO_MOVE)
             {
+                auto [move, moveScore] = scoredMove;
                 if (!board.isLegal(move))
                     continue;
                 if (!board.see(move, seeThreshold))
@@ -467,7 +468,7 @@ int Search::search(SearchThread& thread, int depth, SearchStack* stack, int alph
 
                 if (score >= probcutBeta)
                 {
-                    m_TT.store(board.zkey(), depth - 3, rootPly, bestScore, rawStaticEval, move, ttPV, TTEntry::Bound::LOWER_BOUND);
+                    m_TT.store(board.zkey(), depth - 3, rootPly, score, rawStaticEval, move, ttPV, TTEntry::Bound::LOWER_BOUND);
                     return score;
                 }
             }

--- a/Sirius/src/search.cpp
+++ b/Sirius/src/search.cpp
@@ -402,7 +402,8 @@ int Search::search(SearchThread& thread, int depth, SearchStack* stack, int alph
     bool ttPV = pvNode || (ttHit && ttData.pv);
     bool improving = !inCheck && rootPly > 1 && stack->staticEval > stack[-2].staticEval;
     stack[1].killers = {};
-
+    Bitboard threats = board.threats();
+    
     if (!pvNode && !inCheck && !excluded)
     {
         // reverse futility pruning
@@ -448,7 +449,7 @@ int Search::search(SearchThread& thread, int depth, SearchStack* stack, int alph
                 if (!board.see(move, seeThreshold))
                     continue;
 
-                int history = history.getNoisyStats(threats, ExtMove::from(board, move));
+                int histScore = history.getNoisyStats(threats, ExtMove::from(board, move));
                 
                 m_TT.prefetch(board.keyAfter(move));
                 stack->contHistEntry = &history.contHistEntry(ExtMove::from(board, move));
@@ -497,8 +498,6 @@ int Search::search(SearchThread& thread, int depth, SearchStack* stack, int alph
 
     MoveList quietsTried;
     MoveList noisiesTried;
-
-    Bitboard threats = board.threats();
 
     int bestScore = -SCORE_MAX;
     int movesPlayed = 0;

--- a/Sirius/src/search_params.h
+++ b/Sirius/src/search_params.h
@@ -87,6 +87,10 @@ SEARCH_PARAM(nmpDepthReductionScale, 4, 3, 6, 1);
 SEARCH_PARAM(nmpEvalReductionScale, 210, 50, 300, 10);
 SEARCH_PARAM(nmpMaxEvalReduction, 4, 2, 5, 1);
 
+SEARCH_PARAM(probcutMinDepth, 5, 4, 7, 1);
+SEARCH_PARAM(probcutBetaMargin, 200, 100, 300, 15);
+SEARCH_PARAM(probcutReduction, 4, 3, 6, 1);
+
 SEARCH_PARAM(fpBaseMargin, 160, 60, 360, 12);
 SEARCH_PARAM(fpDepthMargin, 124, 10, 180, 12);
 SEARCH_PARAM(fpMaxDepth, 4, 4, 9, 1);


### PR DESCRIPTION
```
Elo   | 2.88 +- 2.32 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 30364 W: 7916 L: 7664 D: 14784
Penta | [369, 3684, 6891, 3802, 436]
```
https://mcthouacbb.pythonanywhere.com/test/346/

Bench: 6076570