### PR TITLE
Use aligned alloc for TT + fix issues with multithreaded initialization

### DIFF
--- a/Sirius/src/search.cpp
+++ b/Sirius/src/search.cpp
@@ -85,7 +85,7 @@ void SearchThread::join()
 }
 
 Search::Search(Board& board)
-    : m_Board(board), m_ShouldStop(false), m_TT(2 * 1024 * 1024)
+    : m_Board(board), m_ShouldStop(false), m_TT(64)
 {
     setThreads(1);
 }

--- a/Sirius/src/search.h
+++ b/Sirius/src/search.h
@@ -122,7 +122,7 @@ public:
 
     void setTTSize(int mb)
     {
-        m_TT.resize(mb);
+        m_TT.resize(mb, m_Threads.size());
     }
 private:
     void joinThreads();

--- a/Sirius/src/tt.h
+++ b/Sirius/src/tt.h
@@ -51,7 +51,8 @@ struct TTEntry
 static_assert(sizeof(TTEntry) == 10, "TTEntry must be 10 bytes");
 static_assert(alignof(TTEntry) == 2, "TTEntry must have 2 byte alignment");
 
-static constexpr int ENTRY_COUNT = 3;
+constexpr int ENTRY_COUNT = 3;
+constexpr size_t TT_ALIGNMENT = 64;
 
 struct alignas(32) TTBucket
 {
@@ -77,7 +78,7 @@ public:
     TT(size_t size);
     ~TT() = default;
 
-    void resize(int mb);
+    void resize(int mb, int numThreads);
 
     TT(const TT&) = delete;
     TT& operator=(const TT&) = delete;
@@ -102,15 +103,17 @@ public:
         {
             threads.emplace_back([i, this, numThreads]()
             {
-                std::fill(m_Buckets.begin() + m_Buckets.size() * i / numThreads, m_Buckets.begin() + m_Buckets.size() * (i + 1) / numThreads, TTBucket{});
+                std::fill(m_Buckets + m_Size * i / numThreads, m_Buckets + m_Size * (i + 1) / numThreads, TTBucket{});
             });
         }
+        std::cout << "Threading" << std::endl;
     }
 
     int hashfull() const;
 private:
     uint32_t index(uint64_t key) const;
 
-    std::vector<TTBucket> m_Buckets;
+    TTBucket* m_Buckets;
+    size_t m_Size;
     int m_CurrAge;
 };

--- a/Sirius/src/tt.h
+++ b/Sirius/src/tt.h
@@ -76,7 +76,7 @@ public:
     static constexpr int GEN_CYCLE_LENGTH = 1 << 5;
 
     TT(size_t size);
-    ~TT() = default;
+    ~TT();
 
     void resize(int mb, int numThreads);
 
@@ -106,7 +106,6 @@ public:
                 std::fill(m_Buckets + m_Size * i / numThreads, m_Buckets + m_Size * (i + 1) / numThreads, TTBucket{});
             });
         }
-        std::cout << "Threading" << std::endl;
     }
 
     int hashfull() const;


### PR DESCRIPTION
Use of std::vector<> forced single threaded initialization when resizing the TT, effectively negating the previous commit
This commit fixes that and switches to using std::aligned_alloc for allocating the TT
No functional change
Bench: 6901440 