### PR TITLE
Cutnode negative extensions when ttScore <= alpha

### DIFF
--- a/Sirius/src/search.cpp
+++ b/Sirius/src/search.cpp
@@ -641,6 +641,8 @@ int Search::search(SearchThread& thread, int depth, SearchStack* stack, int alph
                 return sBeta;
             else if (ttData.score >= beta)
                 extension = -2 + pvNode;
+            else if (ttData.score <= alpha && cutnode)
+                extension = -1;
         }
 
         stack->multiExts += extension >= 2;


### PR DESCRIPTION
```
Elo   | 5.84 +- 3.37 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 3.00]
Games | N: 14160 W: 3665 L: 3427 D: 7068
Penta | [178, 1618, 3257, 1842, 185]
```
https://mcthouacbb.pythonanywhere.com/test/571/

Bench: 7078333