### PR TITLE
Consider pinned pieces in static exchange evaluation

### DIFF
--- a/Sirius/src/attacks.h
+++ b/Sirius/src/attacks.h
@@ -120,9 +120,14 @@ inline constexpr int pawnPushOffset()
     return c == Color::WHITE ? 8 : -8;
 }
 
+inline Bitboard alignedSquares(Square a, Square b)
+{
+    return attackData.alignedSquares[a.value()][b.value()];
+}
+
 inline bool aligned(Square a, Square b, Square c)
 {
-    return attackData.alignedSquares[a.value()][b.value()].has(c);
+    return alignedSquares(a, b).has(c);
 }
 
 inline Bitboard inBetweenSquares(Square src, Square dst)

--- a/Sirius/src/board.cpp
+++ b/Sirius/src/board.cpp
@@ -742,7 +742,7 @@ bool Board::see(Move move, int margin) const
     {
         sideToMove = ~sideToMove;
         Bitboard stmAttackers = attackers & pieces(sideToMove);
-        if ((pinners(~sideToMove) & allPieces).any())
+        if ((pinners(sideToMove) & allPieces).any())
             stmAttackers &= ~pinned | pinnedAligned;
 
         if (stmAttackers.empty())

--- a/Sirius/src/board.cpp
+++ b/Sirius/src/board.cpp
@@ -726,10 +726,25 @@ bool Board::see(Move move, int margin) const
 
     bool us = false;
 
+    Bitboard whitePinned = checkBlockers(Color::WHITE) & pieces(Color::WHITE);
+    Bitboard blackPinned = checkBlockers(Color::BLACK) & pieces(Color::BLACK);
+
+    Bitboard whiteKingRay = attacks::alignedSquares(dst, kingSq(Color::WHITE));
+    Bitboard blackKingRay = attacks::alignedSquares(dst, kingSq(Color::BLACK));
+
+    Bitboard whitePinnedAligned = whiteKingRay & whitePinned;
+    Bitboard blackPinnedAligned = blackKingRay & blackPinned;
+
+    Bitboard pinned = whitePinned | blackPinned;
+    Bitboard pinnedAligned = whitePinnedAligned | blackPinnedAligned;
+
     while (true)
     {
         sideToMove = ~sideToMove;
         Bitboard stmAttackers = attackers & pieces(sideToMove);
+        if ((pinners(~sideToMove) & allPieces).any())
+            stmAttackers &= ~pinned | pinnedAligned;
+
         if (stmAttackers.empty())
             return !us;
 


### PR DESCRIPTION
This patch is a combination of an idea in stockfish and what I believe is an original idea from pawnocchio
https://github.com/official-stockfish/Stockfish/blob/d7c04a942950f1fe3f655bf8b608e8ef21c07628/src/position.cpp#L1087-L1089
https://github.com/JonathanHallstrom/pawnocchio/commit/702cc57afb18f427fdf30bb8517498f1a721e165
In SEE, pieces which are pinned are not allowed to be an attacker for the square, unless
- The pin is aligned with the target square, so the piece can move there regardless
- All the pinning pieces for that side have disappeared
    - It would be more correct to allow it to participate if only its pinner disappeared, but this is a bit difficult to keep track of and rarely occurs
```
Elo   | 3.81 +- 2.58 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 3.00]
Games | N: 23990 W: 6415 L: 6152 D: 11423
Penta | [285, 2828, 5542, 3019, 321]
```
https://mcthouacbb.pythonanywhere.com/test/682/

Bench: 6377876