### PR TITLE
Refactor how continuation history and continuation correction history are accessed

### DIFF
--- a/Sirius/src/eval/endgame.cpp
+++ b/Sirius/src/eval/endgame.cpp
@@ -67,7 +67,6 @@ int evalKQvKP(const Board& board, const EvalState&, Color strongSide)
     Square queen = board.pieces(strongSide, PieceType::QUEEN).lsb();
     Square pawn = board.pieces(weakSide, PieceType::PAWN).lsb();
     Square ourKing = board.kingSq(strongSide);
-    Square theirKing = board.kingSq(weakSide);
 
     int kpDist = Square::chebyshev(ourKing, pawn);
 
@@ -95,7 +94,6 @@ int evalKQvKR(const Board& board, const EvalState& evalState, Color strongSide)
 
     Square ourKing = board.kingSq(strongSide);
     Square theirKing = board.kingSq(weakSide);
-    Square rook = board.pieces(weakSide, PieceType::ROOK).lsb();
 
     int cornerDist = distToAnyCorner(theirKing);
     int kingDist = Square::manhattan(ourKing, theirKing);

--- a/Sirius/src/eval/eval.cpp
+++ b/Sirius/src/eval/eval.cpp
@@ -258,7 +258,6 @@ void initEvalData(const Board& board, EvalData& evalData, const PawnStructure& p
 {
     constexpr Color them = ~us;
     Bitboard ourPawns = board.pieces(us, PAWN);
-    Bitboard theirPawns = board.pieces(them, PAWN);
     Bitboard blockedPawns = ourPawns & attacks::pawnPushes<them>(board.allPieces());
     Square ourKing = board.kingSq(us);
 

--- a/Sirius/src/history.cpp
+++ b/Sirius/src/history.cpp
@@ -1,5 +1,6 @@
 #include "history.h"
 #include "zobrist.h"
+#include "search.h"
 
 namespace
 {
@@ -57,12 +58,15 @@ void History::clear()
     fillHistTable(m_ContCorrHist, 0);
 }
 
-int History::getQuietStats(Move move, Bitboard threats, Piece movingPiece, std::span<const CHEntry* const> contHistEntries) const
+int History::getQuietStats(Move move, Bitboard threats, Piece movingPiece, SearchStack* stack, int ply) const
 {
     int score = getMainHist(move, threats, getPieceColor(movingPiece));
-    for (auto entry : contHistEntries)
-        if (entry)
-            score += getContHist(move, movingPiece, entry);
+    if (ply > 0 && stack[-1].contHistEntry != nullptr)
+        score += getContHist(move, movingPiece, stack[-1].contHistEntry);
+    if (ply > 1 && stack[-2].contHistEntry != nullptr)
+        score += getContHist(move, movingPiece, stack[-2].contHistEntry);
+    if (ply > 3 && stack[-4].contHistEntry != nullptr)
+        score += getContHist(move, movingPiece, stack[-4].contHistEntry);
     return score;
 }
 
@@ -71,7 +75,7 @@ int History::getNoisyStats(const Board& board, Move move) const
     return getCaptHist(board, move);
 }
 
-int History::correctStaticEval(const Board& board, int staticEval, Move prevMove, Piece prevPiece, std::span<const ContCorrEntry* const> contCorrEntries) const
+int History::correctStaticEval(const Board& board, int staticEval, SearchStack* stack, int ply) const
 {
     Color stm = board.sideToMove();
     uint64_t threatsKey = murmurHash3((board.threats() & board.pieces(stm)).value());
@@ -90,30 +94,45 @@ int History::correctStaticEval(const Board& board, int staticEval, Move prevMove
     correction += search::minorCorrWeight * minorPieceEntry;
     correction += search::majorCorrWeight * majorPieceEntry;
 
+    Move prevMove = ply > 0 ? stack[-1].playedMove : Move();
+    // use pawn to a1 as sentinel for null moves in contcorrhist
+    Piece prevPiece = ply > 0 ? stack[-1].movedPiece : Piece::NONE;
     if (prevPiece == Piece::NONE)
         prevPiece = makePiece(PieceType::PAWN, ~board.sideToMove());
-    for (auto contCorr : contCorrEntries)
+
+    const auto contCorrEntry = [&](int pliesBack)
     {
-        // todo: tunable weights for each ply
-        if (contCorr)
-            correction += search::contCorrWeight * (*contCorr)[packPieceIndices(prevPiece)][prevMove.toSq().value()];
-    }
+        int value = 0;
+        if (ply >= pliesBack && stack[-pliesBack].contCorrEntry != nullptr)
+            value = (*stack[-pliesBack].contCorrEntry)[packPieceIndices(prevPiece)][prevMove.toSq().value()];
+        return value;
+    };
+
+    correction += search::contCorr2Weight * contCorrEntry(2);
+    correction += search::contCorr3Weight * contCorrEntry(3);
+    correction += search::contCorr4Weight * contCorrEntry(4);
+    correction += search::contCorr5Weight * contCorrEntry(5);
+    correction += search::contCorr6Weight * contCorrEntry(6);
+    correction += search::contCorr7Weight * contCorrEntry(7);
 
     int corrected = staticEval + correction / (256 * CORR_HIST_SCALE);
     return std::clamp(corrected, -SCORE_MATE_IN_MAX + 1, SCORE_MATE_IN_MAX - 1);
 }
 
-void History::updateQuietStats(const Board& board, Move move, std::span<CHEntry*> contHistEntries, int bonus)
+void History::updateQuietStats(const Board& board, Move move, SearchStack* stack, int ply, int bonus)
 {
     updateMainHist(board, move, bonus);
-    updateContHist(move, movingPiece(board, move), contHistEntries, bonus);
+    updateContHist(move, movingPiece(board, move), stack, ply, bonus);
 }
 
-void History::updateContHist(Move move, Piece movingPiece, std::span<CHEntry*> contHistEntries, int bonus)
+void History::updateContHist(Move move, Piece movingPiece, SearchStack* stack, int ply, int bonus)
 {
-    for (auto entry : contHistEntries)
-        if (entry)
-            updateContHist(move, movingPiece, entry, bonus);
+    if (ply > 0 && stack[-1].contHistEntry)
+        updateContHist(move, movingPiece, stack[-1].contHistEntry, bonus);
+    if (ply > 1 && stack[-2].contHistEntry)
+        updateContHist(move, movingPiece, stack[-2].contHistEntry, bonus);
+    if (ply > 3 && stack[-4].contHistEntry)
+        updateContHist(move, movingPiece, stack[-4].contHistEntry, bonus);
 }
 
 void History::updateNoisyStats(const Board& board, Move move, int bonus)
@@ -121,7 +140,7 @@ void History::updateNoisyStats(const Board& board, Move move, int bonus)
     updateCaptHist(board, move, bonus);
 }
 
-void History::updateCorrHist(const Board& board, int bonus, int depth, Move prevMove, Piece prevPiece, std::span<ContCorrEntry*> contCorrEntries)
+void History::updateCorrHist(const Board& board, int bonus, int depth, SearchStack* stack, int ply)
 {
     Color stm = board.sideToMove();
     uint64_t threatsKey = murmurHash3((board.threats() & board.pieces(stm)).value());
@@ -146,17 +165,27 @@ void History::updateCorrHist(const Board& board, int bonus, int depth, Move prev
     auto& majorPieceEntry = m_MajorPieceCorrHist[static_cast<int>(stm)][board.majorPieceKey().value % MAJOR_PIECE_CORR_HIST_ENTRIES];
     majorPieceEntry.update(scaledBonus, weight);
 
+    Move prevMove = ply > 0 ? stack[-1].playedMove : Move();
+    // use pawn to a1 as sentinel for null moves in contcorrhist
+    Piece prevPiece = ply > 0 ? stack[-1].movedPiece : Piece::NONE;
     if (prevPiece == Piece::NONE)
         prevPiece = makePiece(PieceType::PAWN, ~board.sideToMove());
-    for (auto contCorr : contCorrEntries)
+
+    const auto updateContCorr = [&](int pliesBack)
     {
-        // todo: tunable weights for each ply
-        if (contCorr)
+        if (ply >= pliesBack && stack[-pliesBack].contCorrEntry != nullptr)
         {
-            auto& contCorrEntry = (*contCorr)[packPieceIndices(prevPiece)][prevMove.toSq().value()];
+            auto& contCorrEntry = (*stack[-pliesBack].contCorrEntry)[packPieceIndices(prevPiece)][prevMove.toSq().value()];
             contCorrEntry.update(scaledBonus, weight);
         }
-    }
+    };
+
+    updateContCorr(2);
+    updateContCorr(3);
+    updateContCorr(4);
+    updateContCorr(5);
+    updateContCorr(6);
+    updateContCorr(7);
 }
 
 int History::getMainHist(Move move, Bitboard threats, Color color) const

--- a/Sirius/src/history.cpp
+++ b/Sirius/src/history.cpp
@@ -127,11 +127,11 @@ void History::updateQuietStats(const Board& board, Move move, SearchStack* stack
 
 void History::updateContHist(Move move, Piece movingPiece, SearchStack* stack, int ply, int bonus)
 {
-    if (ply > 0 && stack[-1].contHistEntry)
+    if (ply > 0 && stack[-1].contHistEntry != nullptr)
         updateContHist(move, movingPiece, stack[-1].contHistEntry, bonus);
-    if (ply > 1 && stack[-2].contHistEntry)
+    if (ply > 1 && stack[-2].contHistEntry != nullptr)
         updateContHist(move, movingPiece, stack[-2].contHistEntry, bonus);
-    if (ply > 3 && stack[-4].contHistEntry)
+    if (ply > 3 && stack[-4].contHistEntry != nullptr)
         updateContHist(move, movingPiece, stack[-4].contHistEntry, bonus);
 }
 

--- a/Sirius/src/history.h
+++ b/Sirius/src/history.h
@@ -3,8 +3,9 @@
 #include "defs.h"
 #include "board.h"
 #include "search_params.h"
-#include <span>
 #include <algorithm>
+
+struct SearchStack;
 
 // all these functions assume that move is a pseudolegal move on the board
 inline Piece movingPiece(const Board& board, Move move)
@@ -154,15 +155,15 @@ public:
         return m_ContCorrHist[packPieceIndices(movingPiece(board, move))][move.toSq().value()];
     }
 
-    int getQuietStats(Move move, Bitboard threats, Piece movingPiece, std::span<const CHEntry* const> contHistEntries) const;
+    int getQuietStats(Move move, Bitboard threats, Piece movingPiece, SearchStack* stack, int ply) const;
     int getNoisyStats(const Board& board, Move move) const;
-    int correctStaticEval(const Board& board, int staticEval, Move prevMove, Piece prevPiece, std::span<const ContCorrEntry* const> contCorrEntries) const;
+    int correctStaticEval(const Board& board, int staticEval, SearchStack* stack, int ply) const;
 
     void clear();
-    void updateQuietStats(const Board& board, Move move, std::span<CHEntry*> contHistEntries, int bonus);
-    void updateContHist(Move move, Piece movingPiece, std::span<CHEntry*> contHistEntries, int bonus);
+    void updateQuietStats(const Board& board, Move move, SearchStack* stack, int ply, int bonus);
+    void updateContHist(Move move, Piece movingPiece, SearchStack* stack, int ply, int bonus);
     void updateNoisyStats(const Board& board, Move move, int bonus);
-    void updateCorrHist(const Board& board, int bonus, int depth, Move prevMove, Piece prevPiece, std::span<ContCorrEntry*> contCorrEntries);
+    void updateCorrHist(const Board& board, int bonus, int depth, SearchStack* stack, int ply);
 private:
     int getMainHist(Move move, Bitboard threats, Color color) const;
     int getContHist(Move move, Piece movingPiece, const CHEntry* entry) const;

--- a/Sirius/src/move_ordering.cpp
+++ b/Sirius/src/move_ordering.cpp
@@ -1,4 +1,5 @@
 #include "move_ordering.h"
+#include "search.h"
 
 #include <climits>
 
@@ -55,7 +56,7 @@ int MoveOrdering::scoreQuiet(Move move) const
     if (move == m_Killers[0] || move == m_Killers[1])
         return KILLER_SCORE + (move == m_Killers[0]);
     else
-        return m_History.getQuietStats(move, m_Board.threats(), movingPiece(m_Board, move), m_ContHistEntries);
+        return m_History.getQuietStats(move, m_Board.threats(), movingPiece(m_Board, move), m_Stack, m_Ply);
 }
 
 int MoveOrdering::scoreMoveQSearch(Move move) const
@@ -76,9 +77,9 @@ MoveOrdering::MoveOrdering(const Board& board, Move ttMove, const History& histo
 {
 }
 
-MoveOrdering::MoveOrdering(const Board& board, Move ttMove, const std::array<Move, 2>& killers, std::span<const CHEntry* const> contHistEntries, const History& history)
+MoveOrdering::MoveOrdering(const Board& board, Move ttMove, const std::array<Move, 2>& killers, SearchStack* stack, int ply, const History& history)
     : m_Board(board), m_TTMove(ttMove),
-    m_History(history), m_ContHistEntries(contHistEntries), m_Killers(killers),
+    m_History(history), m_Stack(stack), m_Ply(ply), m_Killers(killers),
     m_Curr(0), m_Stage(MovePickStage::TT_MOVE)
 {
 }

--- a/Sirius/src/move_ordering.h
+++ b/Sirius/src/move_ordering.h
@@ -5,6 +5,8 @@
 #include "history.h"
 #include <array>
 
+struct SearchStack;
+
 struct ScoredMove
 {
     Move move;
@@ -43,7 +45,7 @@ public:
     static constexpr int CAPTURE_SCORE = 500000;
 
     MoveOrdering(const Board& board, Move ttMove, const History& history);
-    MoveOrdering(const Board& board, Move hashMove, const std::array<Move, 2>& killers, std::span<const CHEntry* const> contHistEntries, const History& history);
+    MoveOrdering(const Board& board, Move hashMove, const std::array<Move, 2>& killers, SearchStack* stack, int ply, const History& history);
 
     ScoredMove selectMove();
     ScoredMove selectHighest();
@@ -56,7 +58,8 @@ private:
     MoveList m_Moves;
     Move m_TTMove;
     const History& m_History;
-    std::span<const CHEntry* const> m_ContHistEntries;
+    SearchStack* m_Stack;
+    int m_Ply;
     std::array<Move, 2> m_Killers;
 
     std::array<int, 256> m_MoveScores;

--- a/Sirius/src/search.cpp
+++ b/Sirius/src/search.cpp
@@ -412,16 +412,6 @@ int Search::search(SearchThread& thread, int depth, SearchStack* stack, int alph
     bool ttHit = false;
 
     int rawStaticEval = SCORE_NONE;
-    Move prevMove = rootPly > 0 ? stack[-1].playedMove : Move();
-    Piece prevPiece = rootPly > 0 ? stack[-1].movedPiece : Piece::NONE;
-    std::array<ContCorrEntry*, 6> contCorrEntries = {
-        rootPly > 1 ? stack[-2].contCorrEntry : nullptr,
-        rootPly > 2 ? stack[-3].contCorrEntry : nullptr,
-        rootPly > 3 ? stack[-4].contCorrEntry : nullptr,
-        rootPly > 4 ? stack[-5].contCorrEntry : nullptr,
-        rootPly > 5 ? stack[-6].contCorrEntry : nullptr,
-        rootPly > 6 ? stack[-7].contCorrEntry : nullptr,
-    };
 
     if (!excluded)
     {
@@ -444,7 +434,7 @@ int Search::search(SearchThread& thread, int depth, SearchStack* stack, int alph
         {
             rawStaticEval = ttHit ? ttData.staticEval : eval::evaluate(board, &thread);
             // Correction history(~91 elo)
-            stack->staticEval = history.correctStaticEval(board, rawStaticEval, prevMove, prevPiece, contCorrEntries);
+            stack->staticEval = history.correctStaticEval(board, rawStaticEval, stack, rootPly);
             stack->eval = stack->staticEval;
             // use tt score as a better eval(~8 elo)
             if (ttHit && (
@@ -541,18 +531,12 @@ int Search::search(SearchThread& thread, int depth, SearchStack* stack, int alph
     if (depth >= minIIRDepth && !inCheck && !excluded && !ttHit)
         depth--;
 
-    // continuation history(~40 elo)
-    std::array<CHEntry*, 3> contHistEntries = {
-        rootPly > 0 ? stack[-1].contHistEntry : nullptr,
-        rootPly > 1 ? stack[-2].contHistEntry : nullptr,
-        rootPly > 3 ? stack[-4].contHistEntry : nullptr
-    };
-
     MoveOrdering ordering(
         board,
         ttData.move,
         stack->killers,
-        contHistEntries,
+        stack,
+        rootPly,
         thread.history
     );
 
@@ -585,7 +569,7 @@ int Search::search(SearchThread& thread, int depth, SearchStack* stack, int alph
 
         Piece movedPiece = movingPiece(board, move);
         int baseLMR = lmrTable[std::min(depth, 63)][std::min(movesPlayed, 63)];
-        int histScore = quiet ? history.getQuietStats(move, threats, movedPiece, contHistEntries) : history.getNoisyStats(board, move);
+        int histScore = quiet ? history.getQuietStats(move, threats, movedPiece, stack, rootPly) : history.getNoisyStats(board, move);
         baseLMR -= histScore / (quiet ? lmrQuietHistDivisor : lmrNoisyHistDivisor);
 
         // move loop pruning(~184 elo)
@@ -708,7 +692,7 @@ int Search::search(SearchThread& thread, int depth, SearchStack* stack, int alph
                 if (quiet && (score <= alpha || score >= beta))
                 {
                     int bonus = score >= beta ? historyBonus(depth) : -historyMalus(depth);
-                    history.updateContHist(move, movedPiece, contHistEntries, bonus);
+                    history.updateContHist(move, movedPiece, stack, rootPly, bonus);
                 }
             }
         }
@@ -763,11 +747,11 @@ int Search::search(SearchThread& thread, int depth, SearchStack* stack, int alph
                 int malus = historyMalus(histDepth);
                 if (quiet)
                 {
-                    history.updateQuietStats(board, move, contHistEntries, bonus);
+                    history.updateQuietStats(board, move, stack, rootPly, bonus);
                     for (Move quietMove : quietsTried)
                     {
                         if (quietMove != move)
-                            history.updateQuietStats(board, quietMove, contHistEntries, -malus);
+                            history.updateQuietStats(board, quietMove, stack, rootPly, -malus);
                     }
                 }
                 else
@@ -798,7 +782,7 @@ int Search::search(SearchThread& thread, int depth, SearchStack* stack, int alph
         if (!inCheck && (stack->bestMove == Move() || moveIsQuiet(board, stack->bestMove)) &&
             !(bound == TTEntry::Bound::LOWER_BOUND && stack->staticEval >= bestScore) &&
             !(bound == TTEntry::Bound::UPPER_BOUND && stack->staticEval <= bestScore))
-            history.updateCorrHist(board, bestScore - stack->staticEval, depth, prevMove, prevPiece, contCorrEntries);
+            history.updateCorrHist(board, bestScore - stack->staticEval, depth, stack, rootPly);
 
         m_TT.store(board.zkey(), depth, rootPly, bestScore, rawStaticEval, stack->bestMove, ttPV, bound);
     }
@@ -834,16 +818,6 @@ int Search::qsearch(SearchThread& thread, SearchStack* stack, int alpha, int bet
 
     bool inCheck = board.checkers().any();
     int rawStaticEval = SCORE_NONE;
-    Move prevMove = rootPly > 0 ? stack[-1].playedMove : Move();
-    Piece prevPiece = rootPly > 0 ? stack[-1].movedPiece : Piece::NONE;
-    std::array<ContCorrEntry*, 6> contCorrEntries = {
-        rootPly > 1 ? stack[-2].contCorrEntry : nullptr,
-        rootPly > 2 ? stack[-3].contCorrEntry : nullptr,
-        rootPly > 3 ? stack[-4].contCorrEntry : nullptr,
-        rootPly > 4 ? stack[-5].contCorrEntry : nullptr,
-        rootPly > 5 ? stack[-6].contCorrEntry : nullptr,
-        rootPly > 6 ? stack[-7].contCorrEntry : nullptr,
-    };
 
     if (inCheck)
     {
@@ -853,7 +827,7 @@ int Search::qsearch(SearchThread& thread, SearchStack* stack, int alpha, int bet
     else
     {
         rawStaticEval = ttHit ? ttData.staticEval : eval::evaluate(board, &thread);
-        stack->staticEval = inCheck ? SCORE_NONE : thread.history.correctStaticEval(board, rawStaticEval, prevMove, prevPiece, contCorrEntries);
+        stack->staticEval = inCheck ? SCORE_NONE : thread.history.correctStaticEval(board, rawStaticEval, stack, rootPly);
 
         // use tt score as a better eval(~8 elo)
         stack->eval = stack->staticEval;
@@ -876,16 +850,10 @@ int Search::qsearch(SearchThread& thread, SearchStack* stack, int alpha, int bet
     if (rootPly >= MAX_PLY)
         return alpha;
 
-    std::array<CHEntry*, 3> contHistEntries = {
-        rootPly > 0 ? stack[-1].contHistEntry : nullptr,
-        rootPly > 1 ? stack[-2].contHistEntry : nullptr,
-        rootPly > 3 ? stack[-4].contHistEntry : nullptr
-    };
-
     MoveOrdering ordering = [&]()
     {
         if (inCheck)
-            return MoveOrdering(board, ttData.move, stack->killers, contHistEntries, history);
+            return MoveOrdering(board, ttData.move, stack->killers, stack, rootPly, history);
         else
             return MoveOrdering(board, ttData.move, history);
     }();

--- a/Sirius/src/search.cpp
+++ b/Sirius/src/search.cpp
@@ -692,7 +692,7 @@ int Search::search(SearchThread& thread, int depth, SearchStack* stack, int alph
                 if (quiet && (score <= alpha || score >= beta))
                 {
                     int bonus = score >= beta ? historyBonus(depth) : -historyMalus(depth);
-                    history.updateContHist(move, movedPiece, stack, rootPly, bonus);
+                    history.updateContHist(move, movedPiece, stack, rootPly - 1, bonus);
                 }
             }
         }

--- a/Sirius/src/search_params.h
+++ b/Sirius/src/search_params.h
@@ -69,7 +69,12 @@ SEARCH_PARAM(nonPawnNstmCorrWeight, 277, 96, 768, 64);
 SEARCH_PARAM(threatsCorrWeight, 280, 96, 768, 64);
 SEARCH_PARAM(minorCorrWeight, 306, 96, 768, 64);
 SEARCH_PARAM(majorCorrWeight, 322, 96, 768, 64);
-SEARCH_PARAM(contCorrWeight, 192, 96, 768, 64);
+SEARCH_PARAM(contCorr2Weight, 192, 96, 768, 64);
+SEARCH_PARAM(contCorr3Weight, 192, 96, 768, 64);
+SEARCH_PARAM(contCorr4Weight, 192, 96, 768, 64);
+SEARCH_PARAM(contCorr5Weight, 192, 96, 768, 64);
+SEARCH_PARAM(contCorr6Weight, 192, 96, 768, 64);
+SEARCH_PARAM(contCorr7Weight, 192, 96, 768, 64);
 
 SEARCH_PARAM(aspInitDelta, 9, 8, 30, 4);
 SEARCH_PARAM(minAspDepth, 5, 3, 7, 1);


### PR DESCRIPTION
Instead of passing an array of entries, a pointer to the search stack entry is passed.
This is a small speedup over the old method
Passed STC
```
Elo   | 6.98 +- 3.65 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 3.00]
Games | N: 11004 W: 2896 L: 2675 D: 5433
Penta | [108, 1183, 2717, 1368, 126]
```
https://mcthouacbb.pythonanywhere.com/test/560/

Also passed STC non-regression
```
Elo   | 13.47 +- 7.32 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.03 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 2788 W: 778 L: 670 D: 1340
Penta | [20, 300, 662, 376, 36]
```
https://mcthouacbb.pythonanywhere.com/test/558/

No functional change
Bench: 7629147