### PR TITLE
Remove material corrhist

### DIFF
--- a/Sirius/src/history.cpp
+++ b/Sirius/src/history.cpp
@@ -51,7 +51,6 @@ void History::clear()
     fillHistTable(m_ContHist, 0);
     fillHistTable(m_CaptHist, 0);
     fillHistTable(m_PawnCorrHist, 0);
-    fillHistTable(m_MaterialCorrHist, 0);
     fillHistTable(m_NonPawnCorrHist, 0);
     fillHistTable(m_ThreatsCorrHist, 0);
     fillHistTable(m_MinorPieceCorrHist, 0);
@@ -77,7 +76,6 @@ int History::correctStaticEval(const Board& board, int staticEval) const
     Color stm = board.sideToMove();
     uint64_t threatsKey = murmurHash3((board.threats() & board.pieces(stm)).value());
     int pawnEntry = m_PawnCorrHist[static_cast<int>(stm)][board.pawnKey().value % PAWN_CORR_HIST_ENTRIES];
-    int materialEntry = m_MaterialCorrHist[static_cast<int>(stm)][board.materialKey() % MATERIAL_CORR_HIST_ENTRIES];
     int nonPawnStmEntry = m_NonPawnCorrHist[static_cast<int>(stm)][static_cast<int>(stm)][board.nonPawnKey(stm).value % NON_PAWN_CORR_HIST_ENTRIES];
     int nonPawnNstmEntry = m_NonPawnCorrHist[static_cast<int>(stm)][static_cast<int>(~stm)][board.nonPawnKey(~stm).value % NON_PAWN_CORR_HIST_ENTRIES];
     int threatsEntry = m_ThreatsCorrHist[static_cast<int>(stm)][threatsKey % THREATS_CORR_HIST_ENTRIES];
@@ -86,7 +84,6 @@ int History::correctStaticEval(const Board& board, int staticEval) const
 
     int correction = 0;
     correction += search::pawnCorrWeight * pawnEntry;
-    correction += search::materialCorrWeight * materialEntry;
     correction += search::nonPawnStmCorrWeight * nonPawnStmEntry;
     correction += search::nonPawnNstmCorrWeight * nonPawnNstmEntry;
     correction += search::threatsCorrWeight * threatsEntry;
@@ -124,9 +121,6 @@ void History::updateCorrHist(const Board& board, int bonus, int depth)
 
     auto& pawnEntry = m_PawnCorrHist[static_cast<int>(stm)][board.pawnKey().value % PAWN_CORR_HIST_ENTRIES];
     pawnEntry.update(scaledBonus, weight);
-
-    auto& materialEntry = m_MaterialCorrHist[static_cast<int>(stm)][board.materialKey() % MATERIAL_CORR_HIST_ENTRIES];
-    materialEntry.update(scaledBonus, weight);
 
     auto& nonPawnWhiteEntry = m_NonPawnCorrHist[static_cast<int>(stm)][static_cast<int>(Color::WHITE)][board.nonPawnKey(Color::WHITE).value % NON_PAWN_CORR_HIST_ENTRIES];
     nonPawnWhiteEntry.update(scaledBonus, weight);

--- a/Sirius/src/history.h
+++ b/Sirius/src/history.h
@@ -109,13 +109,11 @@ using CaptHist = MultiArray<HistoryEntry<HISTORY_MAX>, 7, 12, 64, 2, 2>;
 
 // correction history(~91 elo)
 constexpr int PAWN_CORR_HIST_ENTRIES = 16384;
-constexpr int MATERIAL_CORR_HIST_ENTRIES = 32768;
 constexpr int NON_PAWN_CORR_HIST_ENTRIES = 16384;
 constexpr int THREATS_CORR_HIST_ENTRIES = 16384;
 constexpr int MINOR_PIECE_CORR_HIST_ENTRIES = 16384;
 constexpr int MAJOR_PIECE_CORR_HIST_ENTRIES = 16384;
 using PawnCorrHist = MultiArray<CorrHistEntry, 2, PAWN_CORR_HIST_ENTRIES>;
-using MaterialCorrHist = MultiArray<CorrHistEntry, 2, MATERIAL_CORR_HIST_ENTRIES>;
 using NonPawnCorrHist = MultiArray<CorrHistEntry, 2, 2, NON_PAWN_CORR_HIST_ENTRIES>;
 using ThreatsCorrHist = MultiArray<CorrHistEntry, 2, THREATS_CORR_HIST_ENTRIES>;
 using MinorPieceCorrHist = MultiArray<CorrHistEntry, 2, MINOR_PIECE_CORR_HIST_ENTRIES>;
@@ -161,7 +159,6 @@ private:
     ContHist m_ContHist;
     CaptHist m_CaptHist;
     PawnCorrHist m_PawnCorrHist;
-    MaterialCorrHist m_MaterialCorrHist;
     NonPawnCorrHist m_NonPawnCorrHist;
     ThreatsCorrHist m_ThreatsCorrHist;
     MinorPieceCorrHist m_MinorPieceCorrHist;

--- a/Sirius/src/search_params.h
+++ b/Sirius/src/search_params.h
@@ -60,7 +60,6 @@ SEARCH_PARAM(histMalusOffset, 66, 64, 768, 64);
 SEARCH_PARAM(histBetaMargin, 50, 30, 120, 5);
 
 SEARCH_PARAM(pawnCorrWeight, 295, 96, 768, 64);
-SEARCH_PARAM(materialCorrWeight, 292, 96, 768, 64);
 SEARCH_PARAM(nonPawnStmCorrWeight, 316, 96, 768, 64);
 SEARCH_PARAM(nonPawnNstmCorrWeight, 277, 96, 768, 64);
 SEARCH_PARAM(threatsCorrWeight, 280, 96, 768, 64);


### PR DESCRIPTION
```
Elo   | 0.84 +- 2.97 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.96 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 18182 W: 4609 L: 4565 D: 9008
Penta | [229, 2210, 4160, 2272, 220]
```
https://mcthouacbb.pythonanywhere.com/test/549/

Bench: 7646340