### PR TITLE
Revert two commits

### DIFF
--- a/Sirius/src/search.cpp
+++ b/Sirius/src/search.cpp
@@ -630,22 +630,22 @@ int Search::search(SearchThread& thread, int depth, SearchStack* stack, int alph
         int newDepth = depth + extension - 1;
         int score = 0;
 
-        int reduction = baseLMR;
-
-        reduction += !improving;
-        reduction += noisyTTMove;
-        reduction -= ttPV;
-        reduction -= givesCheck;
-        reduction -= inCheck;
-        reduction -= std::abs(stack->eval - rawStaticEval) > lmrCorrplexityMargin;
-        reduction += cutnode;
-        reduction += stack[1].failHighCount >= static_cast<uint32_t>(lmrFailHighCountMargin);
-
         // late move reductions(~111 elo)
         if (movesPlayed >= (pvNode ? lmrMinMovesPv : lmrMinMovesNonPv) &&
             depth >= lmrMinDepth &&
             quietLosing)
         {
+            int reduction = baseLMR;
+
+            reduction += !improving;
+            reduction += noisyTTMove;
+            reduction -= ttPV;
+            reduction -= givesCheck;
+            reduction -= inCheck;
+            reduction -= std::abs(stack->eval - rawStaticEval) > lmrCorrplexityMargin;
+            reduction += cutnode;
+            reduction += stack[1].failHighCount >= static_cast<uint32_t>(lmrFailHighCountMargin);
+
             int reduced = std::min(std::max(newDepth - reduction, 1), newDepth);
             score = -search(thread, reduced, stack + 1, -alpha - 1, -alpha, false, true);
             if (score > alpha && reduced < newDepth)
@@ -663,7 +663,7 @@ int Search::search(SearchThread& thread, int depth, SearchStack* stack, int alph
             }
         }
         else if (!pvNode || movesPlayed > 1)
-            score = -search(thread, newDepth - (reduction > 3), stack + 1, -alpha - 1, -alpha, false, !cutnode);
+            score = -search(thread, newDepth, stack + 1, -alpha - 1, -alpha, false, !cutnode);
 
         if (pvNode && (movesPlayed == 1 || score > alpha))
             score = -search(thread, newDepth, stack + 1, -beta, -alpha, true, false);

--- a/Sirius/src/search.cpp
+++ b/Sirius/src/search.cpp
@@ -428,11 +428,7 @@ int Search::search(SearchThread& thread, int depth, SearchStack* stack, int alph
             stack->eval >= beta && stack->staticEval >= beta + nmpEvalBaseMargin - nmpEvalDepthMargin * depth &&
             nonPawns.multiple())
         {
-            int r =
-                improving +
-                nmpBaseReduction +
-                depth / nmpDepthReductionScale +
-                std::min((stack->eval - beta) / nmpEvalReductionScale, nmpMaxEvalReduction);
+            int r = nmpBaseReduction + depth / nmpDepthReductionScale + std::min((stack->eval - beta) / nmpEvalReductionScale, nmpMaxEvalReduction);
             board.makeNullMove();
             rootPly++;
             int nullScore = -search(thread, depth - r, stack + 1, -beta, -beta + 1, false, !cutnode);


### PR DESCRIPTION
Reverts #219 and #222. Something was wrong with the worker that ran these tests
```
Elo   | 1.87 +- 2.77 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [-3.00, 1.00]
Games | N: 21556 W: 5733 L: 5617 D: 10206
Penta | [293, 2592, 4905, 2682, 306]
```
https://mcthouacbb.pythonanywhere.com/test/455/

```
Elo   | 1.18 +- 2.33 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.99 (-2.94, 2.94) [-3.00, 1.00]
Games | N: 30306 W: 7966 L: 7863 D: 14477
Penta | [436, 3607, 6949, 3740, 421]
```
https://mcthouacbb.pythonanywhere.com/test/456/

Bench: 9738101