### PR TITLE
Remove IIR

### DIFF
--- a/Sirius/src/search.cpp
+++ b/Sirius/src/search.cpp
@@ -379,11 +379,6 @@ int Search::search(SearchThread& thread, int depth, SearchStack* stack, int alph
             ))
                 return ttData.score;
         }
-        // Internal Iterative Reductions(~23 elo)
-        if (pvNode && ttData.move == Move() && depth >= minIIRPvNodeDepth)
-            depth--;
-        if (cutnode && ttData.move == Move() && depth >= minIIRCutnodeDepth)
-            depth--;
 
         if (inCheck)
         {


### PR DESCRIPTION
Currently completely worthless. Elo result in #206 is wrong, the worker that ran that test has some issues. Will have to reintroduce IIR at some point in the future
```
Elo   | 2.99 +- 3.31 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [-3.00, 1.00]
Games | N: 14618 W: 3825 L: 3699 D: 7094
Penta | [179, 1719, 3418, 1783, 210]
```
https://mcthouacbb.pythonanywhere.com/test/452/

Bench: 8447979