### PR TITLE
Introduce Continuation Correction History

### DIFF
--- a/Sirius/src/history.h
+++ b/Sirius/src/history.h
@@ -118,6 +118,8 @@ using NonPawnCorrHist = MultiArray<CorrHistEntry, 2, 2, NON_PAWN_CORR_HIST_ENTRI
 using ThreatsCorrHist = MultiArray<CorrHistEntry, 2, THREATS_CORR_HIST_ENTRIES>;
 using MinorPieceCorrHist = MultiArray<CorrHistEntry, 2, MINOR_PIECE_CORR_HIST_ENTRIES>;
 using MajorPieceCorrHist = MultiArray<CorrHistEntry, 2, MAJOR_PIECE_CORR_HIST_ENTRIES>;
+using ContCorrEntry = MultiArray<CorrHistEntry, 12, 64>;
+using ContCorrHist = MultiArray<ContCorrEntry, 12, 64>;
 
 int historyBonus(int depth);
 int historyMalus(int depth);
@@ -137,15 +139,29 @@ public:
         return m_ContHist[packPieceIndices(movingPiece(board, move))][move.toSq().value()];
     }
 
+    ContCorrEntry& contCorrEntry(const Board& board, Move move)
+    {
+        if (move == Move())
+            return m_ContCorrHist[packPieceIndices(makePiece(PieceType::PAWN, board.sideToMove()))][move.toSq().value()];
+        return m_ContCorrHist[packPieceIndices(movingPiece(board, move))][move.toSq().value()];
+    }
+
+    const ContCorrEntry& contCorrEntry(const Board& board, Move move) const
+    {
+        if (move == Move())
+            return m_ContCorrHist[packPieceIndices(makePiece(PieceType::PAWN, board.sideToMove()))][move.toSq().value()];
+        return m_ContCorrHist[packPieceIndices(movingPiece(board, move))][move.toSq().value()];
+    }
+
     int getQuietStats(Move move, Bitboard threats, Piece movingPiece, std::span<const CHEntry* const> contHistEntries) const;
     int getNoisyStats(const Board& board, Move move) const;
-    int correctStaticEval(const Board& board, int staticEval) const;
+    int correctStaticEval(const Board& board, int staticEval, Move prevMove, Piece prevPiece, const ContCorrEntry* contCorr2) const;
 
     void clear();
     void updateQuietStats(const Board& board, Move move, std::span<CHEntry*> contHistEntries, int bonus);
     void updateContHist(Move move, Piece movingPiece, std::span<CHEntry*> contHistEntries, int bonus);
     void updateNoisyStats(const Board& board, Move move, int bonus);
-    void updateCorrHist(const Board& board, int bonus, int depth);
+    void updateCorrHist(const Board& board, int bonus, int depth, Move prevMove, Piece prevPiece, ContCorrEntry* contCorr2);
 private:
     int getMainHist(Move move, Bitboard threats, Color color) const;
     int getContHist(Move move, Piece movingPiece, const CHEntry* entry) const;
@@ -163,4 +179,5 @@ private:
     ThreatsCorrHist m_ThreatsCorrHist;
     MinorPieceCorrHist m_MinorPieceCorrHist;
     MajorPieceCorrHist m_MajorPieceCorrHist;
+    ContCorrHist m_ContCorrHist;
 };

--- a/Sirius/src/search.h
+++ b/Sirius/src/search.h
@@ -21,12 +21,15 @@ struct SearchStack
     std::array<Move, MAX_PLY + 1> pv;
     int pvLength;
 
+    Move playedMove;
+    Piece movedPiece;
     Move excludedMove;
     int multiExts;
 
     Move bestMove;
     std::array<Move, 2> killers;
 
+    ContCorrEntry* contCorrEntry;
     CHEntry* contHistEntry;
     int histScore;
 

--- a/Sirius/src/search_params.h
+++ b/Sirius/src/search_params.h
@@ -65,6 +65,7 @@ SEARCH_PARAM(nonPawnNstmCorrWeight, 277, 96, 768, 64);
 SEARCH_PARAM(threatsCorrWeight, 280, 96, 768, 64);
 SEARCH_PARAM(minorCorrWeight, 306, 96, 768, 64);
 SEARCH_PARAM(majorCorrWeight, 322, 96, 768, 64);
+SEARCH_PARAM(contCorr2Weight, 256, 96, 768, 64);
 
 SEARCH_PARAM(aspInitDelta, 9, 8, 30, 4);
 SEARCH_PARAM(minAspDepth, 5, 3, 7, 1);


### PR DESCRIPTION
Correction history indexed by the previous move and the move from 2 plies ago
```
Elo   | 1.54 +- 1.23 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.94 (-2.94, 2.94) [0.00, 3.00]
Games | N: 106190 W: 27323 L: 26851 D: 52016
Penta | [1303, 12951, 24225, 13203, 1413]
```
https://mcthouacbb.pythonanywhere.com/test/552/

Bench: 7904901