### PR TITLE
Tweak negative extensions

### DIFF
--- a/Sirius/src/search.cpp
+++ b/Sirius/src/search.cpp
@@ -606,7 +606,7 @@ int Search::search(SearchThread& thread, int depth, SearchStack* stack, int alph
             else if (sBeta >= beta)
                 return sBeta;
             else if (ttData.score >= beta)
-                extension = -1;
+                extension = -2 + pvNode;
         }
 
         stack->multiExts += extension >= 2;


### PR DESCRIPTION
Taken from integral by @aronpetko: https://github.com/aronpetko/integral/blob/a71ac96c2b71ebf2b556280fef8a0cf964d43cf6/src/engine/search/search.cc#L900
```
Elo   | 6.52 +- 4.38 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
Games | N: 8256 W: 2243 L: 2088 D: 3925
Penta | [79, 974, 1908, 1047, 120]
```
https://mcthouacbb.pythonanywhere.com/test/434/

Bench: 6263215