### PR TITLE
Reduce non-pv full depth search if expected reduction is high

### DIFF
--- a/Sirius/src/search.cpp
+++ b/Sirius/src/search.cpp
@@ -634,22 +634,22 @@ int Search::search(SearchThread& thread, int depth, SearchStack* stack, int alph
         int newDepth = depth + extension - 1;
         int score = 0;
 
+        int reduction = baseLMR;
+
+        reduction += !improving;
+        reduction += noisyTTMove;
+        reduction -= ttPV;
+        reduction -= givesCheck;
+        reduction -= inCheck;
+        reduction -= std::abs(stack->eval - rawStaticEval) > lmrCorrplexityMargin;
+        reduction += cutnode;
+        reduction += stack[1].failHighCount >= static_cast<uint32_t>(lmrFailHighCountMargin);
+
         // late move reductions(~111 elo)
         if (movesPlayed >= (pvNode ? lmrMinMovesPv : lmrMinMovesNonPv) &&
             depth >= lmrMinDepth &&
             quietLosing)
         {
-            int reduction = baseLMR;
-
-            reduction += !improving;
-            reduction += noisyTTMove;
-            reduction -= ttPV;
-            reduction -= givesCheck;
-            reduction -= inCheck;
-            reduction -= std::abs(stack->eval - rawStaticEval) > lmrCorrplexityMargin;
-            reduction += cutnode;
-            reduction += stack[1].failHighCount >= static_cast<uint32_t>(lmrFailHighCountMargin);
-
             int reduced = std::min(std::max(newDepth - reduction, 1), newDepth);
             score = -search(thread, reduced, stack + 1, -alpha - 1, -alpha, false, true);
             if (score > alpha && reduced < newDepth)
@@ -667,7 +667,7 @@ int Search::search(SearchThread& thread, int depth, SearchStack* stack, int alph
             }
         }
         else if (!pvNode || movesPlayed > 1)
-            score = -search(thread, newDepth, stack + 1, -alpha - 1, -alpha, false, !cutnode);
+            score = -search(thread, newDepth - (reduction > 3), stack + 1, -alpha - 1, -alpha, false, !cutnode);
 
         if (pvNode && (movesPlayed == 1 || score > alpha))
             score = -search(thread, newDepth, stack + 1, -beta, -alpha, true, false);


### PR DESCRIPTION
Yoinked from stockfish: https://github.com/official-stockfish/Stockfish/blob/fb6be17ad40d321b5fff02395bc156568fce3091/src/search.cpp#L1231
```
Elo   | 11.03 +- 5.99 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 4254 W: 1138 L: 1003 D: 2113
Penta | [35, 472, 1000, 563, 57]
```
https://mcthouacbb.pythonanywhere.com/test/435/

Bench: 6126282 (rebased)