### PR TITLE
Reintroduce internal iterative reductions

### DIFF
--- a/Sirius/src/search.cpp
+++ b/Sirius/src/search.cpp
@@ -483,6 +483,9 @@ int Search::search(SearchThread& thread, int depth, SearchStack* stack, int alph
         }
     }
 
+    if (depth >= 4 && !inCheck && !excluded && !ttHit)
+        depth--;
+
     // continuation history(~40 elo)
     std::array<CHEntry*, 3> contHistEntries = {
         rootPly > 0 ? stack[-1].contHistEntry : nullptr,

--- a/Sirius/src/search.cpp
+++ b/Sirius/src/search.cpp
@@ -483,7 +483,7 @@ int Search::search(SearchThread& thread, int depth, SearchStack* stack, int alph
         }
     }
 
-    if (depth >= 4 && !inCheck && !excluded && !ttHit)
+    if (depth >= minIIRDepth && !inCheck && !excluded && !ttHit)
         depth--;
 
     // continuation history(~40 elo)

--- a/Sirius/src/search_params.h
+++ b/Sirius/src/search_params.h
@@ -71,8 +71,7 @@ SEARCH_PARAM(aspInitDelta, 9, 8, 30, 4);
 SEARCH_PARAM(minAspDepth, 5, 3, 7, 1);
 SEARCH_PARAM(aspWideningFactor, 5, 1, 32, 2);
 
-SEARCH_PARAM(minIIRPvNodeDepth, 3, 2, 9, 1);
-SEARCH_PARAM(minIIRCutnodeDepth, 3, 2, 9, 1);
+SEARCH_PARAM(minIIRDepth, 4, 2, 9, 1);
 
 SEARCH_PARAM(rfpMaxDepth, 8, 4, 10, 1);
 SEARCH_PARAM(rfpImprovingMargin, 32, 30, 80, 8);

--- a/elo_estimates.md
+++ b/elo_estimates.md
@@ -10,7 +10,7 @@ All features tested against commit a049bb98 or functionally equivalent commits e
 ### In "proper" order
 - Aspiration windows: ~108 elo https://mcthouacbb.pythonanywhere.com/test/358/
 - TT Cutoffs: ~101 elo https://mcthouacbb.pythonanywhere.com/test/360/
-- **Internal iterative reductions**: ~23 elo https://mcthouacbb.pythonanywhere.com/test/396/
+- **Internal iterative reductions**: ~8 elo https://mcthouacbb.pythonanywhere.com/test/460/
 - Improving: ~31 elo https://mcthouacbb.pythonanywhere.com/test/381/
 - TT Eval adjustment: ~8 elo https://mcthouacbb.pythonanywhere.com/test/363/
 - Correction history: ~91 elo https://mcthouacbb.pythonanywhere.com/test/318/
@@ -60,10 +60,10 @@ All features tested against commit a049bb98 or functionally equivalent commits e
 - Improving: ~31 elo
 - Quiet history: ~30 elo
 - Late move pruning: ~23 elo
-- **Internal iterative reductions**: ~23 elo
 - Capture history: ~19 elo
 - History pruning: ~14 elo
 - Check extensions: ~13 elo
+- **Internal iterative reductions**: ~8 elo
 - TT Eval adjustment: ~8 elo
 - Killers: ~6 elo
 - **Razoring**: ~6 elo


### PR DESCRIPTION
```
Elo   | 8.34 +- 4.11 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.99 (-2.94, 2.94) [0.00, 3.00]
Games | N: 9454 W: 2586 L: 2359 D: 4509
Penta | [99, 1083, 2174, 1234, 137]
```
https://mcthouacbb.pythonanywhere.com/test/460/

Bench: 7520397