### PR TITLE
Small cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@ Sirius does not come with a gui. To play against it, you should download a chess
 ## Strength
 See [Releases](https://github.com/mcthouacbb/Sirius/releases)
 
-| Version | Release Date | [CCRL Blitz](https://ccrl.chessdom.com/ccrl/404/) | [CCRL 40/15](https://ccrl.chessdom.com/ccrl/4040/) |
+| Version | Release Date | [CCRL Blitz](https://www.computerchess.org.uk/ccrl/404/) | [CCRL 40/15](https://www.computerchess.org.uk/ccrl/4040/) |
 | --- | --- | --- | --- |
-| 5.0 | 2023-10-27 | N/A | 2677 |
-| 6.0 | 2024-02-17 | N/A | 2965 |
-| 7.0 | 2024-07-09 | N/A | 3224 |
-| 8.0 | 2024-10-05 | 3444 | N/A  |
+| 5.0 | 2023-10-27 | N/A | 2678 |
+| 6.0 | 2024-02-17 | N/A | 2964 |
+| 7.0 | 2024-07-09 | N/A | 3222 |
+| 8.0 | 2024-10-05 | 3444 | 3354  |
 
 ## Usage
 Sirius can be used with any UCI Chess GUI or matchrunner including Arena, Cutechess, Cutechess-cli, Fastchess, Banksia, and more.

--- a/Sirius/src/board.cpp
+++ b/Sirius/src/board.cpp
@@ -358,7 +358,7 @@ std::string Board::fenStr() const
     fen += ' ';
     fen += std::to_string(currState().halfMoveClock);
     fen += ' ';
-    fen += std::to_string(m_GamePly / 2 + (m_SideToMove == Color::BLACK));
+    fen += std::to_string(m_GamePly / 2 + 1);
 
     return fen;
 }

--- a/Sirius/src/history.cpp
+++ b/Sirius/src/history.cpp
@@ -58,12 +58,12 @@ void History::clear()
     fillHistTable(m_MajorPieceCorrHist, 0);
 }
 
-int History::getQuietStats(const Board& board, Move move, std::span<const CHEntry* const> contHistEntries) const
+int History::getQuietStats(Move move, Bitboard threats, Piece movingPiece, std::span<const CHEntry* const> contHistEntries) const
 {
-    int score = getMainHist(board, move);
+    int score = getMainHist(move, threats, getPieceColor(movingPiece));
     for (auto entry : contHistEntries)
         if (entry)
-            score += getContHist(board, move, entry);
+            score += getContHist(move, movingPiece, entry);
     return score;
 }
 
@@ -144,16 +144,16 @@ void History::updateCorrHist(const Board& board, int bonus, int depth)
     majorPieceEntry.update(scaledBonus, weight);
 }
 
-int History::getMainHist(const Board& board, Move move) const
+int History::getMainHist(Move move, Bitboard threats, Color color) const
 {
-    bool srcThreat = board.threats().has(move.fromSq());
-    bool dstThreat = board.threats().has(move.toSq());
-    return m_MainHist[static_cast<int>(board.sideToMove())][move.fromTo()][srcThreat][dstThreat];
+    bool srcThreat = threats.has(move.fromSq());
+    bool dstThreat = threats.has(move.toSq());
+    return m_MainHist[static_cast<int>(color)][move.fromTo()][srcThreat][dstThreat];
 }
 
-int History::getContHist(const Board& board, Move move, const CHEntry* entry) const
+int History::getContHist(Move move, Piece movingPiece, const CHEntry* entry) const
 {
-    return (*entry)[packPieceIndices(movingPiece(board, move))][move.toSq().value()];
+    return (*entry)[packPieceIndices(movingPiece)][move.toSq().value()];
 }
 
 int History::getCaptHist(const Board& board, Move move) const

--- a/Sirius/src/history.h
+++ b/Sirius/src/history.h
@@ -139,7 +139,7 @@ public:
         return m_ContHist[packPieceIndices(movingPiece(board, move))][move.toSq().value()];
     }
 
-    int getQuietStats(const Board& board, Move move, std::span<const CHEntry* const> contHistEntries) const;
+    int getQuietStats(Move move, Bitboard threats, Piece movingPiece, std::span<const CHEntry* const> contHistEntries) const;
     int getNoisyStats(const Board& board, Move move) const;
     int correctStaticEval(const Board& board, int staticEval) const;
 
@@ -149,8 +149,8 @@ public:
     void updateNoisyStats(const Board& board, Move move, int bonus);
     void updateCorrHist(const Board& board, int bonus, int depth);
 private:
-    int getMainHist(const Board& board, Move move) const;
-    int getContHist(const Board& board, Move move, const CHEntry* entry) const;
+    int getMainHist(Move move, Bitboard threats, Color color) const;
+    int getContHist(Move move, Piece movingPiece, const CHEntry* entry) const;
     int getCaptHist(const Board& board, Move move) const;
 
     void updateMainHist(const Board& board, Move move, int bonus);

--- a/Sirius/src/history.h
+++ b/Sirius/src/history.h
@@ -5,57 +5,32 @@
 #include <span>
 #include <algorithm>
 
-struct ExtMove : public Move
+// all these functions assume that move is a pseudolegal move on the board
+inline Piece movingPiece(const Board& board, Move move)
 {
-public:
-    static ExtMove from(const Board& board, Move move);
+    return board.pieceAt(move.fromSq());
+}
 
-    Piece movingPiece() const;
-    Piece capturedPiece() const;
-    Piece promotionPiece() const;
-private:
-    static Piece promotionPiece(Color sideToMove, Promotion promotion);
-
-    ExtMove(Move move, Piece moving, Piece captured, Piece promotion);
-
-    Piece m_Moving, m_Captured, m_Promotion;
-};
-
-inline ExtMove ExtMove::from(const Board& board, Move move)
+inline Piece capturedPiece(const Board& board, Move move)
 {
-    Piece moving = board.pieceAt(move.fromSq());
-    Piece captured =
-        move.type() == MoveType::ENPASSANT ?
+    return move.type() == MoveType::ENPASSANT ?
         makePiece(PieceType::PAWN, ~board.sideToMove()) :
         board.pieceAt(move.toSq());
-    Piece promotion = move.type() == MoveType::PROMOTION ? promotionPiece(board.sideToMove(), move.promotion()) : Piece::NONE;
-    return ExtMove(move, moving, captured, promotion);
 }
 
-inline Piece ExtMove::movingPiece() const
+// pieces are currently stored as type + 8 * color internally
+// however, this wastes indices between
+// white king = 5
+// and black pawn = 8
+// this function packs all the piece indices tightly into indices 0-11
+inline int packPieceIndices(Piece piece)
 {
-    return m_Moving;
-}
-
-inline Piece ExtMove::capturedPiece() const
-{
-    return m_Captured;
-}
-
-inline Piece ExtMove::promotionPiece() const
-{
-    return m_Promotion;
-}
-
-inline ExtMove::ExtMove(Move move, Piece moving, Piece captured, Piece promotion)
-    : Move(move.fromSq(), move.toSq(), move.type(), move.promotion()), m_Moving(moving), m_Captured(captured), m_Promotion(promotion)
-{
-
-}
-
-inline Piece ExtMove::promotionPiece(Color sideToMove, Promotion promotion)
-{
-    return makePiece(static_cast<PieceType>((static_cast<int>(promotion) >> 14) + static_cast<int>(PieceType::KNIGHT)), sideToMove);
+    // does not work with NONE pieces
+    assert(piece != Piece::NONE);
+    PieceType type = getPieceType(piece);
+    if (getPieceColor(piece) == Color::WHITE)
+        return static_cast<int>(type);
+    return static_cast<int>(type) + 6;
 }
 
 template<int MAX_VAL>
@@ -127,10 +102,10 @@ static constexpr int HISTORY_MAX = 16384;
 // main history(~29 elo)
 using MainHist = MultiArray<HistoryEntry<HISTORY_MAX>, 2, 4096, 2, 2>;
 // continuation history(~40 elo)
-using CHEntry = MultiArray<HistoryEntry<HISTORY_MAX>, 16, 64>;
-using ContHist = MultiArray<CHEntry, 16, 64>;
+using CHEntry = MultiArray<HistoryEntry<HISTORY_MAX>, 12, 64>;
+using ContHist = MultiArray<CHEntry, 12, 64>;
 // capture history(~19 elo)
-using CaptHist = MultiArray<HistoryEntry<HISTORY_MAX>, 7, 16, 64, 2, 2>;
+using CaptHist = MultiArray<HistoryEntry<HISTORY_MAX>, 7, 12, 64, 2, 2>;
 
 // correction history(~91 elo)
 constexpr int PAWN_CORR_HIST_ENTRIES = 16384;
@@ -154,33 +129,33 @@ class History
 public:
     History() = default;
 
-    CHEntry& contHistEntry(ExtMove move)
+    CHEntry& contHistEntry(const Board& board, Move move)
     {
-        return m_ContHist[static_cast<int>(move.movingPiece())][move.toSq().value()];
+        return m_ContHist[packPieceIndices(movingPiece(board, move))][move.toSq().value()];
     }
 
-    const CHEntry& contHistEntry(ExtMove move) const
+    const CHEntry& contHistEntry(const Board& board, Move move) const
     {
-        return m_ContHist[static_cast<int>(move.movingPiece())][move.toSq().value()];
+        return m_ContHist[packPieceIndices(movingPiece(board, move))][move.toSq().value()];
     }
 
-    int getQuietStats(Bitboard threats, ExtMove move, std::span<const CHEntry* const> contHistEntries) const;
-    int getNoisyStats(Bitboard threats, ExtMove move) const;
-    int correctStaticEval(int staticEval, const Board& board) const;
+    int getQuietStats(const Board& board, Move move, std::span<const CHEntry* const> contHistEntries) const;
+    int getNoisyStats(const Board& board, Move move) const;
+    int correctStaticEval(const Board& board, int staticEval) const;
 
     void clear();
-    void updateQuietStats(Bitboard threats, ExtMove move, std::span<CHEntry*> contHistEntries, int bonus);
-    void updateContHist(ExtMove move, std::span<CHEntry*> contHistEntries, int bonus);
-    void updateNoisyStats(Bitboard threats, ExtMove move, int bonus);
-    void updateCorrHist(int bonus, int depth, const Board& board);
+    void updateQuietStats(const Board& board, Move move, std::span<CHEntry*> contHistEntries, int bonus);
+    void updateContHist(Move move, Piece movingPiece, std::span<CHEntry*> contHistEntries, int bonus);
+    void updateNoisyStats(const Board& board, Move move, int bonus);
+    void updateCorrHist(const Board& board, int bonus, int depth);
 private:
-    int getMainHist(Bitboard threats, ExtMove move) const;
-    int getContHist(const CHEntry* entry, ExtMove move) const;
-    int getCaptHist(Bitboard threats, ExtMove move) const;
+    int getMainHist(const Board& board, Move move) const;
+    int getContHist(const Board& board, Move move, const CHEntry* entry) const;
+    int getCaptHist(const Board& board, Move move) const;
 
-    void updateMainHist(Bitboard threats, ExtMove move, int bonus);
-    void updateContHist(CHEntry* entry, ExtMove move, int bonus);
-    void updateCaptHist(Bitboard threats, ExtMove move, int bonus);
+    void updateMainHist(const Board& board, Move move, int bonus);
+    void updateContHist(Move move, Piece movingPiece, CHEntry* entry, int bonus);
+    void updateCaptHist(const Board& board, Move move, int bonus);
 
     MainHist m_MainHist;
     ContHist m_ContHist;

--- a/Sirius/src/move_ordering.cpp
+++ b/Sirius/src/move_ordering.cpp
@@ -41,12 +41,12 @@ int MoveOrdering::scoreNoisy(Move move) const
 
     if (isCapture)
     {
-        int hist = m_History.getNoisyStats(m_Board.threats(), ExtMove::from(m_Board, move));
+        int hist = m_History.getNoisyStats(m_Board, move);
         return hist + CAPTURE_SCORE * m_Board.see(move, -hist / 32) + mvvLva(m_Board, move);
     }
     else
     {
-        return m_History.getNoisyStats(m_Board.threats(), ExtMove::from(m_Board, move)) + PROMOTION_SCORE + promotionBonus(move);
+        return m_History.getNoisyStats(m_Board, move) + PROMOTION_SCORE + promotionBonus(move);
     }
 }
 
@@ -55,14 +55,14 @@ int MoveOrdering::scoreQuiet(Move move) const
     if (move == m_Killers[0] || move == m_Killers[1])
         return KILLER_SCORE + (move == m_Killers[0]);
     else
-        return m_History.getQuietStats(m_Board.threats(), ExtMove::from(m_Board, move), m_ContHistEntries);
+        return m_History.getQuietStats(m_Board, move, m_ContHistEntries);
 }
 
 int MoveOrdering::scoreMoveQSearch(Move move) const
 {
     bool isCapture = moveIsCapture(m_Board, move);
     bool isPromotion = move.type() == MoveType::PROMOTION;
-    int score = m_History.getNoisyStats(m_Board.threats(), ExtMove::from(m_Board, move));
+    int score = m_History.getNoisyStats(m_Board, move);
     if (isCapture)
         score += mvvLva(m_Board, move);
     if (isPromotion)
@@ -91,7 +91,7 @@ ScoredMove MoveOrdering::selectMove()
         case TT_MOVE:
             ++m_Stage;
             if (m_TTMove != Move() && m_Board.isPseudoLegal(m_TTMove))
-                return ScoredMove(m_TTMove, 10000000);
+                return ScoredMove{m_TTMove, 10000000};
 
             // fallthrough
         case GEN_NOISY:
@@ -133,13 +133,13 @@ ScoredMove MoveOrdering::selectMove()
                 if (scoredMove.move != m_TTMove)
                     return scoredMove;
             }
-            return {Move(), NO_MOVE};
+            return ScoredMove{Move(), NO_MOVE};
 
 
         case QS_TT_MOVE:
             ++m_Stage;
             if (m_TTMove != Move() && m_Board.isPseudoLegal(m_TTMove) && !moveIsQuiet(m_Board, m_TTMove))
-                return ScoredMove(m_TTMove, 10000000);
+                return ScoredMove{m_TTMove, 10000000};
 
             // fallthrough
         case QS_GEN_NOISIES:
@@ -156,7 +156,7 @@ ScoredMove MoveOrdering::selectMove()
                 if (scoredMove.move != m_TTMove)
                     return scoredMove;
             }
-            return {Move(), NO_MOVE};
+            return ScoredMove{Move(), NO_MOVE};
     }
     if (m_Curr >= m_Moves.size())
         return {Move(), NO_MOVE};

--- a/Sirius/src/move_ordering.cpp
+++ b/Sirius/src/move_ordering.cpp
@@ -55,7 +55,7 @@ int MoveOrdering::scoreQuiet(Move move) const
     if (move == m_Killers[0] || move == m_Killers[1])
         return KILLER_SCORE + (move == m_Killers[0]);
     else
-        return m_History.getQuietStats(m_Board, move, m_ContHistEntries);
+        return m_History.getQuietStats(move, m_Board.threats(), movingPiece(m_Board, move), m_ContHistEntries);
 }
 
 int MoveOrdering::scoreMoveQSearch(Move move) const

--- a/Sirius/src/search.cpp
+++ b/Sirius/src/search.cpp
@@ -393,7 +393,7 @@ int Search::search(SearchThread& thread, int depth, SearchStack* stack, int alph
         {
             rawStaticEval = ttHit ? ttData.staticEval : eval::evaluate(board, &thread);
             // Correction history(~91 elo)
-            stack->staticEval = history.correctStaticEval(rawStaticEval, board);
+            stack->staticEval = history.correctStaticEval(board, rawStaticEval);
             stack->eval = stack->staticEval;
             // use tt score as a better eval(~8 elo)
             if (ttHit && (
@@ -413,7 +413,6 @@ int Search::search(SearchThread& thread, int depth, SearchStack* stack, int alph
         stack[-1].staticEval != SCORE_NONE && stack->staticEval > -stack[-1].staticEval + 1;
 
     stack[1].killers = {};
-    Bitboard threats = board.threats();
 
     // whole node pruning(~228 elo)
     if (!pvNode && !inCheck && !excluded)
@@ -466,10 +465,10 @@ int Search::search(SearchThread& thread, int depth, SearchStack* stack, int alph
                 if (!board.see(move, seeThreshold))
                     continue;
 
-                int histScore = history.getNoisyStats(threats, ExtMove::from(board, move));
+                int histScore = history.getNoisyStats(board, move);
 
                 m_TT.prefetch(board.keyAfter(move));
-                stack->contHistEntry = &history.contHistEntry(ExtMove::from(board, move));
+                stack->contHistEntry = &history.contHistEntry(board, move);
                 stack->histScore = histScore;
                 rootPly++;
                 board.makeMove(move, thread.evalState);
@@ -543,8 +542,7 @@ int Search::search(SearchThread& thread, int depth, SearchStack* stack, int alph
         bool quietLosing = moveScore < MoveOrdering::KILLER_SCORE;
 
         int baseLMR = lmrTable[std::min(depth, 63)][std::min(movesPlayed, 63)];
-        ExtMove extMove = ExtMove::from(board, move);
-        int histScore = quiet ? history.getQuietStats(threats, extMove, contHistEntries) : history.getNoisyStats(threats, extMove);
+        int histScore = quiet ? history.getQuietStats(board, move, contHistEntries) : history.getNoisyStats(board, move);
         baseLMR -= histScore / (quiet ? lmrQuietHistDivisor : lmrNoisyHistDivisor);
 
         // move loop pruning(~184 elo)
@@ -621,7 +619,8 @@ int Search::search(SearchThread& thread, int depth, SearchStack* stack, int alph
         stack->multiExts += extension >= 2;
 
         m_TT.prefetch(board.keyAfter(move));
-        stack->contHistEntry = &history.contHistEntry(extMove);
+        Piece movedPiece = movingPiece(board, move);
+        stack->contHistEntry = &history.contHistEntry(board, move);
         stack->histScore = histScore;
 
         uint64_t nodesBefore = thread.nodes;
@@ -671,7 +670,7 @@ int Search::search(SearchThread& thread, int depth, SearchStack* stack, int alph
                 if (quiet && (score <= alpha || score >= beta))
                 {
                     int bonus = score >= beta ? historyBonus(depth) : -historyMalus(depth);
-                    history.updateContHist(extMove, contHistEntries, bonus);
+                    history.updateContHist(move, movedPiece, contHistEntries, bonus);
                 }
             }
         }
@@ -729,22 +728,22 @@ int Search::search(SearchThread& thread, int depth, SearchStack* stack, int alph
                 int malus = historyMalus(histDepth);
                 if (quiet)
                 {
-                    history.updateQuietStats(threats, ExtMove::from(board, move), contHistEntries, bonus);
+                    history.updateQuietStats(board, move, contHistEntries, bonus);
                     for (Move quietMove : quietsTried)
                     {
                         if (quietMove != move)
-                            history.updateQuietStats(threats, ExtMove::from(board, quietMove), contHistEntries, -malus);
+                            history.updateQuietStats(board, quietMove, contHistEntries, -malus);
                     }
                 }
                 else
                 {
-                    history.updateNoisyStats(threats, ExtMove::from(board, move), bonus);
+                    history.updateNoisyStats(board, move, bonus);
                 }
 
                 for (Move noisyMove : noisiesTried)
                 {
                     if (noisyMove != move)
-                        history.updateNoisyStats(threats, ExtMove::from(board, noisyMove), -malus);
+                        history.updateNoisyStats(board, noisyMove, -malus);
                 }
                 bound = TTEntry::Bound::LOWER_BOUND;
                 break;
@@ -764,7 +763,7 @@ int Search::search(SearchThread& thread, int depth, SearchStack* stack, int alph
         if (!inCheck && (stack->bestMove == Move() || moveIsQuiet(board, stack->bestMove)) &&
             !(bound == TTEntry::Bound::LOWER_BOUND && stack->staticEval >= bestScore) &&
             !(bound == TTEntry::Bound::UPPER_BOUND && stack->staticEval <= bestScore))
-            history.updateCorrHist(bestScore - stack->staticEval, depth, board);
+            history.updateCorrHist(board, bestScore - stack->staticEval, depth);
 
         m_TT.store(board.zkey(), depth, rootPly, bestScore, rawStaticEval, stack->bestMove, ttPV, bound);
     }
@@ -808,7 +807,7 @@ int Search::qsearch(SearchThread& thread, SearchStack* stack, int alpha, int bet
     else
     {
         rawStaticEval = ttHit ? ttData.staticEval : eval::evaluate(board, &thread);
-        stack->staticEval = thread.history.correctStaticEval(rawStaticEval, board);
+        stack->staticEval = thread.history.correctStaticEval(board, rawStaticEval);
 
         // use tt score as a better eval(~8 elo)
         stack->eval = stack->staticEval;
@@ -866,7 +865,7 @@ int Search::qsearch(SearchThread& thread, SearchStack* stack, int alpha, int bet
             continue;
         }
         movesPlayed++;
-        stack->contHistEntry = &history.contHistEntry(ExtMove::from(board, move));
+        stack->contHistEntry = &history.contHistEntry(board, move);
         board.makeMove(move, thread.evalState);
         thread.nodes.fetch_add(1, std::memory_order_relaxed);
         rootPly++;

--- a/Sirius/src/search.cpp
+++ b/Sirius/src/search.cpp
@@ -808,11 +808,11 @@ int Search::qsearch(SearchThread& thread, SearchStack* stack, int alpha, int bet
     else
     {
         rawStaticEval = ttHit ? ttData.staticEval : eval::evaluate(board, &thread);
-        stack->staticEval = inCheck ? SCORE_NONE : thread.history.correctStaticEval(rawStaticEval, board);
+        stack->staticEval = thread.history.correctStaticEval(rawStaticEval, board);
 
         // use tt score as a better eval(~8 elo)
         stack->eval = stack->staticEval;
-        if (!inCheck && ttHit && (
+        if (ttHit && (
             ttData.bound == TTEntry::Bound::EXACT ||
             (ttData.bound == TTEntry::Bound::LOWER_BOUND && ttData.score >= stack->eval) ||
             (ttData.bound == TTEntry::Bound::UPPER_BOUND && ttData.score <= stack->eval)

--- a/Sirius/src/search.cpp
+++ b/Sirius/src/search.cpp
@@ -479,6 +479,9 @@ int Search::search(SearchThread& thread, int depth, SearchStack* stack, int alph
                 if (score >= probcutBeta && probcutDepth >= 0)
                     score = -search(thread, probcutDepth, stack + 1, -probcutBeta, -probcutBeta + 1, false, !cutnode);
 
+                if (m_ShouldStop)
+                    return alpha;
+
                 rootPly--;
                 board.unmakeMove(thread.evalState);
                 stack->contHistEntry = nullptr;


### PR DESCRIPTION
Passed non-regression STC
```
Elo   | 1.98 +- 3.54 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.96 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 11916 W: 3103 L: 3035 D: 5778
Penta | [127, 1347, 2969, 1361, 154]
```
https://mcthouacbb.pythonanywhere.com/test/538/

A few small cleanups to the codebase. Biggest change is the removal of the ExtMove struct, which was just making the code unnecessarily complicated.

No functional change
Bench: 7876826