### PR TITLE
Exclude all blocked pawns from mobility area 

### DIFF
--- a/Sirius/src/eval/eval.cpp
+++ b/Sirius/src/eval/eval.cpp
@@ -259,7 +259,7 @@ void initEvalData(const Board& board, EvalData& evalData, const PawnStructure& p
     constexpr Color them = ~us;
     Bitboard ourPawns = board.pieces(us, PAWN);
     Bitboard theirPawns = board.pieces(them, PAWN);
-    Bitboard blockedPawns = ourPawns & attacks::pawnPushes<them>(theirPawns);
+    Bitboard blockedPawns = ourPawns & attacks::pawnPushes<them>(board.allPieces());
     Square ourKing = board.kingSq(us);
 
     evalData.mobilityArea[us] = ~pawnStructure.pawnAttacks[them] & ~Bitboard::fromSquare(ourKing) & ~blockedPawns;


### PR DESCRIPTION
```
Elo   | 1.80 +- 1.45 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 3.00]
Games | N: 77028 W: 20008 L: 19610 D: 37410
Penta | [950, 9278, 17755, 9486, 1045]
```
https://mcthouacbb.pythonanywhere.com/test/532/

I think I forgot to retune

Bench: 7482707