### PR TITLE
NMP Verification Search

### DIFF
--- a/Sirius/src/search.cpp
+++ b/Sirius/src/search.cpp
@@ -475,7 +475,7 @@ int Search::search(SearchThread& thread, int depth, SearchStack* stack, int alph
 
         // null move pruning(~31 elo)
         Bitboard nonPawns = board.pieces(board.sideToMove()) ^ board.pieces(board.sideToMove(), PieceType::PAWN);
-        if (board.pliesFromNull() > 0 && depth >= nmpMinDepth &&
+        if (board.pliesFromNull() > 0 && rootPly >= thread.nmpMinPly && depth >= nmpMinDepth &&
             stack->eval >= beta && stack->staticEval >= beta + nmpEvalBaseMargin - nmpEvalDepthMargin * depth &&
             nonPawns.multiple())
         {
@@ -484,7 +484,17 @@ int Search::search(SearchThread& thread, int depth, SearchStack* stack, int alph
             int nullScore = -search(thread, depth - r, stack + 1, -beta, -beta + 1, false, !cutnode);
             unmakeNullMove(thread, stack);
             if (nullScore >= beta)
-                return nullScore;
+            {
+                if (depth <= 15 || thread.nmpMinPly == 0)
+                    return isMateScore(nullScore) ? beta : nullScore;
+
+                thread.nmpMinPly = rootPly + (depth - r) * 3 / 4;
+                int verifScore = search(thread, depth - r, stack + 1, -beta, -beta + 1, false, true);
+                thread.nmpMinPly = 0;
+
+                if (verifScore >= beta)
+                    return verifScore;
+            }
         }
 
         // probcut(~3 elo)

--- a/Sirius/src/search.cpp
+++ b/Sirius/src/search.cpp
@@ -489,7 +489,7 @@ int Search::search(SearchThread& thread, int depth, SearchStack* stack, int alph
                     return isMateScore(nullScore) ? beta : nullScore;
 
                 thread.nmpMinPly = rootPly + (depth - r) * 3 / 4;
-                int verifScore = search(thread, depth - r, stack + 1, -beta, -beta + 1, false, true);
+                int verifScore = search(thread, depth - r, stack + 1, beta - 1, beta, false, true);
                 thread.nmpMinPly = 0;
 
                 if (verifScore >= beta)

--- a/Sirius/src/search.cpp
+++ b/Sirius/src/search.cpp
@@ -485,7 +485,7 @@ int Search::search(SearchThread& thread, int depth, SearchStack* stack, int alph
             unmakeNullMove(thread, stack);
             if (nullScore >= beta)
             {
-                if (depth <= 15 || thread.nmpMinPly == 0)
+                if (depth <= 15 || thread.nmpMinPly > 0)
                     return isMateScore(nullScore) ? beta : nullScore;
 
                 thread.nmpMinPly = rootPly + (depth - r) * 3 / 4;

--- a/Sirius/src/search.h
+++ b/Sirius/src/search.h
@@ -98,6 +98,7 @@ struct SearchThread
     int rootDepth = 0;
     int rootPly = 0;
     int selDepth = 0;
+    int nmpMinPly = 0;
     std::array<SearchStack, MAX_PLY + 1> stack;
     History history;
     PawnTable pawnTable;


### PR DESCRIPTION
```
Elo   | 1.04 +- 3.10 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 16638 W: 4414 L: 4364 D: 7860
Penta | [236, 1911, 3970, 1971, 231]
```
https://mcthouacbb.pythonanywhere.com/test/620/

Bench: 6482524