### PR TITLE
Increase max futility pruning depth

### DIFF
--- a/Sirius/src/search_params.h
+++ b/Sirius/src/search_params.h
@@ -112,7 +112,7 @@ SEARCH_PARAM(probcutReduction, 4, 3, 6, 1);
 SEARCH_PARAM(fpBaseMargin, 149, 60, 360, 12);
 SEARCH_PARAM(fpDepthMargin, 123, 10, 180, 12);
 SEARCH_PARAM(fpHistDivisor, 400, 256, 512, 16);
-SEARCH_PARAM(fpMaxDepth, 4, 4, 9, 1);
+SEARCH_PARAM(fpMaxDepth, 8, 4, 9, 1);
 
 SEARCH_PARAM(lmpMaxDepth, 10, 4, 11, 1);
 SEARCH_PARAM(lmpMinMovesBase, 2, 2, 7, 1);


### PR DESCRIPTION
```
Elo   | 1.70 +- 1.37 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 82572 W: 21506 L: 21101 D: 39965
Penta | [952, 9823, 19384, 10122, 1005]
```
https://mcthouacbb.pythonanywhere.com/test/713/

Bench: 6993439