### PR TITLE
Fix 50mr taking precedence over checkmates

### DIFF
--- a/Sirius/src/board.cpp
+++ b/Sirius/src/board.cpp
@@ -1,6 +1,7 @@
 #include "board.h"
 #include "attacks.h"
 #include "eval/eval_state.h"
+#include "movegen.h"
 
 #include <cstring>
 #include <charconv>
@@ -604,6 +605,21 @@ void Board::unmakeNullMove()
     m_GamePly--;
 
     m_SideToMove = ~m_SideToMove;
+}
+
+
+bool Board::is50MoveDraw() const
+{
+    if (halfMoveClock() < 100)
+        return false;
+    if (checkers().empty())
+        return true;
+    
+    MoveList moves;
+    genMoves<MoveGenType::LEGAL>(*this, moves);
+    if (moves.size() == 0)
+        return false;
+    return true;
 }
 
 bool Board::squareAttacked(Color color, Square square, Bitboard blockers) const

--- a/Sirius/src/board.h
+++ b/Sirius/src/board.h
@@ -173,9 +173,9 @@ public:
     ZKey majorPieceKey() const;
     uint64_t materialKey() const;
 
-    bool isDraw(int searchPly);
-    bool is3FoldDraw(int searchPly);
-    bool is50MoveDraw();
+    bool isDraw(int searchPly) const;
+    bool is3FoldDraw(int searchPly) const;
+    bool is50MoveDraw() const;
 
     Piece pieceAt(Square square) const;
     Bitboard pieces(PieceType type) const;
@@ -266,19 +266,14 @@ inline BoardState& Board::currState()
     return m_States.back();
 }
 
-inline bool Board::isDraw(int searchPly)
+inline bool Board::isDraw(int searchPly) const
 {
     return is50MoveDraw() || is3FoldDraw(searchPly);
 }
 
-inline bool Board::is3FoldDraw(int searchPly)
+inline bool Board::is3FoldDraw(int searchPly) const
 {
     return currState().repetitions > 1 || (currState().repetitions == 1 && currState().lastRepetition < searchPly);
-}
-
-inline bool Board::is50MoveDraw()
-{
-    return currState().halfMoveClock >= 100;
 }
 
 inline Color Board::sideToMove() const


### PR DESCRIPTION
If you checkmate when the half move clock is 100, the game is a win, not a draw.
Bench: 7520397