### PR TITLE
Remove double extension limit and disable singular extensions when ply >= 2 * rootDepth

### DIFF
--- a/Sirius/src/search.h
+++ b/Sirius/src/search.h
@@ -24,7 +24,6 @@ struct SearchStack
     Move playedMove;
     Piece movedPiece;
     Move excludedMove;
-    int multiExts;
 
     Move bestMove;
     std::array<Move, 2> killers;
@@ -97,6 +96,7 @@ struct SearchThread
 
     SearchLimits limits;
 
+    int rootDepth = 0;
     int rootPly = 0;
     int selDepth = 0;
     std::array<SearchStack, MAX_PLY + 1> stack;

--- a/Sirius/src/search_params.h
+++ b/Sirius/src/search_params.h
@@ -128,7 +128,6 @@ SEARCH_PARAM(histPruningMargin, 1743, 512, 4096, 128);
 SEARCH_PARAM(seMinDepth, 6, 4, 9, 1);
 SEARCH_PARAM(seTTDepthMargin, 3, 2, 5, 1);
 SEARCH_PARAM(sBetaScale, 13, 8, 32, 1);
-SEARCH_PARAM(maxMultiExts, 6, 3, 12, 1);
 SEARCH_PARAM(doubleExtMargin, 12, 0, 40, 2);
 
 SEARCH_PARAM(lmrMinDepth, 3, 2, 5, 1);


### PR DESCRIPTION
```
Elo   | 1.29 +- 3.22 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 15032 W: 3904 L: 3848 D: 7280
Penta | [184, 1763, 3571, 1809, 189]
```
https://mcthouacbb.pythonanywhere.com/test/592/

Bench: 7520056