### PR TITLE
Fix issues with multithreading and searching to max depth.

### DIFF
--- a/Sirius/src/search.cpp
+++ b/Sirius/src/search.cpp
@@ -287,11 +287,11 @@ int Search::iterDeep(SearchThread& thread, bool report, bool normalSearch)
             comm::currComm->reportSearchInfo(info);
         }
         if (thread.isMainThread() && m_TimeMan.stopSoft(bestMove, thread.nodes, thread.limits))
-        {
-            m_ShouldStop.store(true, std::memory_order_relaxed);
             break;
-        }
     }
+
+    if (thread.isMainThread())
+        m_ShouldStop.store(true, std::memory_order_relaxed);
 
     if (report)
     {


### PR DESCRIPTION
Sirius crashed in this position at TCEC
4R3/pp4kq/4K3/2p2P1p/P3NB2/8/8/8 w - - 0 1 [(lichess-link)](https://lichess.org/analysis/4R3/pp4kq/4K3/2p2P1p/P3NB2/8/8/8_w_-_-_0_1?color=white
After searching to the maximum depth on the previous move. The reason is that, previously, Sirius did not quit helper threads if the main thread exited from reaching max depth.

I was only able to reproduce this issue when disabling mate distance pruning on helper threads, and this patch does fix the issue in that case.

No functional change
Bench: 6377876