### PR TITLE
Noisy futility pruning

### DIFF
--- a/Sirius/src/search.cpp
+++ b/Sirius/src/search.cpp
@@ -627,6 +627,19 @@ int Search::search(SearchThread& thread, int depth, SearchStack* stack, int alph
                 continue;
             }
 
+            // capture futility pruning
+            fpMargin = 122 * depth + 371 * movesPlayed / 128;
+            if (depth <= 5 &&
+                !quiet &&
+                !inCheck &&
+                alpha < SCORE_WIN &&
+                stack->staticEval + fpMargin <= alpha)
+            {
+                if (!isMateScore(bestScore) && bestScore <= stack->staticEval + fpMargin)
+                    bestScore = stack->staticEval + fpMargin;
+                break;
+            }
+
             // late move pruning(~23 elo)
             if (!pvNode &&
                 !inCheck &&


### PR DESCRIPTION
Idea from Calvin and originally fromReckless
https://github.com/codedeliveryservice/Reckless/blob/68b3eff0511311481395fc9506a23514502d7b19/src/search.rs#L552-L559
https://kelseyde.pythonanywhere.com/test/671/
```
Elo   | 3.78 +- 2.56 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 3.00]
Games | N: 23728 W: 6259 L: 6001 D: 11468
Penta | [241, 2841, 5501, 2981, 300]
```
https://mcthouacbb.pythonanywhere.com/test/754/

Bench: 6799775