### PR TITLE
Tweak IIR

### DIFF
--- a/Sirius/src/search.cpp
+++ b/Sirius/src/search.cpp
@@ -377,7 +377,10 @@ int Search::search(SearchThread& thread, int depth, SearchStack* stack, int alph
             ))
                 return ttData.score;
         }
-        else if (depth >= minIIRDepth)
+
+        if (pvNode && ttData.move == Move() && depth >= 3)
+            depth--;
+        if (cutnode && ttData.move == Move() && depth >= 3)
             depth--;
 
         if (inCheck)


### PR DESCRIPTION
Elo estimate testing indicated it was worthless, so I suspected elo could be gained here
Basically copied from [Clover](https://github.com/lucametehau/CloverEngine/blob/38662de75a54ccddaa7b8ff03f86d6a775627bc0/src/search.h#L405)
```
Elo   | 22.84 +- 8.99 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
Games | N: 1980 W: 570 L: 440 D: 970
Penta | [16, 196, 457, 284, 37]
```
https://mcthouacbb.pythonanywhere.com/test/396/

Bench: 6240861