### PR TITLE
Avoid qs see when best score is mated

### DIFF
--- a/Sirius/src/search.cpp
+++ b/Sirius/src/search.cpp
@@ -853,7 +853,7 @@ int Search::qsearch(SearchThread& thread, SearchStack* stack, int alpha, int bet
         auto [move, moveScore] = scoredMove;
         if (!board.isLegal(move))
             continue;
-        if (!board.see(move, 0))
+        if (bestScore > -SCORE_WIN && !board.see(move, 0))
             continue;
         if (!inCheck && futility <= alpha && !board.see(move, 1))
         {


### PR DESCRIPTION
```
Elo   | -0.05 +- 2.34 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 29388 W: 7628 L: 7632 D: 14128
Penta | [385, 3572, 6763, 3610, 364]
```
https://mcthouacbb.pythonanywhere.com/test/498/

Bench: 8139124