### PR TITLE
Clamp the amount corrhist can change an entry when updating

### DIFF
--- a/Sirius/src/history.cpp
+++ b/Sirius/src/history.cpp
@@ -1,5 +1,4 @@
 #include "history.h"
-#include "search_params.h"
 #include "zobrist.h"
 
 namespace

--- a/Sirius/src/history.h
+++ b/Sirius/src/history.h
@@ -67,6 +67,7 @@ inline void HistoryEntry<MAX_VAL>::update(int bonus)
 
 constexpr int CORR_HIST_SCALE = 256;
 constexpr int MAX_CORR_HIST = CORR_HIST_SCALE * 32;
+constexpr int MAX_CORR_HIST_UPDATE = MAX_CORR_HIST / 4;
 
 struct CorrHistEntry
 {
@@ -94,6 +95,7 @@ inline CorrHistEntry::operator int() const
 inline void CorrHistEntry::update(int target, int weight)
 {
     int newValue = (m_Value * (256 - weight) + target * weight) / 256;
+    newValue = std::clamp(newValue, m_Value - MAX_CORR_HIST_UPDATE, m_Value + MAX_CORR_HIST_UPDATE);
     m_Value = static_cast<int16_t>(std::clamp(newValue, -MAX_CORR_HIST, MAX_CORR_HIST));
 }
 

--- a/Sirius/src/history.h
+++ b/Sirius/src/history.h
@@ -2,6 +2,7 @@
 
 #include "defs.h"
 #include "board.h"
+#include "search_params.h"
 #include <span>
 #include <algorithm>
 
@@ -66,8 +67,6 @@ inline void HistoryEntry<MAX_VAL>::update(int bonus)
 }
 
 constexpr int CORR_HIST_SCALE = 256;
-constexpr int MAX_CORR_HIST = CORR_HIST_SCALE * 32;
-constexpr int MAX_CORR_HIST_UPDATE = MAX_CORR_HIST / 4;
 
 struct CorrHistEntry
 {
@@ -95,8 +94,8 @@ inline CorrHistEntry::operator int() const
 inline void CorrHistEntry::update(int target, int weight)
 {
     int newValue = (m_Value * (256 - weight) + target * weight) / 256;
-    newValue = std::clamp(newValue, m_Value - MAX_CORR_HIST_UPDATE, m_Value + MAX_CORR_HIST_UPDATE);
-    m_Value = static_cast<int16_t>(std::clamp(newValue, -MAX_CORR_HIST, MAX_CORR_HIST));
+    newValue = std::clamp(newValue, m_Value - search::maxCorrHistUpdate, m_Value + search::maxCorrHistUpdate);
+    m_Value = static_cast<int16_t>(std::clamp(newValue, -search::maxCorrHist, search::maxCorrHist));
 }
 
 static constexpr int HISTORY_MAX = 16384;

--- a/Sirius/src/search_params.h
+++ b/Sirius/src/search_params.h
@@ -59,6 +59,10 @@ SEARCH_PARAM(histMalusOffset, 66, 64, 768, 64);
 
 SEARCH_PARAM(histBetaMargin, 50, 30, 120, 5);
 
+// 256 corrhist units = 1 eval unit
+SEARCH_PARAM(maxCorrHist, 8192, 6144, 24576, 512);
+SEARCH_PARAM(maxCorrHistUpdate, 2048, 1024, 8192, 64);
+
 SEARCH_PARAM(pawnCorrWeight, 295, 96, 768, 64);
 SEARCH_PARAM(nonPawnStmCorrWeight, 316, 96, 768, 64);
 SEARCH_PARAM(nonPawnNstmCorrWeight, 277, 96, 768, 64);


### PR DESCRIPTION
```
Elo   | 2.14 +- 1.70 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 3.00]
Games | N: 55764 W: 14436 L: 14093 D: 27235
Penta | [711, 6604, 12924, 6917, 726]
```
https://mcthouacbb.pythonanywhere.com/test/553/

Bench: 7999126