### PR TITLE
Increase history bonus/malus if score is far above beta

### DIFF
--- a/Sirius/src/search.cpp
+++ b/Sirius/src/search.cpp
@@ -682,7 +682,7 @@ int Search::search(SearchThread& thread, int depth, SearchStack* stack, int alph
                     }
                 }
 
-                int histDepth = depth + (bestScore > beta + 50);
+                int histDepth = depth + (bestScore > beta + histBetaMargin);
                 int bonus = historyBonus(histDepth);
                 int malus = historyMalus(histDepth);
                 if (quiet)

--- a/Sirius/src/search.cpp
+++ b/Sirius/src/search.cpp
@@ -682,8 +682,9 @@ int Search::search(SearchThread& thread, int depth, SearchStack* stack, int alph
                     }
                 }
 
-                int bonus = historyBonus(depth);
-                int malus = historyMalus(depth);
+                int histDepth = depth + (bestScore > beta + 50);
+                int bonus = historyBonus(histDepth);
+                int malus = historyMalus(histDepth);
                 if (quiet)
                 {
                     history.updateQuietStats(threats, ExtMove::from(board, move), contHistEntries, bonus);

--- a/Sirius/src/search_params.h
+++ b/Sirius/src/search_params.h
@@ -57,6 +57,8 @@ SEARCH_PARAM(histMalusQuadratic, 5, 1, 8, 1);
 SEARCH_PARAM(histMalusLinear, 243, 64, 384, 32);
 SEARCH_PARAM(histMalusOffset, 66, 64, 768, 64);
 
+SEARCH_PARAM(histBetaMargin, 50, 30, 120, 5);
+
 SEARCH_PARAM(pawnCorrWeight, 295, 96, 768, 64);
 SEARCH_PARAM(materialCorrWeight, 292, 96, 768, 64);
 SEARCH_PARAM(nonPawnStmCorrWeight, 316, 96, 768, 64);


### PR DESCRIPTION
```
Elo   | 7.74 +- 4.88 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.00 (-2.94, 2.94) [0.00, 5.00]
Games | N: 6912 W: 1874 L: 1720 D: 3318
Penta | [91, 776, 1579, 908, 102]
```
https://mcthouacbb.pythonanywhere.com/test/355/

Bench: 6605518