### PR TITLE
Simplify LMP max depth

### DIFF
--- a/Sirius/src/search.cpp
+++ b/Sirius/src/search.cpp
@@ -599,7 +599,6 @@ int Search::search(SearchThread& thread, int depth, SearchStack* stack, int alph
             // late move pruning(~23 elo)
             if (!pvNode &&
                 !inCheck &&
-                depth <= lmpMaxDepth &&
                 movesPlayed >= lmpMinMovesBase + depth * depth / (improving ? 1 : 2))
                 break;
 

--- a/Sirius/src/search_params.h
+++ b/Sirius/src/search_params.h
@@ -114,7 +114,6 @@ SEARCH_PARAM(fpDepthMargin, 123, 10, 180, 12);
 SEARCH_PARAM(fpHistDivisor, 400, 256, 512, 16);
 SEARCH_PARAM(fpMaxDepth, 4, 4, 9, 1);
 
-SEARCH_PARAM(lmpMaxDepth, 10, 4, 11, 1);
 SEARCH_PARAM(lmpMinMovesBase, 2, 2, 7, 1);
 
 SEARCH_PARAM(seePruneMarginNoisy, -95, -120, -30, 6);


### PR DESCRIPTION
Currently does nothing, a node at depth 11 would need to search 63 moves to trigger LMP
Bench: 6744837