### PR TITLE
Reduce more in nmp if improving

### DIFF
--- a/Sirius/src/search.cpp
+++ b/Sirius/src/search.cpp
@@ -433,7 +433,11 @@ int Search::search(SearchThread& thread, int depth, SearchStack* stack, int alph
             stack->eval >= beta && stack->staticEval >= beta + nmpEvalBaseMargin - nmpEvalDepthMargin * depth &&
             nonPawns.multiple())
         {
-            int r = nmpBaseReduction + depth / nmpDepthReductionScale + std::min((stack->eval - beta) / nmpEvalReductionScale, nmpMaxEvalReduction);
+            int r =
+                improving +
+                nmpBaseReduction +
+                depth / nmpDepthReductionScale +
+                std::min((stack->eval - beta) / nmpEvalReductionScale, nmpMaxEvalReduction);
             board.makeNullMove();
             rootPly++;
             int nullScore = -search(thread, depth - r, stack + 1, -beta, -beta + 1, false, !cutnode);


### PR DESCRIPTION
```
Elo   | 8.72 +- 5.23 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 5658 W: 1501 L: 1359 D: 2798
Penta | [61, 625, 1319, 759, 65]
```
https://mcthouacbb.pythonanywhere.com/test/432/

Bench: 6164126