### PR TITLE
Tweak singular extensions

### DIFF
--- a/Sirius/src/search.cpp
+++ b/Sirius/src/search.cpp
@@ -632,7 +632,7 @@ int Search::search(SearchThread& thread, int depth, SearchStack* stack, int alph
 
             if (score < sBeta)
             {
-                if (!pvNode && stack->multiExts < maxMultiExts && score < sBeta - doubleExtMargin)
+                if (!pvNode && stack->multiExts <= maxMultiExts && score < sBeta - doubleExtMargin)
                     extension = 2;
                 else
                     extension = 1;

--- a/Sirius/src/search_params.h
+++ b/Sirius/src/search_params.h
@@ -118,11 +118,11 @@ SEARCH_PARAM(seeCaptHistDivisor, 32, 16, 96, 2);
 SEARCH_PARAM(maxHistPruningDepth, 5, 2, 8, 1);
 SEARCH_PARAM(histPruningMargin, 1768, 512, 4096, 128);
 
-SEARCH_PARAM(seMinDepth, 7, 4, 9, 1);
+SEARCH_PARAM(seMinDepth, 6, 4, 9, 1);
 SEARCH_PARAM(seTTDepthMargin, 3, 2, 5, 1);
-SEARCH_PARAM(sBetaScale, 15, 8, 32, 1);
+SEARCH_PARAM(sBetaScale, 14, 8, 32, 1);
 SEARCH_PARAM(maxMultiExts, 6, 3, 12, 1);
-SEARCH_PARAM(doubleExtMargin, 14, 0, 40, 2);
+SEARCH_PARAM(doubleExtMargin, 12, 0, 40, 2);
 
 SEARCH_PARAM(lmrMinDepth, 3, 2, 5, 1);
 SEARCH_PARAM(lmrMinMovesNonPv, 3, 1, 6, 1);


### PR DESCRIPTION
Passed STC
```
Elo   | 2.94 +- 2.16 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 3.00]
Games | N: 33230 W: 8425 L: 8144 D: 16661
Penta | [361, 3938, 7774, 4143, 399]
```
https://mcthouacbb.pythonanywhere.com/test/572/

Passed LTC
```
Elo   | 6.72 +- 3.52 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 10810 W: 2623 L: 2414 D: 5773
Penta | [52, 1239, 2629, 1418, 67]
```
https://mcthouacbb.pythonanywhere.com/test/573/

Bench: 7698672