### PR TITLE
Introduce opponent worsening and use it to adjust rfp margin

### DIFF
--- a/Sirius/src/search.cpp
+++ b/Sirius/src/search.cpp
@@ -419,7 +419,7 @@ int Search::search(SearchThread& thread, int depth, SearchStack* stack, int alph
     if (!pvNode && !inCheck && !excluded)
     {
         // reverse futility pruning(~86 elo)
-        int rfpMargin = (improving ? rfpImpMargin : rfpNImpMargin) * depth - 20 * oppWorsening + stack[-1].histScore / rfpHistDivisor;
+        int rfpMargin = (improving ? rfpImpMargin : rfpNonImpMargin) * depth - 20 * oppWorsening + stack[-1].histScore / rfpHistDivisor;
         if (depth <= rfpMaxDepth &&
             stack->eval >= std::max(rfpMargin, 20) + beta)
             return stack->eval;

--- a/Sirius/src/search_params.h
+++ b/Sirius/src/search_params.h
@@ -75,7 +75,7 @@ SEARCH_PARAM(minIIRDepth, 4, 2, 9, 1);
 
 SEARCH_PARAM(rfpMaxDepth, 8, 4, 10, 1);
 SEARCH_PARAM(rfpImpMargin, 32, 30, 80, 8);
-SEARCH_PARAM(rfpNImpMargin, 87, 50, 100, 8);
+SEARCH_PARAM(rfpNonImpMargin, 87, 50, 100, 8);
 SEARCH_PARAM(rfpHistDivisor, 408, 256, 512, 16);
 
 SEARCH_PARAM(razoringMaxDepth, 3, 1, 5, 1);

--- a/Sirius/src/search_params.h
+++ b/Sirius/src/search_params.h
@@ -74,8 +74,8 @@ SEARCH_PARAM(aspWideningFactor, 5, 1, 32, 2);
 SEARCH_PARAM(minIIRDepth, 4, 2, 9, 1);
 
 SEARCH_PARAM(rfpMaxDepth, 8, 4, 10, 1);
-SEARCH_PARAM(rfpImprovingMargin, 32, 30, 80, 8);
-SEARCH_PARAM(rfpMargin, 87, 50, 100, 8);
+SEARCH_PARAM(rfpImpMargin, 32, 30, 80, 8);
+SEARCH_PARAM(rfpNImpMargin, 87, 50, 100, 8);
 SEARCH_PARAM(rfpHistDivisor, 408, 256, 512, 16);
 
 SEARCH_PARAM(razoringMaxDepth, 3, 1, 5, 1);


### PR DESCRIPTION
RFP more when the static evaluation is better than what the opponent had last move
Also clamp the RFP margin to a minimum of 20
```
Elo   | 2.05 +- 1.64 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 59770 W: 15635 L: 15282 D: 28853
Penta | [752, 7103, 13881, 7338, 811]
```
https://mcthouacbb.pythonanywhere.com/test/531/

Bench: 7876826