### PR TITLE
Adjust aspiration windows delta by score squared

### DIFF
--- a/Sirius/src/search.cpp
+++ b/Sirius/src/search.cpp
@@ -304,7 +304,7 @@ int Search::iterDeep(SearchThread& thread, bool report, bool normalSearch)
 // Aspiration windows(~108 elo)
 int Search::aspWindows(SearchThread& thread, int depth, Move& bestMove, int prevScore)
 {
-    int delta = aspInitDelta;
+    int delta = aspInitDelta + prevScore * prevScore / 16384;
     int alpha = -SCORE_MAX;
     int beta = SCORE_MAX;
     int aspDepth = depth;


### PR DESCRIPTION
```
Elo   | 1.37 +- 1.08 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 125118 W: 32434 L: 31939 D: 60745
Penta | [1237, 14452, 30734, 14851, 1285]
```
https://mcthouacbb.pythonanywhere.com/test/726/

Bench: 6846190