### PR TITLE
Clamp phase properly

### DIFF
--- a/Sirius/src/eval/phase.cpp
+++ b/Sirius/src/eval/phase.cpp
@@ -1,5 +1,7 @@
 #include "phase.h"
 
+#include <algorithm>
+
 namespace eval
 {
 
@@ -25,7 +27,7 @@ int getPiecePhase(PieceType piece)
 
 int getFullEval(int mg, int eg, int phase)
 {
-    phase = std::min(phase, TOTAL_PHASE);
+    phase = std::clamp(phase, 0, TOTAL_PHASE);
     return (mg * (TOTAL_PHASE - phase) + eg * phase) / TOTAL_PHASE;
 }
 


### PR DESCRIPTION
```
Elo   | 0.29 +- 2.55 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.98 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 24014 W: 6350 L: 6330 D: 11334
Penta | [307, 2802, 5771, 2818, 309]
```
https://mcthouacbb.pythonanywhere.com/test/600/

Bench: 7484237