### PR TITLE
LMR continuation history updates fix

### DIFF
--- a/Sirius/src/search.cpp
+++ b/Sirius/src/search.cpp
@@ -655,7 +655,7 @@ int Search::search(SearchThread& thread, int depth, SearchStack* stack, int alph
                 newDepth += doDeeper - doShallower;
                 score = -search(thread, newDepth, stack + 1, -alpha - 1, -alpha, false, !cutnode);
 
-                if (quiet && score <= alpha || score >= beta)
+                if (quiet && (score <= alpha || score >= beta))
                 {
                     int bonus = score >= beta ? historyBonus(depth) : -historyMalus(depth);
                     history.updateContHist(extMove, contHistEntries, bonus);


### PR DESCRIPTION
How tf did I miss this
```
Elo   | 1.53 +- 3.35 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.99 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 14056 W: 3667 L: 3605 D: 6784
Penta | [169, 1672, 3295, 1712, 180]
```
https://mcthouacbb.pythonanywhere.com/test/431/

Bench: 6331692