### PR TITLE
Move BestMove out of the search stack + some minor fixes

### DIFF
--- a/Sirius/src/search.cpp
+++ b/Sirius/src/search.cpp
@@ -310,8 +310,8 @@ int Search::aspWindows(SearchThread& thread, int depth, Move& bestMove, int prev
 
     if (depth >= minAspDepth)
     {
-        alpha = prevScore - delta;
-        beta = prevScore + delta;
+        alpha = std::max(prevScore - delta, -SCORE_MAX);
+        beta = std::min(prevScore + delta, SCORE_MAX);
     }
 
     while (true)
@@ -323,7 +323,7 @@ int Search::aspWindows(SearchThread& thread, int depth, Move& bestMove, int prev
         if (searchScore <= alpha)
         {
             beta = (alpha + beta) / 2;
-            alpha -= delta;
+            alpha = std::max(alpha - delta, -SCORE_MAX);
             aspDepth = depth;
         }
         else
@@ -331,7 +331,7 @@ int Search::aspWindows(SearchThread& thread, int depth, Move& bestMove, int prev
             bestMove = thread.stack[0].pv[0];
             if (searchScore >= beta)
             {
-                beta += delta;
+                beta = std::min(beta + delta, SCORE_MAX);
                 aspDepth = std::max(aspDepth - 1, depth - 5);
             }
             else

--- a/Sirius/src/search.cpp
+++ b/Sirius/src/search.cpp
@@ -460,7 +460,7 @@ int Search::search(SearchThread& thread, int depth, SearchStack* stack, int alph
     if (!pvNode && !inCheck && !excluded)
     {
         // reverse futility pruning(~86 elo)
-        int rfpMargin = (improving ? rfpImpMargin : rfpNonImpMargin) * depth - rfpOppWorsening * oppWorsening + (stack -1)->histScore / rfpHistDivisor;
+        int rfpMargin = (improving ? rfpImpMargin : rfpNonImpMargin) * depth - rfpOppWorsening * oppWorsening + (stack - 1)->histScore / rfpHistDivisor;
         if (depth <= rfpMaxDepth &&
             stack->eval >= std::max(rfpMargin, 20) + beta)
             return stack->eval;
@@ -543,7 +543,7 @@ int Search::search(SearchThread& thread, int depth, SearchStack* stack, int alph
 
     (stack + 1)->failHighCount = 0;
 
-    stack->bestMove = Move::nullmove();
+    Move bestMove = Move::nullmove();
 
     TTEntry::Bound bound = TTEntry::Bound::UPPER_BOUND;
 
@@ -717,7 +717,7 @@ int Search::search(SearchThread& thread, int depth, SearchStack* stack, int alph
             {
                 bound = TTEntry::Bound::EXACT;
                 alpha = bestScore;
-                stack->bestMove = move;
+                bestMove = move;
                 if (pvNode)
                 {
                     stack->pv[0] = move;
@@ -778,12 +778,12 @@ int Search::search(SearchThread& thread, int depth, SearchStack* stack, int alph
 
     if (!excluded)
     {
-        if (!inCheck && (stack->bestMove == Move::nullmove() || moveIsQuiet(board, stack->bestMove)) &&
+        if (!inCheck && (bestMove == Move::nullmove() || moveIsQuiet(board, bestMove)) &&
             !(bound == TTEntry::Bound::LOWER_BOUND && stack->staticEval >= bestScore) &&
             !(bound == TTEntry::Bound::UPPER_BOUND && stack->staticEval <= bestScore))
             history.updateCorrHist(board, bestScore - stack->staticEval, depth, stack, rootPly);
 
-        m_TT.store(board.zkey(), depth, rootPly, bestScore, rawStaticEval, stack->bestMove, ttPV, bound);
+        m_TT.store(board.zkey(), depth, rootPly, bestScore, rawStaticEval, bestMove, ttPV, bound);
     }
 
     return bestScore;
@@ -859,7 +859,7 @@ int Search::qsearch(SearchThread& thread, SearchStack* stack, int alpha, int bet
     }();
 
     TTEntry::Bound bound = TTEntry::Bound::UPPER_BOUND;
-    stack->bestMove = Move::nullmove();
+    Move bestMove = Move::nullmove();
     int movesPlayed = 0;
 
     ScoredMove scoredMove = {};
@@ -892,7 +892,7 @@ int Search::qsearch(SearchThread& thread, SearchStack* stack, int alpha, int bet
 
             if (bestScore > alpha)
             {
-                stack->bestMove = move;
+                bestMove = move;
 
                 stack->pvLength = (stack + 1)->pvLength + 1;
                 stack->pv[0] = move;
@@ -914,7 +914,7 @@ int Search::qsearch(SearchThread& thread, SearchStack* stack, int alpha, int bet
     if (inCheck && movesPlayed == 0)
         return -SCORE_MATE + rootPly;
 
-    m_TT.store(board.zkey(), 0, rootPly, bestScore, rawStaticEval, stack->bestMove, ttPV, bound);
+    m_TT.store(board.zkey(), 0, rootPly, bestScore, rawStaticEval, bestMove, ttPV, bound);
 
     return bestScore;
 }

--- a/Sirius/src/search.h
+++ b/Sirius/src/search.h
@@ -25,7 +25,6 @@ struct SearchStack
     Piece movedPiece;
     Move excludedMove;
 
-    Move bestMove;
     std::array<Move, 2> killers;
 
     ContCorrEntry* contCorrEntry;


### PR DESCRIPTION
```
Elo   | 1.88 +- 3.58 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.02 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 12908 W: 3413 L: 3343 D: 6152
Penta | [161, 1598, 2893, 1614, 188]
```
https://mcthouacbb.pythonanywhere.com/test/616/

Bench: 6482524