### PR TITLE
Search at most one non-losing quiet check evasion in qsearch

### DIFF
--- a/Sirius/src/search.cpp
+++ b/Sirius/src/search.cpp
@@ -921,6 +921,7 @@ int Search::qsearch(SearchThread& thread, SearchStack* stack, int alpha, int bet
             }
         }
 
+        // Obsidian idea
         if (moveIsQuiet(board, move) && inCheck && bestScore > -SCORE_WIN)
             break;
     }

--- a/Sirius/src/search.cpp
+++ b/Sirius/src/search.cpp
@@ -920,6 +920,9 @@ int Search::qsearch(SearchThread& thread, SearchStack* stack, int alpha, int bet
                 break;
             }
         }
+
+        if (moveIsQuiet(board, move) && inCheck && bestScore > -SCORE_WIN)
+            break;
     }
 
     if (inCheck && movesPlayed == 0)


### PR DESCRIPTION
Idea is from Obsidian
- https://github.com/gab8192/Obsidian/commit/19554e1835b56ca19fa0923c87b2b1dbc67d74ac
- https://github.com/gab8192/Obsidian/commit/cc502c3391d7e5c754c66db5d6fc822dc5f4b350
```
Elo   | 3.50 +- 2.46 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 26880 W: 7206 L: 6935 D: 12739
Penta | [327, 3210, 6149, 3373, 381]
```
https://mcthouacbb.pythonanywhere.com/test/640/

Bench: 7027225