### PR TITLE
Remove SEE pruning max depth

### DIFF
--- a/Sirius/src/search.cpp
+++ b/Sirius/src/search.cpp
@@ -608,7 +608,6 @@ int Search::search(SearchThread& thread, int depth, SearchStack* stack, int alph
                 depth * seePruneMarginQuiet :
                 depth * seePruneMarginNoisy - std::clamp(histScore / seeCaptHistDivisor, -seeCaptHistMax * depth, seeCaptHistMax * depth);
             if (!pvNode &&
-                depth <= maxSeePruneDepth &&
                 !board.see(move, seeMargin))
                 continue;
 

--- a/Sirius/src/search_params.h
+++ b/Sirius/src/search_params.h
@@ -117,7 +117,6 @@ SEARCH_PARAM(fpMaxDepth, 4, 4, 9, 1);
 SEARCH_PARAM(lmpMaxDepth, 10, 4, 11, 1);
 SEARCH_PARAM(lmpMinMovesBase, 2, 2, 7, 1);
 
-SEARCH_PARAM(maxSeePruneDepth, 7, 6, 11, 1);
 SEARCH_PARAM(seePruneMarginNoisy, -95, -120, -30, 6);
 SEARCH_PARAM(seePruneMarginQuiet, -58, -120, -30, 6);
 SEARCH_PARAM(seeCaptHistMax, 97, 50, 200, 6);


### PR DESCRIPTION
```
Elo   | 2.73 +- 2.05 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 3.00]
Games | N: 37116 W: 9730 L: 9438 D: 17948
Penta | [451, 4305, 8765, 4575, 462]
```
https://mcthouacbb.pythonanywhere.com/test/712/

Bench: 6744837