### PR TITLE
Update continuation history after lmr research

### DIFF
--- a/Sirius/src/history.cpp
+++ b/Sirius/src/history.cpp
@@ -100,6 +100,11 @@ int History::correctStaticEval(int staticEval, const Board& board) const
 void History::updateQuietStats(Bitboard threats, ExtMove move, std::span<CHEntry*> contHistEntries, int bonus)
 {
     updateMainHist(threats, move, bonus);
+    updateContHist(move, contHistEntries, bonus);
+}
+
+void History::updateContHist(ExtMove move, std::span<CHEntry*> contHistEntries, int bonus)
+{
     for (auto entry : contHistEntries)
         if (entry)
             updateContHist(entry, move, bonus);

--- a/Sirius/src/history.h
+++ b/Sirius/src/history.h
@@ -170,6 +170,7 @@ public:
 
     void clear();
     void updateQuietStats(Bitboard threats, ExtMove move, std::span<CHEntry*> contHistEntries, int bonus);
+    void updateContHist(ExtMove move, std::span<CHEntry*> contHistEntries, int bonus);
     void updateNoisyStats(Bitboard threats, ExtMove move, int bonus);
     void updateCorrHist(int bonus, int depth, const Board& board);
 private:


### PR DESCRIPTION
```
Elo   | 3.53 +- 2.80 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 20156 W: 5240 L: 5035 D: 9881
Penta | [237, 2368, 4682, 2535, 256]
```
https://mcthouacbb.pythonanywhere.com/test/430/

Bench: 6563873