### PR TITLE
Avoid pruning recaptures in qsearch

### DIFF
--- a/Sirius/src/search.cpp
+++ b/Sirius/src/search.cpp
@@ -876,18 +876,22 @@ int Search::qsearch(SearchThread& thread, SearchStack* stack, int alpha, int bet
     ScoredMove scoredMove = {};
     while ((scoredMove = ordering.selectMove()).score != MoveOrdering::NO_MOVE)
     {
-        // quiescence search pruning(~55 elo)
-        if (!inCheck && movesPlayed >= 2)
-            break;
         auto [move, moveScore] = scoredMove;
         if (!board.isLegal(move))
             continue;
-        if (bestScore > -SCORE_WIN && !board.see(move, 0))
-            continue;
-        if (!inCheck && futility <= alpha && !board.see(move, 1))
+
+        // quiescence search pruning(~55 elo)
+        if ((stack - 1)->playedMove != Move::nullmove() || move.toSq() != (stack - 1)->playedMove.toSq())
         {
-            bestScore = std::max(bestScore, futility);
-            continue;
+            if (!inCheck && movesPlayed >= 2)
+                break;
+            if (bestScore > -SCORE_WIN && !board.see(move, 0))
+                continue;
+            if (!inCheck && futility <= alpha && !board.see(move, 1))
+            {
+                bestScore = std::max(bestScore, futility);
+                continue;
+            }
         }
 
         makeMove(thread, stack, move, 0);


### PR DESCRIPTION
```
Elo   | 4.51 +- 2.85 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 3.00]
Games | N: 18958 W: 5076 L: 4830 D: 9052
Penta | [232, 2098, 4563, 2364, 222]
```
https://mcthouacbb.pythonanywhere.com/test/633/

Bench: 7166647