### PR TITLE
Adjust futility pruning margin by history

### DIFF
--- a/Sirius/src/search.cpp
+++ b/Sirius/src/search.cpp
@@ -586,11 +586,12 @@ int Search::search(SearchThread& thread, int depth, SearchStack* stack, int alph
         {
             // futility pruning(~1 elo)
             int lmrDepth = std::max(depth - baseLMR, 0);
+            int fpMargin = std::max(fpBaseMargin + fpDepthMargin * lmrDepth + histScore / 400, 20);
             if (lmrDepth <= fpMaxDepth &&
                 quiet &&
                 !inCheck &&
                 alpha < SCORE_WIN &&
-                stack->eval + fpBaseMargin + fpDepthMargin * lmrDepth <= alpha)
+                stack->staticEval + fpMargin <= alpha)
             {
                 continue;
             }


### PR DESCRIPTION
Also switches to using static eval instead of eval for futility pruning
```
Elo   | 2.13 +- 1.69 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 54430 W: 14219 L: 13885 D: 26326
Penta | [609, 6467, 12791, 6677, 671]
```
https://mcthouacbb.pythonanywhere.com/test/687/

Bench: 7294089