### PR TITLE
Revert "Avoid pruning recaptures in qsearch"

### DIFF
--- a/Sirius/src/search.cpp
+++ b/Sirius/src/search.cpp
@@ -876,22 +876,18 @@ int Search::qsearch(SearchThread& thread, SearchStack* stack, int alpha, int bet
     ScoredMove scoredMove = {};
     while ((scoredMove = ordering.selectMove()).score != MoveOrdering::NO_MOVE)
     {
+        // quiescence search pruning(~55 elo)
+        if (!inCheck && movesPlayed >= 2)
+            break;
         auto [move, moveScore] = scoredMove;
         if (!board.isLegal(move))
             continue;
-
-        // quiescence search pruning(~55 elo)
-        if ((stack - 1)->playedMove != Move::nullmove() || move.toSq() != (stack - 1)->playedMove.toSq())
+        if (bestScore > -SCORE_WIN && !board.see(move, 0))
+            continue;
+        if (!inCheck && futility <= alpha && !board.see(move, 1))
         {
-            if (!inCheck && movesPlayed >= 2)
-                break;
-            if (bestScore > -SCORE_WIN && !board.see(move, 0))
-                continue;
-            if (!inCheck && futility <= alpha && !board.see(move, 1))
-            {
-                bestScore = std::max(bestScore, futility);
-                continue;
-            }
+            bestScore = std::max(bestScore, futility);
+            continue;
         }
 
         makeMove(thread, stack, move, 0);


### PR DESCRIPTION
The condition in the previous patch is completely broken.
Reverts mcthouacbb/Sirius#268