### PR TITLE
Tweak capture move ordering to MVV + capthist

### DIFF
--- a/Sirius/src/move_ordering.cpp
+++ b/Sirius/src/move_ordering.cpp
@@ -6,14 +6,14 @@
 namespace
 {
 
-int mvvLva(const Board& board, Move move)
+int mvv(const Board& board, Move move)
 {
-    int srcPiece = static_cast<int>(getPieceType(board.pieceAt(move.fromSq())));
+    constexpr int MVV_VALUES[6] = {800, 2400, 2400, 4800, 7200};
+
     int dstPiece = static_cast<int>(move.type() == MoveType::ENPASSANT ?
         PieceType::PAWN :
         getPieceType(board.pieceAt(move.toSq()))
     );
-    constexpr int MVV_VALUES[6] = {800, 2400, 2400, 4800, 7200};
     return MVV_VALUES[dstPiece];
 }
 
@@ -44,7 +44,7 @@ int MoveOrdering::scoreNoisy(Move move) const
     if (isCapture)
     {
         int hist = m_History.getNoisyStats(m_Board, move);
-        int score = hist + mvvLva(m_Board, move);
+        int score = hist + mvv(m_Board, move);
         return score + CAPTURE_SCORE * m_Board.see(move, -score / 32);
     }
     else
@@ -64,7 +64,7 @@ int MoveOrdering::scoreMoveQSearch(Move move) const
     bool isPromotion = move.type() == MoveType::PROMOTION;
     int score = m_History.getNoisyStats(m_Board, move);
     if (isCapture)
-        score += mvvLva(m_Board, move);
+        score += mvv(m_Board, move);
     if (isPromotion)
         score += 100 * promotionBonus(move);
 

--- a/Sirius/src/move_ordering.cpp
+++ b/Sirius/src/move_ordering.cpp
@@ -13,7 +13,8 @@ int mvvLva(const Board& board, Move move)
         PieceType::PAWN :
         getPieceType(board.pieceAt(move.toSq()))
     );
-    return 10 * dstPiece - srcPiece + 15;
+    constexpr int MVV_VALUES[6] = {800, 2400, 2400, 4800, 7200};
+    return MVV_VALUES[dstPiece];
 }
 
 int promotionBonus(Move move)
@@ -43,7 +44,8 @@ int MoveOrdering::scoreNoisy(Move move) const
     if (isCapture)
     {
         int hist = m_History.getNoisyStats(m_Board, move);
-        return hist + CAPTURE_SCORE * m_Board.see(move, -hist / 32) + mvvLva(m_Board, move);
+        int score = hist + mvvLva(m_Board, move);
+        return score + CAPTURE_SCORE * m_Board.see(move, -score / 32);
     }
     else
     {


### PR DESCRIPTION
Use MVV + capthist for scoring captures, and factor MVV into SEE threshold
MVV scoring based on Ethereal scheme
```
Elo   | 1.96 +- 1.57 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 3.00]
Games | N: 66232 W: 17391 L: 17018 D: 31823
Penta | [828, 8025, 15135, 8202, 926]
```
https://mcthouacbb.pythonanywhere.com/test/606/

Bench: 8078007