### PR TITLE
Reduce killers

### DIFF
--- a/Sirius/src/move_ordering.cpp
+++ b/Sirius/src/move_ordering.cpp
@@ -53,8 +53,10 @@ int MoveOrdering::scoreNoisy(Move move) const
 
 int MoveOrdering::scoreQuiet(Move move) const
 {
-    if (move == m_Killers[0] || move == m_Killers[1])
-        return KILLER_SCORE + (move == m_Killers[0]);
+    if (move == m_Killers[0])
+        return MoveOrdering::FIRST_KILLER_SCORE;
+    else if (move == m_Killers[1])
+        return MoveOrdering::SECOND_KILLER_SCORE;
     else
         return m_History.getQuietStats(move, m_Board.threats(), movingPiece(m_Board, move), m_Stack, m_Ply);
 }

--- a/Sirius/src/move_ordering.h
+++ b/Sirius/src/move_ordering.h
@@ -40,7 +40,8 @@ class MoveOrdering
 {
 public:
     static constexpr int NO_MOVE = -8000000;
-    static constexpr int KILLER_SCORE = 300000;
+    static constexpr int FIRST_KILLER_SCORE = 300001;
+    static constexpr int SECOND_KILLER_SCORE = 300000;
     static constexpr int PROMOTION_SCORE = 400000;
     static constexpr int CAPTURE_SCORE = 500000;
 

--- a/Sirius/src/search.cpp
+++ b/Sirius/src/search.cpp
@@ -667,7 +667,7 @@ int Search::search(SearchThread& thread, int depth, SearchStack* stack, int alph
         // late move reductions(~111 elo)
         if (movesPlayed >= (pvNode ? lmrMinMovesPv : lmrMinMovesNonPv) &&
             depth >= lmrMinDepth &&
-            quietLosing)
+            moveScore <= MoveOrdering::KILLER_SCORE + 1)
         {
             int reduction = baseLMR;
 

--- a/Sirius/src/search.cpp
+++ b/Sirius/src/search.cpp
@@ -565,7 +565,7 @@ int Search::search(SearchThread& thread, int depth, SearchStack* stack, int alph
         if (!board.isLegal(move))
             continue;
         bool quiet = moveIsQuiet(board, move);
-        bool quietLosing = moveScore < MoveOrdering::KILLER_SCORE;
+        bool quietLosing = moveScore < MoveOrdering::SECOND_KILLER_SCORE;
 
         Piece movedPiece = movingPiece(board, move);
         int baseLMR = lmrTable[std::min(depth, 63)][std::min(movesPlayed, 63)];
@@ -667,7 +667,7 @@ int Search::search(SearchThread& thread, int depth, SearchStack* stack, int alph
         // late move reductions(~111 elo)
         if (movesPlayed >= (pvNode ? lmrMinMovesPv : lmrMinMovesNonPv) &&
             depth >= lmrMinDepth &&
-            moveScore <= MoveOrdering::KILLER_SCORE + 1)
+            moveScore <= MoveOrdering::FIRST_KILLER_SCORE)
         {
             int reduction = baseLMR;
 


### PR DESCRIPTION
```
Elo   | 3.12 +- 2.27 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.94 (-2.94, 2.94) [0.00, 3.00]
Games | N: 31032 W: 8198 L: 7919 D: 14915
Penta | [376, 3690, 7123, 3933, 394]
```
https://mcthouacbb.pythonanywhere.com/test/565/

Bench: 6931223