### PR TITLE
Only futility prune quiet moves

### DIFF
--- a/Sirius/src/search.cpp
+++ b/Sirius/src/search.cpp
@@ -544,8 +544,8 @@ int Search::search(SearchThread& thread, int depth, SearchStack* stack, int alph
         {
             // futility pruning(~1 elo)
             int lmrDepth = std::max(depth - baseLMR, 0);
-            if (quiet &&
-                lmrDepth <= fpMaxDepth &&
+            if (lmrDepth <= fpMaxDepth &&
+                quiet &&
                 !inCheck &&
                 alpha < SCORE_WIN &&
                 stack->eval + fpBaseMargin + fpDepthMargin * lmrDepth <= alpha)

--- a/Sirius/src/search.cpp
+++ b/Sirius/src/search.cpp
@@ -544,7 +544,8 @@ int Search::search(SearchThread& thread, int depth, SearchStack* stack, int alph
         {
             // futility pruning(~1 elo)
             int lmrDepth = std::max(depth - baseLMR, 0);
-            if (lmrDepth <= fpMaxDepth &&
+            if (quiet &&
+                lmrDepth <= fpMaxDepth &&
                 !inCheck &&
                 alpha < SCORE_WIN &&
                 stack->eval + fpBaseMargin + fpDepthMargin * lmrDepth <= alpha)


### PR DESCRIPTION
```
Elo   | 10.50 +- 5.90 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
Games | N: 4768 W: 1315 L: 1171 D: 2282
Penta | [60, 525, 1088, 633, 78]
```
https://mcthouacbb.pythonanywhere.com/test/433/

Bench: 6428259 (rebased)