### PR TITLE
Add cmath include to time_man.cpp

### DIFF
--- a/Sirius/src/time_man.cpp
+++ b/Sirius/src/time_man.cpp
@@ -2,6 +2,7 @@
 #include "search.h"
 #include "search_params.h"
 #include <iostream>
+#include <cmath>
 
 void TimeManager::setLimits(const SearchLimits& limits, Color us)
 {


### PR DESCRIPTION
std::pow was giving errors for tcec compile
Thanks to @mhouppin(Nano) for finding the cause quickly
The error from tcec logs:
```
Sirius/src/time_man.cpp:66:70: error: no member named 'pow' in namespace 'std'
   66 |         static_cast<double>(search::bmStabilityScale) / 100.0 * std::pow(
      |                                                                 ~~~~~^
1 error generated.
```
Bench: 6377876