### PR TITLE
Add clang format + refactor

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,236 @@
+---
+Language:        Cpp
+BasedOnStyle:  WebKit
+AccessModifierOffset: -4
+AlignAfterOpenBracket: DontAlign
+AlignArrayOfStructures: None
+AlignConsecutiveAssignments:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  PadOperators:    true
+AlignConsecutiveBitFields:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  PadOperators:    false
+AlignConsecutiveDeclarations:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  PadOperators:    false
+AlignConsecutiveMacros:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  PadOperators:    false
+AlignConsecutiveShortCaseStatements:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCaseColons: false
+AlignEscapedNewlines: Right
+AlignOperands:   DontAlign
+AlignTrailingComments:
+  Kind:            Never
+  OverEmptyLines:  0
+AllowAllArgumentsOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: Empty
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortEnumsOnASingleLine: true
+AllowShortFunctionsOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLambdasOnASingleLine: All
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: MultiLine
+AttributeMacros:
+  - __capability
+BinPackArguments: true
+BinPackParameters: true
+BitFieldColonSpacing: Both
+BraceWrapping:
+  AfterCaseLabel:  false
+  AfterClass:      false
+  AfterControlStatement: Never
+  AfterEnum:       false
+  AfterExternBlock: false
+  AfterFunction:   true
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  BeforeCatch:     false
+  BeforeElse:      false
+  BeforeLambdaBody: false
+  BeforeWhile:     false
+  IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakAfterAttributes: Never
+BreakAfterJavaFieldAnnotations: false
+BreakArrays:     true
+BreakBeforeBinaryOperators: All
+BreakBeforeConceptDeclarations: Always
+BreakBeforeBraces: WebKit
+BreakBeforeInlineASMColon: OnlyMultiline
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializers: BeforeComma
+BreakInheritanceList: BeforeColon
+BreakStringLiterals: true
+ColumnLimit:     0
+CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: false
+DerivePointerAlignment: false
+DisableFormat:   false
+EmptyLineAfterAccessModifier: Never
+EmptyLineBeforeAccessModifier: LogicalBlock
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: false
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IfMacros:
+  - KJ_IF_MAYBE
+IncludeBlocks:   Preserve
+IncludeCategories:
+  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
+    Priority:        2
+    SortPriority:    0
+    CaseSensitive:   false
+  - Regex:           '^(<|"(gtest|gmock|isl|json)/)'
+    Priority:        3
+    SortPriority:    0
+    CaseSensitive:   false
+  - Regex:           '.*'
+    Priority:        1
+    SortPriority:    0
+    CaseSensitive:   false
+IncludeIsMainRegex: '(Test)?$'
+IncludeIsMainSourceRegex: ''
+IndentAccessModifiers: false
+IndentCaseBlocks: false
+IndentCaseLabels: false
+IndentExternBlock: AfterExternBlock
+IndentGotoLabels: true
+IndentPPDirectives: None
+IndentRequiresClause: true
+IndentWidth:     4
+IndentWrappedFunctionNames: false
+InsertBraces:    false
+InsertNewlineAtEOF: false
+InsertTrailingCommas: None
+IntegerLiteralSeparator:
+  Binary:          0
+  BinaryMinDigits: 0
+  Decimal:         0
+  DecimalMinDigits: 0
+  Hex:             0
+  HexMinDigits:    0
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: true
+KeepEmptyLinesAtEOF: false
+LambdaBodyIndentation: Signature
+LineEnding:      DeriveLF
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: Inner
+ObjCBinPackProtocolList: Auto
+ObjCBlockIndentWidth: 4
+ObjCBreakBeforeNestedBlockParam: true
+ObjCSpaceAfterProperty: true
+ObjCSpaceBeforeProtocolList: true
+PackConstructorInitializers: BinPack
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakOpenParenthesis: 0
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyIndentedWhitespace: 0
+PenaltyReturnTypeOnItsOwnLine: 60
+PointerAlignment: Left
+PPIndentWidth:   -1
+QualifierAlignment: Leave
+ReferenceAlignment: Pointer
+ReflowComments:  true
+RemoveBracesLLVM: false
+RemoveParentheses: Leave
+RemoveSemicolon: false
+RequiresClausePosition: OwnLine
+RequiresExpressionIndentation: OuterScope
+SeparateDefinitionBlocks: Leave
+ShortNamespaceLines: 1
+SortIncludes:    CaseSensitive
+SortJavaStaticImport: Before
+SortUsingDeclarations: LexicographicNumeric
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: true
+SpaceAroundPointerQualifiers: Default
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCaseColon: false
+SpaceBeforeCpp11BracedList: true
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeJsonColon: false
+SpaceBeforeParens: ControlStatements
+SpaceBeforeParensOptions:
+  AfterControlStatements: true
+  AfterForeachMacros: true
+  AfterFunctionDefinitionName: false
+  AfterFunctionDeclarationName: false
+  AfterIfMacros:   true
+  AfterOverloadedOperator: false
+  AfterRequiresInClause: false
+  AfterRequiresInExpression: false
+  BeforeNonEmptyParentheses: false
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceBeforeSquareBrackets: false
+SpaceInEmptyBlock: true
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  Never
+SpacesInContainerLiterals: true
+SpacesInLineCommentPrefix:
+  Minimum:         1
+  Maximum:         -1
+SpacesInParens:  Never
+SpacesInParensOptions:
+  InCStyleCasts:   false
+  InConditionalStatements: false
+  InEmptyParentheses: false
+  Other:           false
+SpacesInSquareBrackets: false
+Standard:        Latest
+StatementAttributeLikeMacros:
+  - Q_EMIT
+StatementMacros:
+  - Q_UNUSED
+  - QT_REQUIRE_VERSION
+TabWidth:        8
+UseTab:          Never
+VerilogBreakBetweenInstancePorts: true
+WhitespaceSensitiveMacros:
+  - BOOST_PP_STRINGIZE
+  - CF_SWIFT_NAME
+  - NS_SWIFT_NAME
+  - PP_STRINGIZE
+  - STRINGIZE
+...
+

--- a/.clang-format
+++ b/.clang-format
@@ -1,175 +1,157 @@
 ---
-Language:        Cpp
-BasedOnStyle:  WebKit
-AccessModifierOffset: -4
-AlignAfterOpenBracket: DontAlign
+Language: Cpp
+BasedOnStyle: WebKit
 AlignArrayOfStructures: None
 AlignConsecutiveAssignments:
-  Enabled:         false
+  Enabled: false
   AcrossEmptyLines: false
-  AcrossComments:  false
-  AlignCompound:   false
-  PadOperators:    true
+  AcrossComments: false
+  AlignCompound: false
+  PadOperators: false
 AlignConsecutiveBitFields:
-  Enabled:         false
+  Enabled: false
   AcrossEmptyLines: false
-  AcrossComments:  false
-  AlignCompound:   false
-  PadOperators:    false
+  AcrossComments: false
+  AlignCompound: false
+  PadOperators: false
 AlignConsecutiveDeclarations:
-  Enabled:         false
+  Enabled: false
   AcrossEmptyLines: false
-  AcrossComments:  false
-  AlignCompound:   false
-  PadOperators:    false
+  AcrossComments: false
+  AlignCompound: false
+  PadOperators: false
 AlignConsecutiveMacros:
-  Enabled:         false
+  Enabled: false
   AcrossEmptyLines: false
-  AcrossComments:  false
-  AlignCompound:   false
-  PadOperators:    false
+  AcrossComments: false
+  AlignCompound: false
+  PadOperators: false
 AlignConsecutiveShortCaseStatements:
-  Enabled:         false
+  Enabled: false
   AcrossEmptyLines: false
-  AcrossComments:  false
+  AcrossComments: false
   AlignCaseColons: false
-AlignEscapedNewlines: Right
-AlignOperands:   DontAlign
+AlignEscapedNewlines: DontAlign
+AlignOperands: DontAlign
 AlignTrailingComments:
-  Kind:            Never
-  OverEmptyLines:  0
+  Kind: Never
+  OverEmptyLines: 0
 AllowAllArgumentsOnNextLine: true
 AllowAllParametersOfDeclarationOnNextLine: true
 AllowShortBlocksOnASingleLine: Empty
 AllowShortCaseLabelsOnASingleLine: false
-AllowShortEnumsOnASingleLine: true
-AllowShortFunctionsOnASingleLine: All
+AllowShortEnumsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: None
 AllowShortIfStatementsOnASingleLine: Never
-AllowShortLambdasOnASingleLine: All
+AllowShortLambdasOnASingleLine: None
 AllowShortLoopsOnASingleLine: false
 AlwaysBreakAfterDefinitionReturnType: None
 AlwaysBreakAfterReturnType: None
 AlwaysBreakBeforeMultilineStrings: false
-AlwaysBreakTemplateDeclarations: MultiLine
-AttributeMacros:
-  - __capability
+AlwaysBreakTemplateDeclarations: Yes
+# AttributeMacros:
+#   - __capability
 BinPackArguments: true
 BinPackParameters: true
 BitFieldColonSpacing: Both
 BraceWrapping:
-  AfterCaseLabel:  false
-  AfterClass:      false
-  AfterControlStatement: Never
-  AfterEnum:       false
-  AfterExternBlock: false
-  AfterFunction:   true
-  AfterNamespace:  false
+  AfterCaseLabel: false
+  AfterClass: true
+  AfterControlStatement: Always
+  AfterEnum: true
+  AfterExternBlock: true
+  AfterFunction: true
+  AfterNamespace: true
   AfterObjCDeclaration: false
-  AfterStruct:     false
-  AfterUnion:      false
-  BeforeCatch:     false
-  BeforeElse:      false
-  BeforeLambdaBody: false
-  BeforeWhile:     false
-  IndentBraces:    false
+  AfterStruct: true
+  AfterUnion: true
+  BeforeCatch: true
+  BeforeElse: true
+  BeforeLambdaBody: true
+  BeforeWhile: true
+  IndentBraces: false
   SplitEmptyFunction: true
   SplitEmptyRecord: true
   SplitEmptyNamespace: true
 BreakAfterAttributes: Never
 BreakAfterJavaFieldAnnotations: false
-BreakArrays:     true
-BreakBeforeBinaryOperators: All
+BreakArrays: true
+BreakBeforeBinaryOperators: NonAssignment
 BreakBeforeConceptDeclarations: Always
-BreakBeforeBraces: WebKit
+BreakBeforeBraces: Allman
 BreakBeforeInlineASMColon: OnlyMultiline
 BreakBeforeTernaryOperators: true
-BreakConstructorInitializers: BeforeComma
-BreakInheritanceList: BeforeColon
-BreakStringLiterals: true
-ColumnLimit:     0
-CommentPragmas:  '^ IWYU pragma:'
+BreakConstructorInitializers: BeforeColon
+BreakInheritanceList: AfterColon
+BreakStringLiterals: false
+ColumnLimit: 100
 CompactNamespaces: false
 ConstructorInitializerIndentWidth: 4
 ContinuationIndentWidth: 4
-Cpp11BracedListStyle: false
+Cpp11BracedListStyle: true
 DerivePointerAlignment: false
-DisableFormat:   false
+DisableFormat: false
 EmptyLineAfterAccessModifier: Never
 EmptyLineBeforeAccessModifier: LogicalBlock
 ExperimentalAutoDetectBinPacking: false
 FixNamespaceComments: false
-ForEachMacros:
-  - foreach
-  - Q_FOREACH
-  - BOOST_FOREACH
-IfMacros:
-  - KJ_IF_MAYBE
-IncludeBlocks:   Preserve
+IncludeBlocks: Preserve
 IncludeCategories:
-  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
-    Priority:        2
-    SortPriority:    0
-    CaseSensitive:   false
-  - Regex:           '^(<|"(gtest|gmock|isl|json)/)'
-    Priority:        3
-    SortPriority:    0
-    CaseSensitive:   false
-  - Regex:           '.*'
-    Priority:        1
-    SortPriority:    0
-    CaseSensitive:   false
+  - Regex: '^"(llvm|llvm-c|clang|clang-c)/'
+    Priority: 2
+    SortPriority: 0
+    CaseSensitive: false
+  - Regex: '^(<|"(gtest|gmock|isl|json)/)'
+    Priority: 3
+    SortPriority: 0
+    CaseSensitive: false
+  - Regex: '.*'
+    Priority: 1
+    SortPriority: 0
+    CaseSensitive: false
 IncludeIsMainRegex: '(Test)?$'
 IncludeIsMainSourceRegex: ''
 IndentAccessModifiers: false
 IndentCaseBlocks: false
-IndentCaseLabels: false
+IndentCaseLabels: true
 IndentExternBlock: AfterExternBlock
 IndentGotoLabels: true
 IndentPPDirectives: None
 IndentRequiresClause: true
-IndentWidth:     4
+IndentWidth: 4
 IndentWrappedFunctionNames: false
-InsertBraces:    false
-InsertNewlineAtEOF: false
+InsertBraces: false
+InsertNewlineAtEOF: true
 InsertTrailingCommas: None
 IntegerLiteralSeparator:
-  Binary:          0
+  Binary: 0
   BinaryMinDigits: 0
-  Decimal:         0
+  Decimal: 0
   DecimalMinDigits: 0
-  Hex:             0
-  HexMinDigits:    0
-JavaScriptQuotes: Leave
-JavaScriptWrapImports: true
+  Hex: 0
+  HexMinDigits: 0
 KeepEmptyLinesAtTheStartOfBlocks: true
 KeepEmptyLinesAtEOF: false
 LambdaBodyIndentation: Signature
-LineEnding:      DeriveLF
+LineEnding: DeriveLF
 MacroBlockBegin: ''
-MacroBlockEnd:   ''
+MacroBlockEnd: ''
 MaxEmptyLinesToKeep: 1
-NamespaceIndentation: Inner
+NamespaceIndentation: None
 ObjCBinPackProtocolList: Auto
 ObjCBlockIndentWidth: 4
 ObjCBreakBeforeNestedBlockParam: true
 ObjCSpaceAfterProperty: true
 ObjCSpaceBeforeProtocolList: true
-PackConstructorInitializers: BinPack
-PenaltyBreakAssignment: 2
-PenaltyBreakBeforeFirstCallParameter: 19
-PenaltyBreakComment: 300
-PenaltyBreakFirstLessLess: 120
-PenaltyBreakOpenParenthesis: 0
-PenaltyBreakString: 1000
-PenaltyBreakTemplateDeclaration: 10
-PenaltyExcessCharacter: 1000000
-PenaltyIndentedWhitespace: 0
-PenaltyReturnTypeOnItsOwnLine: 60
+PackConstructorInitializers: NextLineOnly
+PenaltyBreakBeforeFirstCallParameter: 50
+PenaltyExcessCharacter: 4
+PenaltyReturnTypeOnItsOwnLine: 10000
 PointerAlignment: Left
-PPIndentWidth:   -1
+PPIndentWidth: -1
 QualifierAlignment: Leave
 ReferenceAlignment: Pointer
-ReflowComments:  true
+ReflowComments: true
 RemoveBracesLLVM: false
 RemoveParentheses: Leave
 RemoveSemicolon: false
@@ -177,16 +159,16 @@ RequiresClausePosition: OwnLine
 RequiresExpressionIndentation: OuterScope
 SeparateDefinitionBlocks: Leave
 ShortNamespaceLines: 1
-SortIncludes:    CaseSensitive
+SortIncludes: CaseSensitive
 SortJavaStaticImport: Before
 SortUsingDeclarations: LexicographicNumeric
 SpaceAfterCStyleCast: false
 SpaceAfterLogicalNot: false
-SpaceAfterTemplateKeyword: true
+SpaceAfterTemplateKeyword: false
 SpaceAroundPointerQualifiers: Default
 SpaceBeforeAssignmentOperators: true
 SpaceBeforeCaseColon: false
-SpaceBeforeCpp11BracedList: true
+SpaceBeforeCpp11BracedList: false
 SpaceBeforeCtorInitializerColon: true
 SpaceBeforeInheritanceColon: true
 SpaceBeforeJsonColon: false
@@ -196,7 +178,7 @@ SpaceBeforeParensOptions:
   AfterForeachMacros: true
   AfterFunctionDefinitionName: false
   AfterFunctionDeclarationName: false
-  AfterIfMacros:   true
+  AfterIfMacros: true
   AfterOverloadedOperator: false
   AfterRequiresInClause: false
   AfterRequiresInExpression: false
@@ -205,32 +187,18 @@ SpaceBeforeRangeBasedForLoopColon: true
 SpaceBeforeSquareBrackets: false
 SpaceInEmptyBlock: true
 SpacesBeforeTrailingComments: 1
-SpacesInAngles:  Never
-SpacesInContainerLiterals: true
+SpacesInAngles: Never
+SpacesInContainerLiterals: false
 SpacesInLineCommentPrefix:
-  Minimum:         1
-  Maximum:         -1
-SpacesInParens:  Never
+  Minimum: 1
+  Maximum: -1
+SpacesInParens: Never
 SpacesInParensOptions:
-  InCStyleCasts:   false
+  InCStyleCasts: false
   InConditionalStatements: false
   InEmptyParentheses: false
-  Other:           false
+  Other: false
 SpacesInSquareBrackets: false
-Standard:        Latest
-StatementAttributeLikeMacros:
-  - Q_EMIT
-StatementMacros:
-  - Q_UNUSED
-  - QT_REQUIRE_VERSION
-TabWidth:        8
-UseTab:          Never
-VerilogBreakBetweenInstancePorts: true
-WhitespaceSensitiveMacros:
-  - BOOST_PP_STRINGIZE
-  - CF_SWIFT_NAME
-  - NS_SWIFT_NAME
-  - PP_STRINGIZE
-  - STRINGIZE
-...
-
+Standard: Latest
+TabWidth: 4
+UseTab: Never

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ replit.nix
 build
 
 build
+.vscode

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,24 @@ ifeq ($(OS), Windows_NT)
 	EXE_SUFFIX = .exe
 endif
 
-SOURCES := Sirius/src/attacks.cpp Sirius/src/bench.cpp Sirius/src/board.cpp Sirius/src/cuckoo.cpp Sirius/src/history.cpp Sirius/src/main.cpp Sirius/src/misc.cpp Sirius/src/move_ordering.cpp Sirius/src/movegen.cpp Sirius/src/search.cpp Sirius/src/search_params.cpp Sirius/src/time_man.cpp Sirius/src/tt.cpp Sirius/src/eval/endgame.cpp Sirius/src/eval/eval.cpp Sirius/src/eval/eval_state.cpp Sirius/src/eval/eval_terms.cpp Sirius/src/eval/pawn_structure.cpp Sirius/src/eval/phase.cpp Sirius/src/eval/psqt_state.cpp Sirius/src/comm/book.cpp Sirius/src/comm/cmdline.cpp Sirius/src/comm/fen.cpp Sirius/src/comm/icomm.cpp Sirius/src/comm/move.cpp Sirius/src/comm/uci.cpp
+SOURCES := Sirius/src/attacks.cpp Sirius/src/bench.cpp Sirius/src/board.cpp Sirius/src/cuckoo.cpp \
+	Sirius/src/history.cpp Sirius/src/main.cpp Sirius/src/misc.cpp Sirius/src/move_ordering.cpp \
+	Sirius/src/movegen.cpp Sirius/src/search.cpp Sirius/src/search_params.cpp Sirius/src/time_man.cpp \
+	Sirius/src/tt.cpp Sirius/src/eval/endgame.cpp Sirius/src/eval/eval.cpp Sirius/src/eval/eval_state.cpp \
+	Sirius/src/eval/eval_terms.cpp Sirius/src/eval/pawn_structure.cpp Sirius/src/eval/phase.cpp \
+	Sirius/src/eval/psqt_state.cpp Sirius/src/comm/book.cpp Sirius/src/comm/cmdline.cpp Sirius/src/comm/fen.cpp \
+	Sirius/src/comm/icomm.cpp Sirius/src/comm/move.cpp Sirius/src/comm/uci.cpp
+
+HEADERS := Sirius/src/attacks.h Sirius/src/bench.h Sirius/src/bitboard.h Sirius/src/board.h \
+	Sirius/src/castling.h Sirius/src/cuckoo.h Sirius/src/defs.h Sirius/src/history.h Sirius/src/misc.h \
+	Sirius/src/move_ordering.h Sirius/src/movegen.h Sirius/src/search_params.h Sirius/src/search.h \
+	Sirius/src/sirius.h Sirius/src/time_man.h Sirius/src/tt.h Sirius/src/zobrist.h Sirius/src/util/enum_array.h \
+	Sirius/src/util/multi_array.h Sirius/src/util/murmur.h Sirius/src/util/piece_set.h Sirius/src/util/prng.h \
+	Sirius/src/util/static_vector.h Sirius/src/util/string_split.h Sirius/src/eval/combined_psqt.h \
+	Sirius/src/eval/endgame.h Sirius/src/eval/eval_constants.h Sirius/src/eval/eval_state.h Sirius/src/eval/eval_terms.h \
+	Sirius/src/eval/eval.h Sirius/src/eval/pawn_structure.h Sirius/src/eval/pawn_table.h Sirius/src/eval/phase.h \
+	Sirius/src/eval/psqt_state.h Sirius/src/comm/book.h Sirius/src/comm/cmdline.h Sirius/src/comm/fen.h \
+	Sirius/src/comm/icomm.h Sirius/src/comm/move.h Sirius/src/comm/uci_option.h Sirius/src/comm/uci.h
 
 CXX := clang++
 CXXFLAGS := -std=c++20 -O3 -flto -DNDEBUG -march=native
@@ -19,4 +36,4 @@ $(EXE)$(EXE_SUFFIX): $(SOURCES)
 	$(CXX) $(CXXFLAGS) $(LDFLAGS) $(SOURCES) -o $(EXE)$(EXE_SUFFIX)
 
 format:
-	clang-format -i $(SOURCES)
+	clang-format -i $(SOURCES) $(HEADERS)

--- a/Makefile
+++ b/Makefile
@@ -17,3 +17,6 @@ CXXFLAGS := -std=c++20 -O3 -flto -DNDEBUG -march=native
 
 $(EXE)$(EXE_SUFFIX): $(SOURCES)
 	$(CXX) $(CXXFLAGS) $(LDFLAGS) $(SOURCES) -o $(EXE)$(EXE_SUFFIX)
+
+format:
+	clang-format -i $(SOURCES)

--- a/Sirius/src/attacks.cpp
+++ b/Sirius/src/attacks.cpp
@@ -137,6 +137,7 @@ constexpr uint64_t bishopMagics[64] = {
     0x40102000a0a60140ULL,
 };
 
+// clang-format off
 constexpr uint32_t rookIndexBits[64] = {
     12, 11, 11, 11, 11, 11, 11, 12,
     11, 10, 10, 10, 10, 10, 10, 11,
@@ -158,6 +159,8 @@ constexpr uint32_t bishopIndexBits[64] = {
     5, 5, 5, 5, 5, 5, 5, 5,
     6, 5, 5, 5, 5, 5, 5, 6
 };
+
+// clang-format on
 
 Bitboard rays[64][8] = {};
 
@@ -352,31 +355,17 @@ void init()
 
         attackData.kingAttacks[square] = king;
 
-        Bitboard knight =
-            bb.north().northEast() |
-            bb.north().northWest() |
-            bb.south().southEast() |
-            bb.south().southWest() |
-            bb.east().northEast() |
-            bb.east().southEast() |
-            bb.west().northWest() |
-            bb.west().southWest();
+        Bitboard knight = bb.north().northEast() | bb.north().northWest() | bb.south().southEast()
+            | bb.south().southWest() | bb.east().northEast() | bb.east().southEast()
+            | bb.west().northWest() | bb.west().southWest();
         attackData.knightAttacks[square] = knight;
 
         attackData.pawnAttacks[static_cast<int>(Color::WHITE)][square] = pawnAttacks<Color::WHITE>(bb);
         attackData.pawnAttacks[static_cast<int>(Color::BLACK)][square] = pawnAttacks<Color::BLACK>(bb);
     }
 
-    Direction allDirs[] = {
-        Direction::NORTH,
-        Direction::SOUTH,
-        Direction::EAST,
-        Direction::WEST,
-        Direction::NORTH_EAST,
-        Direction::NORTH_WEST,
-        Direction::SOUTH_EAST,
-        Direction::SOUTH_WEST
-    };
+    Direction allDirs[] = {Direction::NORTH, Direction::SOUTH, Direction::EAST, Direction::WEST,
+        Direction::NORTH_EAST, Direction::NORTH_WEST, Direction::SOUTH_EAST, Direction::SOUTH_WEST};
     for (uint32_t src = 0; src < 64; src++)
     {
         for (uint32_t dst = 0; dst < 64; dst++)
@@ -405,13 +394,15 @@ void init()
         white |= white << 8;
         white |= white << 16;
         white |= white << 32;
-        attackData.passedPawnMasks[static_cast<int>(Color::WHITE)][i] = white | white.west() | white.east();
+        attackData.passedPawnMasks[static_cast<int>(Color::WHITE)][i] =
+            white | white.west() | white.east();
 
         Bitboard black = Bitboard::fromSquare(Square(i)) >> 8;
         black |= black >> 8;
         black |= black >> 16;
         black |= black >> 32;
-        attackData.passedPawnMasks[static_cast<int>(Color::BLACK)][i] = black | black.west() | black.east();
+        attackData.passedPawnMasks[static_cast<int>(Color::BLACK)][i] =
+            black | black.west() | black.east();
 
         Bitboard file = white | black | Bitboard::fromSquare(Square(i));
         attackData.isolatedPawnMasks[i] = file.west() | file.east();
@@ -444,11 +435,10 @@ void init()
     Bitboard* currBishop = attackData.bishopAttacks.data();
     for (uint32_t square = 0; square < 64; square++)
     {
-        Bitboard rookMask =
-            (getRay(Square(square), Direction::NORTH) & ~RANK_8_BB) |
-            (getRay(Square(square), Direction::SOUTH) & ~RANK_1_BB) |
-            (getRay(Square(square), Direction::EAST) & ~FILE_H_BB) |
-            (getRay(Square(square), Direction::WEST) & ~FILE_A_BB);
+        Bitboard rookMask = (getRay(Square(square), Direction::NORTH) & ~RANK_8_BB)
+            | (getRay(Square(square), Direction::SOUTH) & ~RANK_1_BB)
+            | (getRay(Square(square), Direction::EAST) & ~FILE_H_BB)
+            | (getRay(Square(square), Direction::WEST) & ~FILE_A_BB);
 
         attackData.rookTable[square].magic = rookMagics[square];
         attackData.rookTable[square].shift = 64 - rookIndexBits[square];
@@ -458,17 +448,17 @@ void init()
         for (uint32_t i = 0; i < (1u << rookIndexBits[square]); i++)
         {
             Bitboard blockers = getMaskBlockerIdx(rookMask, i);
-            uint32_t idx = static_cast<uint32_t>((blockers.value() * rookMagics[square]) >> (64 - rookIndexBits[square]));
+            uint32_t idx = static_cast<uint32_t>(
+                (blockers.value() * rookMagics[square]) >> (64 - rookIndexBits[square]));
             attackData.rookTable[square].attackData[idx] = getRookAttacksSlow(Square(square), blockers);
             currRook++;
         }
 
-
-        Bitboard bishopMask = ~EDGE_SQUARES &
-            (getRay(Square(square), Direction::NORTH_EAST) |
-                getRay(Square(square), Direction::NORTH_WEST) |
-                getRay(Square(square), Direction::SOUTH_EAST) |
-                getRay(Square(square), Direction::SOUTH_WEST));
+        Bitboard bishopMask = ~EDGE_SQUARES
+            & (getRay(Square(square), Direction::NORTH_EAST)
+                | getRay(Square(square), Direction::NORTH_WEST)
+                | getRay(Square(square), Direction::SOUTH_EAST)
+                | getRay(Square(square), Direction::SOUTH_WEST));
 
         attackData.bishopTable[square].magic = bishopMagics[square];
         attackData.bishopTable[square].shift = 64 - bishopIndexBits[square];
@@ -477,13 +467,14 @@ void init()
         for (uint32_t i = 0; i < (1u << bishopIndexBits[square]); i++)
         {
             Bitboard blockers = getMaskBlockerIdx(bishopMask, i);
-            uint32_t idx = static_cast<uint32_t>((blockers.value() * bishopMagics[square]) >> (64 - bishopIndexBits[square]));
+            uint32_t idx = static_cast<uint32_t>(
+                (blockers.value() * bishopMagics[square]) >> (64 - bishopIndexBits[square]));
 
-            attackData.bishopTable[square].attackData[idx] = getBishopAttacksSlow(Square(square), blockers);
+            attackData.bishopTable[square].attackData[idx] =
+                getBishopAttacksSlow(Square(square), blockers);
             currBishop++;
         }
     }
 }
-
 
 }

--- a/Sirius/src/attacks.cpp
+++ b/Sirius/src/attacks.cpp
@@ -176,7 +176,7 @@ inline Bitboard& rayFrom(uint32_t idx, Direction dir)
 
 Bitboard getMaskBlockerIdx(Bitboard mask, uint32_t idx)
 {
-    Bitboard blockers = Bitboard(0);
+    Bitboard blockers = EMPTY_BB;
     while (mask.any())
     {
         Square lsb = mask.poplsb();
@@ -194,7 +194,7 @@ void initRays()
         Bitboard bb = Bitboard::fromSquare(Square(square));
 
         Bitboard tmp = bb;
-        Bitboard result = Bitboard(0);
+        Bitboard result = EMPTY_BB;
         while (tmp.any())
         {
             tmp = tmp.north();
@@ -203,7 +203,7 @@ void initRays()
         rayFrom(square, Direction::NORTH) = result;
 
         tmp = bb;
-        result = Bitboard(0);
+        result = EMPTY_BB;
         while (tmp.any())
         {
             tmp = tmp.south();
@@ -212,7 +212,7 @@ void initRays()
         rayFrom(square, Direction::SOUTH) = result;
 
         tmp = bb;
-        result = Bitboard(0);
+        result = EMPTY_BB;
         while (tmp.any())
         {
             tmp = tmp.east();
@@ -221,7 +221,7 @@ void initRays()
         rayFrom(square, Direction::EAST) = result;
 
         tmp = bb;
-        result = Bitboard(0);
+        result = EMPTY_BB;
         while (tmp.any())
         {
             tmp = tmp.west();
@@ -230,7 +230,7 @@ void initRays()
         rayFrom(square, Direction::WEST) = result;
 
         tmp = bb;
-        result = Bitboard(0);
+        result = EMPTY_BB;
         while (tmp.any())
         {
             tmp = tmp.northEast();
@@ -239,7 +239,7 @@ void initRays()
         rayFrom(square, Direction::NORTH_EAST) = result;
 
         tmp = bb;
-        result = Bitboard(0);
+        result = EMPTY_BB;
         while (tmp.any())
         {
             tmp = tmp.northWest();
@@ -248,7 +248,7 @@ void initRays()
         rayFrom(square, Direction::NORTH_WEST) = result;
 
         tmp = bb;
-        result = Bitboard(0);
+        result = EMPTY_BB;
         while (tmp.any())
         {
             tmp = tmp.southEast();
@@ -257,7 +257,7 @@ void initRays()
         rayFrom(square, Direction::SOUTH_EAST) = result;
 
         tmp = bb;
-        result = Bitboard(0);
+        result = EMPTY_BB;
         while (tmp.any())
         {
             tmp = tmp.southWest();

--- a/Sirius/src/attacks.h
+++ b/Sirius/src/attacks.h
@@ -210,7 +210,7 @@ inline Bitboard pieceAttacks(Square square, Bitboard blockers)
             return kingAttacks(square);
         // unreachable
         default:
-            return Bitboard(0);
+            return EMPTY_BB;
     }
 }
 

--- a/Sirius/src/attacks.h
+++ b/Sirius/src/attacks.h
@@ -155,18 +155,6 @@ inline Bitboard kingFlank(Color color, int file)
     return attackData.kingFlanks[static_cast<int>(color)][file];
 }
 
-template<Color color>
-inline Bitboard kingRing(Square kingSq)
-{
-    Bitboard kingAtks = attacks::kingAttacks(kingSq);
-    Bitboard kingRing = kingAtks | attacks::pawnPushes<color>(kingAtks);
-    if (FILE_H_BB.has(kingSq))
-        kingRing |= kingRing.west();
-    if (FILE_A_BB.has(kingSq))
-        kingRing |= kingRing.east();
-    return kingRing & ~Bitboard::fromSquare(kingSq);
-}
-
 inline Bitboard pawnAttacks(Color color, Square square)
 {
     return attackData.pawnAttacks[static_cast<int>(color)][square.value()];
@@ -201,6 +189,18 @@ inline Bitboard rookAttacks(Square square, Bitboard blockers)
 inline Bitboard queenAttacks(Square square, Bitboard blockers)
 {
     return bishopAttacks(square, blockers) | rookAttacks(square, blockers);
+}
+
+template<Color color>
+inline Bitboard kingRing(Square kingSq)
+{
+    Bitboard kingAtks = attacks::kingAttacks(kingSq);
+    Bitboard kingRing = kingAtks | attacks::pawnPushes<color>(kingAtks);
+    if (FILE_H_BB.has(kingSq))
+        kingRing |= kingRing.west();
+    if (FILE_A_BB.has(kingSq))
+        kingRing |= kingRing.east();
+    return kingRing & ~Bitboard::fromSquare(kingSq);
 }
 
 template<PieceType pce>

--- a/Sirius/src/attacks.h
+++ b/Sirius/src/attacks.h
@@ -149,9 +149,22 @@ inline Bitboard isolatedPawnMask(Square square)
 {
     return attackData.isolatedPawnMasks[square.value()];
 }
+
 inline Bitboard kingFlank(Color color, int file)
 {
     return attackData.kingFlanks[static_cast<int>(color)][file];
+}
+
+template<Color color>
+inline Bitboard kingRing(Square kingSq)
+{
+    Bitboard kingAtks = attacks::kingAttacks(kingSq);
+    Bitboard kingRing = kingAtks | attacks::pawnPushes<color>(kingAtks);
+    if (FILE_H_BB.has(kingSq))
+        kingRing |= kingRing.west();
+    if (FILE_A_BB.has(kingSq))
+        kingRing |= kingRing.east();
+    return kingRing & ~Bitboard::fromSquare(kingSq);
 }
 
 inline Bitboard pawnAttacks(Color color, Square square)

--- a/Sirius/src/attacks.h
+++ b/Sirius/src/attacks.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "defs.h"
 #include "bitboard.h"
+#include "defs.h"
 #include "util/multi_array.h"
 
 #include <utility>
@@ -173,14 +173,16 @@ inline Bitboard bishopAttacks(Square square, Bitboard blockers)
 {
     blockers &= attackData.bishopTable[square.value()].mask;
     uint64_t index = blockers.value() * attackData.bishopTable[square.value()].magic;
-    return attackData.bishopTable[square.value()].attackData[index >> attackData.bishopTable[square.value()].shift];
+    return attackData.bishopTable[square.value()]
+        .attackData[index >> attackData.bishopTable[square.value()].shift];
 }
 
 inline Bitboard rookAttacks(Square square, Bitboard blockers)
 {
     blockers &= attackData.rookTable[square.value()].mask;
     uint64_t index = blockers.value() * attackData.rookTable[square.value()].magic;
-    return attackData.rookTable[square.value()].attackData[index >> attackData.rookTable[square.value()].shift];
+    return attackData.rookTable[square.value()]
+        .attackData[index >> attackData.rookTable[square.value()].shift];
 }
 
 inline Bitboard queenAttacks(Square square, Bitboard blockers)
@@ -192,23 +194,24 @@ template<PieceType pce>
 inline Bitboard pieceAttacks(Square square, Bitboard blockers)
 {
     using enum PieceType;
-    static_assert(
-        pce == KNIGHT ||
-        pce == BISHOP ||
-        pce == ROOK ||
-        pce == QUEEN ||
-        pce == KING, "invalid piece type for attacks::pieceAttacks");
+    static_assert(pce == KNIGHT || pce == BISHOP || pce == ROOK || pce == QUEEN || pce == KING,
+        "invalid piece type for attacks::pieceAttacks");
     switch (pce)
     {
-        case KNIGHT: return knightAttacks(square);
-        case BISHOP: return bishopAttacks(square, blockers);
-        case ROOK: return rookAttacks(square, blockers);
-        case QUEEN: return queenAttacks(square, blockers);
-        case KING: return kingAttacks(square);
+        case KNIGHT:
+            return knightAttacks(square);
+        case BISHOP:
+            return bishopAttacks(square, blockers);
+        case ROOK:
+            return rookAttacks(square, blockers);
+        case QUEEN:
+            return queenAttacks(square, blockers);
+        case KING:
+            return kingAttacks(square);
         // unreachable
-        default: return Bitboard(0);
+        default:
+            return Bitboard(0);
     }
 }
-
 
 }

--- a/Sirius/src/bench.cpp
+++ b/Sirius/src/bench.cpp
@@ -1,6 +1,8 @@
 #include "bench.h"
 
-constexpr const char* fens[] = { // fens from stormphrax, which got them from alexandria, ultimately came from bitgenie
+// clang-format off
+// fens from stormphrax, which got them from alexandria, ultimately came from bitgenie
+constexpr const char* fens[] = {
     "r3k2r/2pb1ppp/2pp1q2/p7/1nP1B3/1P2P3/P2N1PPP/R2QK2R w KQkq a6 0 14",
     "4rrk1/2p1b1p1/p1p3q1/4p3/2P2n1p/1P1NR2P/PB3PP1/3R1QK1 b - - 2 24",
     "r3qbrk/6p1/2b2pPp/p3pP1Q/PpPpP2P/3P1B2/2PB3K/R5R1 w - - 16 42",
@@ -52,6 +54,7 @@ constexpr const char* fens[] = { // fens from stormphrax, which got them from al
     "3br1k1/p1pn3p/1p3n2/5pNq/2P1p3/1PN3PP/P2Q1PB1/4R1K1 w - - 0 23",
     "2r2b2/5p2/5k2/p1r1pP2/P2pB3/1P3P2/K1P3R1/7R w - - 23 93"
 };
+// clang-format on
 
 void runBench(search::Search& search, int depth)
 {
@@ -72,6 +75,7 @@ void runBench(search::Search& search, int depth)
 
     auto t2 = std::chrono::steady_clock::now();
 
-    double nps = static_cast<double>(nodes) / std::chrono::duration_cast<std::chrono::duration<double>>(t2 - t1).count();
+    double nps = static_cast<double>(nodes)
+        / std::chrono::duration_cast<std::chrono::duration<double>>(t2 - t1).count();
     std::cout << nodes << " nodes " << static_cast<int>(nps) << " nps" << std::endl;
 }

--- a/Sirius/src/bitboard.h
+++ b/Sirius/src/bitboard.h
@@ -71,6 +71,8 @@ constexpr Bitboard::Bitboard(uint64_t v)
 {
 }
 
+constexpr Bitboard EMPTY_BB = Bitboard(0);
+constexpr Bitboard ALL_BB = Bitboard(0xFFFFFFFFFFFFFFFFull);
 constexpr Bitboard FILE_A_BB = Bitboard(0x0101010101010101ull);
 constexpr Bitboard FILE_B_BB = Bitboard(0x0202020202020202ull);
 constexpr Bitboard FILE_C_BB = Bitboard(0x0404040404040404ull);

--- a/Sirius/src/bitboard.h
+++ b/Sirius/src/bitboard.h
@@ -1,9 +1,9 @@
 #pragma once
 
-#include <cstdint>
-#include <iostream>
 #include <bit>
 #include <bitset>
+#include <cstdint>
+#include <iostream>
 
 #if defined(_MSC_VER)
 #include <intrin.h>
@@ -61,6 +61,7 @@ public:
     static constexpr Bitboard nthRank();
 
     static constexpr Bitboard fileBB(int file);
+
 private:
     uint64_t m_Value;
 };
@@ -68,7 +69,6 @@ private:
 constexpr Bitboard::Bitboard(uint64_t v)
     : m_Value(v)
 {
-
 }
 
 constexpr Bitboard FILE_A_BB = Bitboard(0x0101010101010101ull);
@@ -156,7 +156,6 @@ constexpr Bitboard& Bitboard::operator^=(const Bitboard& other)
     m_Value ^= other.m_Value;
     return *this;
 }
-
 
 inline uint8_t reverse(uint8_t b)
 {

--- a/Sirius/src/board.cpp
+++ b/Sirius/src/board.cpp
@@ -1,12 +1,12 @@
 #include "board.h"
 #include "attacks.h"
+#include "cuckoo.h"
 #include "eval/eval_state.h"
 #include "movegen.h"
-#include "cuckoo.h"
 #include "util/string_split.h"
 
-#include <cstring>
 #include <charconv>
+#include <cstring>
 
 Board::Board()
 {
@@ -135,7 +135,8 @@ done:
         {
             m_FRC = true;
             int file = c - 'a';
-            CastleSide side = file > kingSq(color).file() ? CastleSide::KING_SIDE : CastleSide::QUEEN_SIDE;
+            CastleSide side =
+                file > kingSq(color).file() ? CastleSide::KING_SIDE : CastleSide::QUEEN_SIDE;
             m_CastlingData.setRookSquare(color, side, Square(kingSq(color).rank(), file));
             if (side == CastleSide::KING_SIDE)
             {
@@ -184,10 +185,12 @@ done:
     calcThreats();
 }
 
+// clang-format off
 constexpr std::array<char, 16> pieceChars = {
     'P', 'N', 'B', 'R', 'Q', 'K', ' ', ' ',
     'p', 'n', 'b', 'r', 'q', 'k', ' ', ' '
 };
+// clang-format on
 
 std::string Board::stringRep() const
 {
@@ -395,16 +398,20 @@ void Board::makeMove(Move move, eval::EvalState* evalState)
                 // queen side
                 removePiece(move.fromSq(), updates);
                 removePiece(move.toSq(), updates);
-                addPiece(castleKingDst(m_SideToMove, CastleSide::QUEEN_SIDE), makePiece(PieceType::KING, m_SideToMove), updates);
-                addPiece(castleRookDst(m_SideToMove, CastleSide::QUEEN_SIDE), makePiece(PieceType::ROOK, m_SideToMove), updates);
+                addPiece(castleKingDst(m_SideToMove, CastleSide::QUEEN_SIDE),
+                    makePiece(PieceType::KING, m_SideToMove), updates);
+                addPiece(castleRookDst(m_SideToMove, CastleSide::QUEEN_SIDE),
+                    makePiece(PieceType::ROOK, m_SideToMove), updates);
             }
             else
             {
                 // king side
                 removePiece(move.fromSq(), updates);
                 removePiece(move.toSq(), updates);
-                addPiece(castleKingDst(m_SideToMove, CastleSide::KING_SIDE), makePiece(PieceType::KING, m_SideToMove), updates);
-                addPiece(castleRookDst(m_SideToMove, CastleSide::KING_SIDE), makePiece(PieceType::ROOK, m_SideToMove), updates);
+                addPiece(castleKingDst(m_SideToMove, CastleSide::KING_SIDE),
+                    makePiece(PieceType::KING, m_SideToMove), updates);
+                addPiece(castleRookDst(m_SideToMove, CastleSide::KING_SIDE),
+                    makePiece(PieceType::ROOK, m_SideToMove), updates);
             }
             break;
         }
@@ -426,8 +433,6 @@ void Board::makeMove(Move move, eval::EvalState* evalState)
     currState().castlingRights &= m_CastlingData.castleRightsMask(move.toSq());
 
     currState().zkey.updateCastlingRights(currState().castlingRights);
-
-
 
     if (currState().epSquare == prev.epSquare)
         currState().epSquare = -1;
@@ -498,14 +503,13 @@ void Board::unmakeNullMove()
     m_SideToMove = ~m_SideToMove;
 }
 
-
 bool Board::is50MoveDraw() const
 {
     if (halfMoveClock() < 100)
         return false;
     if (checkers().empty())
         return true;
-    
+
     MoveList moves;
     genMoves<MoveGenType::LEGAL>(*this, moves);
     if (moves.size() == 0)
@@ -515,10 +519,7 @@ bool Board::is50MoveDraw() const
 
 bool Board::isInsufMaterialDraw() const
 {
-    Bitboard nonMinorPcs =
-        pieces(PieceType::QUEEN) |
-        pieces(PieceType::ROOK) |
-        pieces(PieceType::PAWN);
+    Bitboard nonMinorPcs = pieces(PieceType::QUEEN) | pieces(PieceType::ROOK) | pieces(PieceType::PAWN);
 
     if (nonMinorPcs.any())
         return false;
@@ -532,7 +533,9 @@ bool Board::isInsufMaterialDraw() const
         case 4:
         {
             Bitboard bishops = pieces(PieceType::BISHOP);
-            if (bishops.popcount() == 2 && ((bishops & LIGHT_SQUARES_BB).popcount() == 2 || (bishops & LIGHT_SQUARES_BB).empty()))
+            if (bishops.popcount() == 2
+                && ((bishops & LIGHT_SQUARES_BB).popcount() == 2
+                    || (bishops & LIGHT_SQUARES_BB).empty()))
                 return true;
             return false;
         }
@@ -595,11 +598,10 @@ Bitboard Board::attackersTo(Color color, Square square, Bitboard blockers) const
 {
     Bitboard queens = pieces(PieceType::QUEEN);
     Bitboard pawns = (pieces(color, PieceType::PAWN) & attacks::pawnAttacks(~color, square));
-    Bitboard nonPawns =
-        (pieces(PieceType::KNIGHT) & attacks::knightAttacks(square)) |
-        (pieces(PieceType::KING) & attacks::kingAttacks(square)) |
-        ((pieces(PieceType::BISHOP) | queens) & attacks::bishopAttacks(square, blockers)) |
-        ((pieces(PieceType::ROOK) | queens) & attacks::rookAttacks(square, blockers));
+    Bitboard nonPawns = (pieces(PieceType::KNIGHT) & attacks::knightAttacks(square))
+        | (pieces(PieceType::KING) & attacks::kingAttacks(square))
+        | ((pieces(PieceType::BISHOP) | queens) & attacks::bishopAttacks(square, blockers))
+        | ((pieces(PieceType::ROOK) | queens) & attacks::rookAttacks(square, blockers));
     return pawns | (nonPawns & pieces(color));
 }
 
@@ -607,14 +609,13 @@ Bitboard Board::attackersTo(Square square, Bitboard blockers) const
 {
     Bitboard queens = pieces(PieceType::QUEEN);
     Bitboard pawns =
-        (pieces(Color::WHITE, PieceType::PAWN) & attacks::pawnAttacks(Color::BLACK, square)) |
-        (pieces(Color::BLACK, PieceType::PAWN) & attacks::pawnAttacks(Color::WHITE, square));
+        (pieces(Color::WHITE, PieceType::PAWN) & attacks::pawnAttacks(Color::BLACK, square))
+        | (pieces(Color::BLACK, PieceType::PAWN) & attacks::pawnAttacks(Color::WHITE, square));
 
-    Bitboard nonPawns =
-        (pieces(PieceType::KNIGHT) & attacks::knightAttacks(square)) |
-        (pieces(PieceType::KING) & attacks::kingAttacks(square)) |
-        ((pieces(PieceType::BISHOP) | queens) & attacks::bishopAttacks(square, blockers)) |
-        ((pieces(PieceType::ROOK) | queens) & attacks::rookAttacks(square, blockers));
+    Bitboard nonPawns = (pieces(PieceType::KNIGHT) & attacks::knightAttacks(square))
+        | (pieces(PieceType::KING) & attacks::kingAttacks(square))
+        | ((pieces(PieceType::BISHOP) | queens) & attacks::bishopAttacks(square, blockers))
+        | ((pieces(PieceType::ROOK) | queens) & attacks::rookAttacks(square, blockers));
     return pawns | nonPawns;
 }
 
@@ -640,9 +641,8 @@ bool Board::isIsolatedPawn(Square square) const
 Bitboard Board::pinnersBlockers(Square square, Bitboard attackers, Bitboard& pinners) const
 {
     Bitboard queens = pieces(PieceType::QUEEN);
-    attackers &=
-        (attacks::rookAttacks(square, Bitboard(0)) & (pieces(PieceType::ROOK) | queens)) |
-        (attacks::bishopAttacks(square, Bitboard(0)) & (pieces(PieceType::BISHOP) | queens));
+    attackers &= (attacks::rookAttacks(square, Bitboard(0)) & (pieces(PieceType::ROOK) | queens))
+        | (attacks::bishopAttacks(square, Bitboard(0)) & (pieces(PieceType::BISHOP) | queens));
 
     Bitboard blockers = Bitboard(0);
 
@@ -796,9 +796,8 @@ bool Board::see(Move move, int margin) const
             Bitboard queen = queens.lsbBB();
             allPieces ^= queen;
             attackers ^= queen;
-            attackers |=
-                (attacks::bishopAttacks(dst, allPieces) & allPieces & diagPieces) |
-                (attacks::rookAttacks(dst, allPieces) & allPieces & straightPieces);
+            attackers |= (attacks::bishopAttacks(dst, allPieces) & allPieces & diagPieces)
+                | (attacks::rookAttacks(dst, allPieces) & allPieces & straightPieces);
 
             value = seePieceValue(PieceType::QUEEN) - value;
             if (value < static_cast<int>(us))
@@ -830,9 +829,14 @@ bool Board::isLegal(Move move) const
     if (move.type() == MoveType::ENPASSANT)
     {
         Square captureSq = to + (m_SideToMove == Color::WHITE ? -8 : 8);
-        Bitboard piecesAfter = Bitboard::fromSquare(to) | (allPieces() ^ Bitboard::fromSquare(from) ^ Bitboard::fromSquare(captureSq));
-        return (attacks::rookAttacks(kingSq(m_SideToMove), piecesAfter) & (pieces(~m_SideToMove, PieceType::ROOK) | pieces(~m_SideToMove, PieceType::QUEEN))).empty() &&
-            (attacks::bishopAttacks(kingSq(m_SideToMove), piecesAfter) & (pieces(~m_SideToMove, PieceType::BISHOP) | pieces(~m_SideToMove, PieceType::QUEEN))).empty();
+        Bitboard piecesAfter = Bitboard::fromSquare(to)
+            | (allPieces() ^ Bitboard::fromSquare(from) ^ Bitboard::fromSquare(captureSq));
+        Bitboard queens = pieces(~m_SideToMove, PieceType::QUEEN);
+        Bitboard hvSliders = pieces(~m_SideToMove, PieceType::ROOK) | queens;
+        Bitboard diagSliders = pieces(~m_SideToMove, PieceType::BISHOP) | queens;
+
+        return (attacks::rookAttacks(kingSq(m_SideToMove), piecesAfter) & hvSliders).empty()
+            && (attacks::bishopAttacks(kingSq(m_SideToMove), piecesAfter) & diagSliders).empty();
     }
 
     if (getPieceType(pieceAt(from)) == PieceType::KING)
@@ -841,7 +845,8 @@ bool Board::isLegal(Move move) const
         {
             CastleSide side = to > from ? CastleSide::KING_SIDE : CastleSide::QUEEN_SIDE;
             Square rookTo = castleRookDst(m_SideToMove, side);
-            Bitboard occ = allPieces() ^ Bitboard::fromSquare(from) ^ Bitboard::fromSquare(rookTo) ^ Bitboard::fromSquare(to);
+            Bitboard occ = allPieces() ^ Bitboard::fromSquare(from) ^ Bitboard::fromSquare(rookTo)
+                ^ Bitboard::fromSquare(to);
 
             Square kingTo = castleKingDst(m_SideToMove, side);
             if (from != kingTo)
@@ -859,9 +864,8 @@ bool Board::isLegal(Move move) const
     }
 
     // pinned pieces
-    return
-        !checkBlockers(m_SideToMove).has(move.fromSq()) ||
-        attacks::aligned(kingSq(m_SideToMove), move.fromSq(), move.toSq());
+    return !checkBlockers(m_SideToMove).has(move.fromSq())
+        || attacks::aligned(kingSq(m_SideToMove), move.fromSq(), move.toSq());
 }
 
 // move generation handles double check and check evasions, so this function also handles them
@@ -883,7 +887,8 @@ bool Board::isPseudoLegal(Move move) const
         if (srcPieceType != PieceType::KING || checkers().any())
             return false;
 
-        Bitboard firstRank = m_SideToMove == Color::WHITE ? Bitboard::nthRank<Color::WHITE, 0>() : Bitboard::nthRank<Color::BLACK, 0>();
+        Bitboard firstRank = m_SideToMove == Color::WHITE ? Bitboard::nthRank<Color::WHITE, 0>()
+                                                          : Bitboard::nthRank<Color::BLACK, 0>();
         if (!firstRank.has(move.fromSq()) || !firstRank.has(move.toSq()))
             return false;
 
@@ -907,7 +912,8 @@ bool Board::isPseudoLegal(Move move) const
         }
     }
 
-    if (dstPiece != Piece::NONE && (getPieceColor(dstPiece) == m_SideToMove || getPieceType(dstPiece) == PieceType::KING))
+    if (dstPiece != Piece::NONE
+        && (getPieceColor(dstPiece) == m_SideToMove || getPieceType(dstPiece) == PieceType::KING))
         return false;
 
     if (srcPieceType != PieceType::KING && checkers().multiple())
@@ -916,14 +922,17 @@ bool Board::isPseudoLegal(Move move) const
     if (move.type() == MoveType::CASTLE)
         return false;
 
-    Bitboard moveMask = checkers().any() && srcPieceType != PieceType::KING ? attacks::moveMask(kingSq(m_SideToMove), checkers().lsb()) : Bitboard(~0ull);
+    Bitboard moveMask = checkers().any() && srcPieceType != PieceType::KING
+        ? attacks::moveMask(kingSq(m_SideToMove), checkers().lsb())
+        : Bitboard(~0ull);
 
     if (move.type() != MoveType::ENPASSANT && !moveMask.has(move.toSq()))
         return false;
 
     if (srcPieceType == PieceType::PAWN)
     {
-        int pushOffset = m_SideToMove == Color::WHITE ? attacks::pawnPushOffset<Color::WHITE>() : attacks::pawnPushOffset<Color::BLACK>();
+        int pushOffset = m_SideToMove == Color::WHITE ? attacks::pawnPushOffset<Color::WHITE>()
+                                                      : attacks::pawnPushOffset<Color::BLACK>();
         if (move.type() == MoveType::ENPASSANT)
         {
             if (move.toSq().value() != epSquare())
@@ -939,7 +948,9 @@ bool Board::isPseudoLegal(Move move) const
             if (move.toSq() - move.fromSq() == pushOffset)
             {
                 // single
-                Bitboard seventhRank = m_SideToMove == Color::WHITE ? Bitboard::nthRank<Color::WHITE, 6>() : Bitboard::nthRank<Color::BLACK, 6>();
+                Bitboard seventhRank = m_SideToMove == Color::WHITE
+                    ? Bitboard::nthRank<Color::WHITE, 6>()
+                    : Bitboard::nthRank<Color::BLACK, 6>();
 
                 if (move.type() == MoveType::PROMOTION)
                 {
@@ -947,7 +958,8 @@ bool Board::isPseudoLegal(Move move) const
                 }
                 else
                 {
-                    return move.fromSq().value() >= 8 && move.fromSq().value() < 56 && !seventhRank.has(move.fromSq());
+                    return move.fromSq().value() >= 8 && move.fromSq().value() < 56
+                        && !seventhRank.has(move.fromSq());
                 }
             }
             else if (move.toSq() - move.fromSq() == pushOffset * 2)
@@ -957,7 +969,9 @@ bool Board::isPseudoLegal(Move move) const
                 if (pieceAt(move.fromSq() + pushOffset) != Piece::NONE)
                     return false;
                 // double
-                Bitboard secondRank = m_SideToMove == Color::WHITE ? Bitboard::nthRank<Color::WHITE, 1>() : Bitboard::nthRank<Color::BLACK, 1>();
+                Bitboard secondRank = m_SideToMove == Color::WHITE
+                    ? Bitboard::nthRank<Color::WHITE, 1>()
+                    : Bitboard::nthRank<Color::BLACK, 1>();
                 return secondRank.has(move.fromSq());
             }
             else
@@ -969,7 +983,9 @@ bool Board::isPseudoLegal(Move move) const
             if (!attacks::pawnAttacks(m_SideToMove, move.fromSq()).has(move.toSq()))
                 return false;
 
-            Bitboard seventhRank = m_SideToMove == Color::WHITE ? Bitboard::nthRank<Color::WHITE, 6>() : Bitboard::nthRank<Color::BLACK, 6>();
+            Bitboard seventhRank = m_SideToMove == Color::WHITE
+                ? Bitboard::nthRank<Color::WHITE, 6>()
+                : Bitboard::nthRank<Color::BLACK, 6>();
 
             if (move.type() == MoveType::PROMOTION)
             {
@@ -977,7 +993,8 @@ bool Board::isPseudoLegal(Move move) const
             }
             else
             {
-                return move.fromSq().value() >= 8 && move.fromSq().value() < 56 && !seventhRank.has(move.fromSq());
+                return move.fromSq().value() >= 8 && move.fromSq().value() < 56
+                    && !seventhRank.has(move.fromSq());
             }
         }
     }
@@ -1028,7 +1045,8 @@ ZKey Board::keyAfter(Move move) const
             if (dstPiece != Piece::NONE)
                 keyAfter.removePiece(getPieceType(dstPiece), getPieceColor(dstPiece), move.toSq());
 
-            keyAfter.movePiece(getPieceType(srcPiece), getPieceColor(srcPiece), move.fromSq(), move.toSq());
+            keyAfter.movePiece(
+                getPieceType(srcPiece), getPieceColor(srcPiece), move.fromSq(), move.toSq());
 
             if (getPieceType(srcPiece) == PieceType::PAWN && std::abs(move.fromSq() - move.toSq()) == 16)
                 epSquare = Square::average(move.fromSq(), move.toSq()).value();
@@ -1052,16 +1070,20 @@ ZKey Board::keyAfter(Move move) const
                 // queen side
                 keyAfter.removePiece(PieceType::KING, m_SideToMove, move.fromSq());
                 keyAfter.removePiece(PieceType::ROOK, m_SideToMove, move.toSq());
-                keyAfter.addPiece(PieceType::KING, m_SideToMove, castleKingDst(m_SideToMove, CastleSide::QUEEN_SIDE));
-                keyAfter.addPiece(PieceType::ROOK, m_SideToMove, castleRookDst(m_SideToMove, CastleSide::QUEEN_SIDE));
+                keyAfter.addPiece(PieceType::KING, m_SideToMove,
+                    castleKingDst(m_SideToMove, CastleSide::QUEEN_SIDE));
+                keyAfter.addPiece(PieceType::ROOK, m_SideToMove,
+                    castleRookDst(m_SideToMove, CastleSide::QUEEN_SIDE));
             }
             else
             {
                 // king side
                 keyAfter.removePiece(PieceType::KING, m_SideToMove, move.fromSq());
                 keyAfter.removePiece(PieceType::ROOK, m_SideToMove, move.toSq());
-                keyAfter.addPiece(PieceType::KING, m_SideToMove, castleKingDst(m_SideToMove, CastleSide::KING_SIDE));
-                keyAfter.addPiece(PieceType::ROOK, m_SideToMove, castleRookDst(m_SideToMove, CastleSide::KING_SIDE));
+                keyAfter.addPiece(PieceType::KING, m_SideToMove,
+                    castleKingDst(m_SideToMove, CastleSide::KING_SIDE));
+                keyAfter.addPiece(PieceType::ROOK, m_SideToMove,
+                    castleRookDst(m_SideToMove, CastleSide::KING_SIDE));
             }
             break;
         }
@@ -1076,10 +1098,9 @@ ZKey Board::keyAfter(Move move) const
 
     keyAfter.updateCastlingRights(currState().castlingRights);
 
-    CastlingRights newCastlingRights =
-        currState().castlingRights &
-        m_CastlingData.castleRightsMask(move.fromSq()) &
-        m_CastlingData.castleRightsMask(move.toSq());
+    CastlingRights newCastlingRights = currState().castlingRights
+        & m_CastlingData.castleRightsMask(move.fromSq())
+        & m_CastlingData.castleRightsMask(move.toSq());
 
     keyAfter.updateCastlingRights(newCastlingRights);
 
@@ -1099,10 +1120,10 @@ void Board::updateCheckInfo()
     Square kingSq = m_SideToMove == Color::WHITE ? whiteKingSq : blackKingSq;
 
     currState().checkInfo.checkers = attackersTo(~m_SideToMove, kingSq);
-    currState().checkInfo.blockers[static_cast<int>(Color::WHITE)] =
-        pinnersBlockers(whiteKingSq, pieces(Color::BLACK), currState().checkInfo.pinners[static_cast<int>(Color::WHITE)]);
-    currState().checkInfo.blockers[static_cast<int>(Color::BLACK)] =
-        pinnersBlockers(blackKingSq, pieces(Color::WHITE), currState().checkInfo.pinners[static_cast<int>(Color::BLACK)]);
+    currState().checkInfo.blockers[static_cast<int>(Color::WHITE)] = pinnersBlockers(whiteKingSq,
+        pieces(Color::BLACK), currState().checkInfo.pinners[static_cast<int>(Color::WHITE)]);
+    currState().checkInfo.blockers[static_cast<int>(Color::BLACK)] = pinnersBlockers(blackKingSq,
+        pieces(Color::WHITE), currState().checkInfo.pinners[static_cast<int>(Color::BLACK)]);
 }
 
 void Board::calcThreats()

--- a/Sirius/src/board.cpp
+++ b/Sirius/src/board.cpp
@@ -641,10 +641,10 @@ bool Board::isIsolatedPawn(Square square) const
 Bitboard Board::pinnersBlockers(Square square, Bitboard attackers, Bitboard& pinners) const
 {
     Bitboard queens = pieces(PieceType::QUEEN);
-    attackers &= (attacks::rookAttacks(square, Bitboard(0)) & (pieces(PieceType::ROOK) | queens))
-        | (attacks::bishopAttacks(square, Bitboard(0)) & (pieces(PieceType::BISHOP) | queens));
+    attackers &= (attacks::rookAttacks(square, EMPTY_BB) & (pieces(PieceType::ROOK) | queens))
+        | (attacks::bishopAttacks(square, EMPTY_BB) & (pieces(PieceType::BISHOP) | queens));
 
-    Bitboard blockers = Bitboard(0);
+    Bitboard blockers = EMPTY_BB;
 
     Bitboard blockMask = allPieces() ^ attackers;
 
@@ -924,7 +924,7 @@ bool Board::isPseudoLegal(Move move) const
 
     Bitboard moveMask = checkers().any() && srcPieceType != PieceType::KING
         ? attacks::moveMask(kingSq(m_SideToMove), checkers().lsb())
-        : Bitboard(~0ull);
+        : ALL_BB;
 
     if (move.type() != MoveType::ENPASSANT && !moveMask.has(move.toSq()))
         return false;
@@ -1129,7 +1129,7 @@ void Board::updateCheckInfo()
 void Board::calcThreats()
 {
     Color color = ~m_SideToMove;
-    Bitboard threats = Bitboard(0);
+    Bitboard threats = EMPTY_BB;
     Bitboard occupied = allPieces();
 
     Bitboard queens = pieces(color, PieceType::QUEEN);

--- a/Sirius/src/board.h
+++ b/Sirius/src/board.h
@@ -1,15 +1,15 @@
 #pragma once
 
-#include "defs.h"
 #include "bitboard.h"
-#include "zobrist.h"
-#include "util/murmur.h"
-#include "util/enum_array.h"
 #include "castling.h"
+#include "defs.h"
+#include "util/enum_array.h"
+#include "util/murmur.h"
+#include "zobrist.h"
 
-#include <string_view>
-#include <string>
 #include <array>
+#include <string>
+#include <string_view>
 #include <vector>
 
 struct CheckInfo
@@ -17,7 +17,6 @@ struct CheckInfo
     Bitboard checkers;
     std::array<Bitboard, 2> pinners;
     std::array<Bitboard, 2> blockers;
-
 };
 
 struct BoardState
@@ -54,9 +53,11 @@ struct BoardState
         else
         {
             nonPawnKeys[color].addPiece(pieceType, color, pos);
-            if (pieceType == PieceType::BISHOP || pieceType == PieceType::KNIGHT || pieceType == PieceType::KING)
+            if (pieceType == PieceType::BISHOP || pieceType == PieceType::KNIGHT
+                || pieceType == PieceType::KING)
                 minorPieceKey.addPiece(pieceType, color, pos);
-            if (pieceType == PieceType::ROOK || pieceType == PieceType::QUEEN || pieceType == PieceType::KING)
+            if (pieceType == PieceType::ROOK || pieceType == PieceType::QUEEN
+                || pieceType == PieceType::KING)
                 majorPieceKey.addPiece(pieceType, color, pos);
         }
     }
@@ -76,9 +77,11 @@ struct BoardState
         else
         {
             nonPawnKeys[color].addPiece(pieceType, color, pos);
-            if (pieceType == PieceType::BISHOP || pieceType == PieceType::KNIGHT || pieceType == PieceType::KING)
+            if (pieceType == PieceType::BISHOP || pieceType == PieceType::KNIGHT
+                || pieceType == PieceType::KING)
                 minorPieceKey.addPiece(pieceType, color, pos);
-            if (pieceType == PieceType::ROOK || pieceType == PieceType::QUEEN || pieceType == PieceType::KING)
+            if (pieceType == PieceType::ROOK || pieceType == PieceType::QUEEN
+                || pieceType == PieceType::KING)
                 majorPieceKey.addPiece(pieceType, color, pos);
         }
     }
@@ -99,9 +102,11 @@ struct BoardState
         else
         {
             nonPawnKeys[color].removePiece(pieceType, color, pos);
-            if (pieceType == PieceType::BISHOP || pieceType == PieceType::KNIGHT || pieceType == PieceType::KING)
+            if (pieceType == PieceType::BISHOP || pieceType == PieceType::KNIGHT
+                || pieceType == PieceType::KING)
                 minorPieceKey.removePiece(pieceType, color, pos);
-            if (pieceType == PieceType::ROOK || pieceType == PieceType::QUEEN || pieceType == PieceType::KING)
+            if (pieceType == PieceType::ROOK || pieceType == PieceType::QUEEN
+                || pieceType == PieceType::KING)
                 majorPieceKey.removePiece(pieceType, color, pos);
         }
     }
@@ -126,9 +131,11 @@ struct BoardState
         else
         {
             nonPawnKeys[color].movePiece(pieceType, color, src, dst);
-            if (pieceType == PieceType::BISHOP || pieceType == PieceType::KNIGHT || pieceType == PieceType::KING)
+            if (pieceType == PieceType::BISHOP || pieceType == PieceType::KNIGHT
+                || pieceType == PieceType::KING)
                 minorPieceKey.movePiece(pieceType, color, src, dst);
-            if (pieceType == PieceType::ROOK || pieceType == PieceType::QUEEN || pieceType == PieceType::KING)
+            if (pieceType == PieceType::ROOK || pieceType == PieceType::QUEEN
+                || pieceType == PieceType::KING)
                 majorPieceKey.movePiece(pieceType, color, src, dst);
         }
     }
@@ -209,6 +216,7 @@ public:
     bool isPseudoLegal(Move move) const;
     bool isLegal(Move move) const;
     ZKey keyAfter(Move move) const;
+
 private:
     template<bool updateEval>
     void makeMove(Move move, eval::EvalState* evalState);
@@ -230,9 +238,7 @@ private:
 
     int seePieceValue(PieceType type) const;
 
-    static constexpr std::array<int, 6> SEE_PIECE_VALUES = {
-        100, 450, 450, 675, 1300, 0
-    };
+    static constexpr std::array<int, 6> SEE_PIECE_VALUES = {100, 450, 450, 675, 1300, 0};
 
     std::vector<BoardState> m_States;
     CastlingData m_CastlingData;
@@ -280,7 +286,8 @@ inline bool Board::isDraw(int searchPly) const
 
 inline bool Board::is3FoldDraw(int searchPly) const
 {
-    return currState().repetitions > 1 || (currState().repetitions == 1 && currState().lastRepetition < searchPly);
+    return currState().repetitions > 1
+        || (currState().repetitions == 1 && currState().lastRepetition < searchPly);
 }
 
 inline bool Board::isFRC() const

--- a/Sirius/src/castling.h
+++ b/Sirius/src/castling.h
@@ -1,6 +1,6 @@
+#include "attacks.h"
 #include "defs.h"
 #include "util/enum_array.h"
-#include "attacks.h"
 
 enum class CastleSide
 {
@@ -57,22 +57,31 @@ public:
     void initMasks()
     {
         m_CastleRightsMasks.fill(CastlingRights::ALL);
-        m_CastleRightsMasks[m_RookSquares[Color::WHITE][CastleSide::KING_SIDE].value()] &= ~CastlingRights::WHITE_KING_SIDE;
-        m_CastleRightsMasks[m_RookSquares[Color::WHITE][CastleSide::QUEEN_SIDE].value()] &= ~CastlingRights::WHITE_QUEEN_SIDE;
-        m_CastleRightsMasks[m_KingSquares[Color::WHITE].value()] &= ~(CastlingRights::WHITE_KING_SIDE | CastlingRights::WHITE_QUEEN_SIDE);
+        m_CastleRightsMasks[m_RookSquares[Color::WHITE][CastleSide::KING_SIDE].value()] &=
+            ~CastlingRights::WHITE_KING_SIDE;
+        m_CastleRightsMasks[m_RookSquares[Color::WHITE][CastleSide::QUEEN_SIDE].value()] &=
+            ~CastlingRights::WHITE_QUEEN_SIDE;
+        m_CastleRightsMasks[m_KingSquares[Color::WHITE].value()] &=
+            ~(CastlingRights::WHITE_KING_SIDE | CastlingRights::WHITE_QUEEN_SIDE);
 
-        m_CastleRightsMasks[m_RookSquares[Color::BLACK][CastleSide::KING_SIDE].value()] &= ~CastlingRights::BLACK_KING_SIDE;
-        m_CastleRightsMasks[m_RookSquares[Color::BLACK][CastleSide::QUEEN_SIDE].value()] &= ~CastlingRights::BLACK_QUEEN_SIDE;
-        m_CastleRightsMasks[m_KingSquares[Color::BLACK].value()] &= ~(CastlingRights::BLACK_KING_SIDE | CastlingRights::BLACK_QUEEN_SIDE);
+        m_CastleRightsMasks[m_RookSquares[Color::BLACK][CastleSide::KING_SIDE].value()] &=
+            ~CastlingRights::BLACK_KING_SIDE;
+        m_CastleRightsMasks[m_RookSquares[Color::BLACK][CastleSide::QUEEN_SIDE].value()] &=
+            ~CastlingRights::BLACK_QUEEN_SIDE;
+        m_CastleRightsMasks[m_KingSquares[Color::BLACK].value()] &=
+            ~(CastlingRights::BLACK_KING_SIDE | CastlingRights::BLACK_QUEEN_SIDE);
 
         const auto setBlockSquares = [&](Color c, CastleSide s)
         {
-            Square kingDst = Square(m_KingSquares[c].rank(), s == CastleSide::KING_SIDE ? FILE_G : FILE_C);
-            Square rookDst = Square(m_RookSquares[c][s].rank(), s == CastleSide::KING_SIDE ? FILE_F : FILE_D);
-            m_BlockSquares[c][s] =
-                attacks::inBetweenSquares(m_KingSquares[c], kingDst) | Bitboard::fromSquare(kingDst) |
-                attacks::inBetweenSquares(m_RookSquares[c][s], rookDst) | Bitboard::fromSquare(rookDst);
-            m_BlockSquares[c][s] &= ~(Bitboard::fromSquare(m_KingSquares[c]) | Bitboard::fromSquare(m_RookSquares[c][s]));
+            Square kingDst =
+                Square(m_KingSquares[c].rank(), s == CastleSide::KING_SIDE ? FILE_G : FILE_C);
+            Square rookDst =
+                Square(m_RookSquares[c][s].rank(), s == CastleSide::KING_SIDE ? FILE_F : FILE_D);
+            m_BlockSquares[c][s] = attacks::inBetweenSquares(m_KingSquares[c], kingDst)
+                | attacks::inBetweenSquares(m_RookSquares[c][s], rookDst)
+                | Bitboard::fromSquare(kingDst) | Bitboard::fromSquare(rookDst);
+            m_BlockSquares[c][s] &=
+                ~(Bitboard::fromSquare(m_KingSquares[c]) | Bitboard::fromSquare(m_RookSquares[c][s]));
         };
 
         setBlockSquares(Color::WHITE, CastleSide::KING_SIDE);
@@ -80,6 +89,7 @@ public:
         setBlockSquares(Color::BLACK, CastleSide::KING_SIDE);
         setBlockSquares(Color::BLACK, CastleSide::QUEEN_SIDE);
     }
+
 private:
     ColorArray<CastleSideArray<Square>> m_RookSquares;
     ColorArray<Square> m_KingSquares;

--- a/Sirius/src/comm/book.cpp
+++ b/Sirius/src/comm/book.cpp
@@ -1,9 +1,9 @@
 #include "book.h"
-#include "move.h"
 #include "../movegen.h"
+#include "move.h"
 #include <algorithm>
-#include <deque>
 #include <cstring>
+#include <deque>
 
 void Book::loadFromPGN(const char* pgn)
 {
@@ -31,7 +31,8 @@ void Book::loadFromPGN(const char* pgn)
 
             if (it != m_Entries.end())
             {
-                if (std::find(it->second.begin(), it->second.end(), BookEntry{find.move}) == it->second.end())
+                if (std::find(it->second.begin(), it->second.end(), BookEntry{find.move})
+                    == it->second.end())
                     it->second.push_back({find.move});
             }
             else

--- a/Sirius/src/comm/book.h
+++ b/Sirius/src/comm/book.h
@@ -21,6 +21,7 @@ public:
     void loadFromPGN(const char* pgns);
 
     const std::vector<BookEntry>* lookup(ZKey key) const;
+
 private:
     std::unordered_map<uint64_t, std::vector<BookEntry>> m_Entries;
 };

--- a/Sirius/src/comm/cmdline.cpp
+++ b/Sirius/src/comm/cmdline.cpp
@@ -1,10 +1,10 @@
-#include "../sirius.h"
 #include "cmdline.h"
-#include "fen.h"
-#include "move.h"
 #include "../eval/eval.h"
 #include "../misc.h"
 #include "../movegen.h"
+#include "../sirius.h"
+#include "fen.h"
+#include "move.h"
 
 #include <fstream>
 #include <sstream>
@@ -181,7 +181,7 @@ void CmdLine::setPositionCommand(std::istringstream& stream)
         std::cout << "fen: " << fen << std::endl;
         if (!comm::isValidFen(fen))
         {
-            std::cout << "Invalid fen string" << std::endl;;
+            std::cout << "Invalid fen string" << std::endl;
             return;
         }
         setToFen(fen);
@@ -247,10 +247,10 @@ void CmdLine::staticEvalCommand()
 {
     auto lock = lockStdout();
     std::cout << "not currently supported" << std::endl;
-    //std::cout << "Eval: " << eval::evaluate(m_Board) << std::endl;
-    //std::cout << "Phase: " << m_Board.psqtState().phase << std::endl;
-    //PackedScore psqt = m_Board.psqtState().evaluate(m_Board);
-    //std::cout << "Piece Square Tables: " << psqt.mg() << ' ' << psqt.eg() << std::endl;
+    // std::cout << "Eval: " << eval::evaluate(m_Board) << std::endl;
+    // std::cout << "Phase: " << m_Board.psqtState().phase << std::endl;
+    // PackedScore psqt = m_Board.psqtState().evaluate(m_Board);
+    // std::cout << "Piece Square Tables: " << psqt.mg() << ' ' << psqt.eg() << std::endl;
 }
 
 void CmdLine::searchCommand(std::istringstream& stream)
@@ -262,7 +262,6 @@ void CmdLine::searchCommand(std::istringstream& stream)
     stream >> tok;
     if (tok == "infinite")
     {
-
     }
     else if (tok == "clock")
     {
@@ -306,7 +305,8 @@ void CmdLine::runPerftCommand(std::istringstream& stream)
     uint64_t result = perft<true>(m_Board, depth);
     auto t2 = std::chrono::steady_clock::now();
     std::cout << "Nodes: " << result << std::endl;
-    std::cout << "Time: " << std::chrono::duration_cast<std::chrono::duration<float>>(t2 - t1).count() << std::endl;
+    std::cout << "Time: " << std::chrono::duration_cast<std::chrono::duration<float>>(t2 - t1).count()
+              << std::endl;
 }
 
 void CmdLine::probeBookCommand()
@@ -325,7 +325,5 @@ void CmdLine::probeBookCommand()
         std::cout << std::endl;
     }
 }
-
-
 
 }

--- a/Sirius/src/comm/cmdline.h
+++ b/Sirius/src/comm/cmdline.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "icomm.h"
 #include "book.h"
+#include "icomm.h"
 
 namespace comm
 {
@@ -31,6 +31,7 @@ public:
     void run();
     virtual void reportSearchInfo(const SearchInfo& info) const override;
     virtual void reportBestMove(Move bestMove) const override;
+
 private:
     bool execCommand(const std::string& command);
     Command getCommand(const std::string& command) const;

--- a/Sirius/src/comm/fen.cpp
+++ b/Sirius/src/comm/fen.cpp
@@ -49,9 +49,8 @@ bool isValidFen(const char* fen)
 
     /*if (castle != "-" && castle != "K" && castle != "Q" && castle != "k" && castle != "q" &&
         castle != "KQ" && castle != "Kk" && castle != "Kq" && castle != "Qk" && castle != "Qq" &&
-        castle != "kq" && castle != "KQk" && castle != "KQq" && castle != "Kkq" && castle != "Qkq" &&
-        castle != "KQkq")
-        return false;*/
+        castle != "kq" && castle != "KQk" && castle != "KQq" && castle != "Kkq" && castle != "Qkq"
+       && castle != "KQkq") return false;*/
 
     if (ep != "-" && ep.size() != 2)
         return false;
@@ -145,7 +144,8 @@ bool isValidFen(const char* fen)
                     return false;
                 break;
             case 3:
-                if (hmc[0] < '0' || hmc[0] > '9' || hmc[1] < '0' || hmc[1] > '9' || hmc[2] < '0' || hmc[2] > '9')
+                if (hmc[0] < '0' || hmc[0] > '9' || hmc[1] < '0' || hmc[1] > '9' || hmc[2] < '0'
+                    || hmc[2] > '9')
                     return false;
                 break;
             default:
@@ -164,6 +164,5 @@ bool isValidFen(const char* fen)
 
     return true;
 }
-
 
 }

--- a/Sirius/src/comm/icomm.cpp
+++ b/Sirius/src/comm/icomm.cpp
@@ -46,5 +46,4 @@ std::unique_lock<std::mutex> IComm::lockStdout() const
     return std::unique_lock<std::mutex>(m_StdoutMutex);
 }
 
-
 }

--- a/Sirius/src/comm/icomm.h
+++ b/Sirius/src/comm/icomm.h
@@ -1,12 +1,12 @@
 #pragma once
 
 #include "../board.h"
+#include "../movegen.h"
 #include "../search.h"
 #include "../time_man.h"
-#include "../movegen.h"
 #include <deque>
-#include <vector>
 #include <string>
+#include <vector>
 
 namespace comm
 {
@@ -23,8 +23,10 @@ public:
 
     virtual void reportSearchInfo(const SearchInfo& info) const = 0;
     virtual void reportBestMove(Move bestMove) const = 0;
+
 private:
     void calcLegalMoves();
+
 protected:
     std::unique_lock<std::mutex> lockStdout() const;
 

--- a/Sirius/src/comm/move.cpp
+++ b/Sirius/src/comm/move.cpp
@@ -48,8 +48,8 @@ MoveStrFind findMoveFromUCI(const Board& board, const MoveList& legalMoves, cons
                 return {MoveStrFind::Result::FOUND, move, 4};
             }
         }
-        if (!board.isFRC() && move.fromSq() == Square(src) && move.type() == MoveType::CASTLE &&
-            (move.fromSq() > move.toSq()) == (src > dst) && std::abs(src - dst) > 1)
+        if (!board.isFRC() && move.fromSq() == Square(src) && move.type() == MoveType::CASTLE
+            && (move.fromSq() > move.toSq()) == (src > dst) && std::abs(src - dst) > 1)
         {
             return {MoveStrFind::Result::FOUND, move, 4};
         }
@@ -121,7 +121,8 @@ MoveStrFind findMoveFromSAN(const Board& board, const MoveList& legalMoves, cons
                     Move move = legalMoves[i];
                     if (move.type() == MoveType::CASTLE && move.toSq() > move.fromSq())
                     {
-                        return {MoveStrFind::Result::FOUND, move, 3 + (moveStr[3] == '+' || moveStr[3] == '#')};
+                        return {MoveStrFind::Result::FOUND, move,
+                            3 + (moveStr[3] == '+' || moveStr[3] == '#')};
                     }
                 }
                 return {MoveStrFind::Result::NOT_FOUND, Move::nullmove(), 3};
@@ -135,7 +136,8 @@ MoveStrFind findMoveFromSAN(const Board& board, const MoveList& legalMoves, cons
                     Move move = legalMoves[i];
                     if (move.type() == MoveType::CASTLE && move.toSq() < move.fromSq())
                     {
-                        return {MoveStrFind::Result::FOUND, move, 5 + (moveStr[5] == '+' || moveStr[5] == '#')};
+                        return {MoveStrFind::Result::FOUND, move,
+                            5 + (moveStr[5] == '+' || moveStr[5] == '#')};
                     }
                 }
                 return {MoveStrFind::Result::NOT_FOUND, Move::nullmove(), 5};
@@ -384,7 +386,8 @@ search_moves:
         switch (it->type())
         {
             case MoveType::ENPASSANT:
-                if (isCapture && (toRank == 2 || toRank == 5) && board.pieceAt(toSquare + pawnOffset) == Piece::NONE)
+                if (isCapture && (toRank == 2 || toRank == 5)
+                    && board.pieceAt(toSquare + pawnOffset) == Piece::NONE)
                     continue;
                 break;
             default:
@@ -424,7 +427,6 @@ search_moves:
         return {MoveStrFind::Result::NOT_FOUND, Move::nullmove(), moveLen};
 }
 
-
 std::string convMoveToUCI(const Board& board, Move move)
 {
     std::string str(4 + (move.type() == MoveType::PROMOTION), ' ');
@@ -445,7 +447,8 @@ std::string convMoveToUCI(const Board& board, Move move)
     return str;
 }
 
-bool isAmbiguous(const Board& board, const MoveList& legalMoves, PieceType piece, Square toSquare, int fromFile, int fromRank)
+bool isAmbiguous(const Board& board, const MoveList& legalMoves, PieceType piece, Square toSquare,
+    int fromFile, int fromRank)
 {
     const Move* match = nullptr;
     for (const Move* it = legalMoves.data(); it != legalMoves.data() + legalMoves.size(); it++)
@@ -573,6 +576,5 @@ std::string convMoveToSAN(const Board& board, const MoveList& legalMoves, Move m
         return str;
     }
 }
-
 
 }

--- a/Sirius/src/comm/move.h
+++ b/Sirius/src/comm/move.h
@@ -19,9 +19,9 @@ struct MoveStrFind
     int len;
     static constexpr int NO_INDEX = 256;
 
-// invalid = {nullptr, moveStr};
-// not found = {end, moveStr + moveLen};
-// ambiguous = {end + 1, moveStr + moveLen};
+    // invalid = {nullptr, moveStr};
+    // not found = {end, moveStr + moveLen};
+    // ambiguous = {end + 1, moveStr + moveLen};
 };
 
 MoveStrFind findMoveFromUCI(const Board& board, const MoveList& legalMoves, const char* moveStr);

--- a/Sirius/src/comm/uci.cpp
+++ b/Sirius/src/comm/uci.cpp
@@ -1,15 +1,15 @@
-#include <string>
 #include <algorithm>
-#include <optional>
 #include <iomanip>
+#include <optional>
+#include <string>
 
-#include "../sirius.h"
-#include "uci.h"
-#include "fen.h"
-#include "move.h"
+#include "../bench.h"
 #include "../eval/eval.h"
 #include "../misc.h"
-#include "../bench.h"
+#include "../sirius.h"
+#include "fen.h"
+#include "move.h"
+#include "uci.h"
 
 #include "../search_params.h"
 
@@ -26,22 +26,22 @@ UCI::UCI()
     {
         m_Search.setThreads(static_cast<int>(option.intValue()));
     };
-    m_Options = {
-        {"UCI_Chess960", UCIOption("UCI_Chess960", UCIOption::BoolData{false})},
+    m_Options = {{"UCI_Chess960", UCIOption("UCI_Chess960", UCIOption::BoolData{false})},
         {"Hash", UCIOption("Hash", {64, 64, 1, 33554432}, hashCallback)},
         {"Threads", UCIOption("Threads", {1, 1, 1, 2048}, threadsCallback)},
         {"MoveOverhead", UCIOption("MoveOverhead", {10, 10, 1, 100})},
-        {"PrettyPrint", UCIOption("PrettyPrint", UCIOption::BoolData{true})}
-    };
+        {"PrettyPrint", UCIOption("PrettyPrint", UCIOption::BoolData{true})}};
 #ifdef EXTERNAL_TUNE
     for (auto& param : search::searchParams())
     {
-        m_Options.insert({param.name, UCIOption(param.name, {param.value, param.defaultValue, param.min, param.max}, [&param](const UCIOption& option)
-        {
-            param.value = static_cast<int>(option.intValue());
-            if (param.callback)
-                param.callback();
-        })});
+        m_Options.insert({param.name,
+            UCIOption(param.name, {param.value, param.defaultValue, param.min, param.max},
+                [&param](const UCIOption& option)
+                {
+                    param.value = static_cast<int>(option.intValue());
+                    if (param.callback)
+                        param.callback();
+                })});
     }
 #endif
 }
@@ -76,21 +76,21 @@ void UCI::prettyPrintSearchInfo(const SearchInfo& info) const
 {
     std::cout << "  ";
     // depth/seldepth
-    std::cout
-        << std::right << std::setw(3) << std::setfill(' ') << info.depth
-        << "/" << std::left << std::setw(3) << std::setfill(' ') << info.selDepth;
+    std::cout << std::right << std::setw(3) << std::setfill(' ') << info.depth << "/" << std::left
+              << std::setw(3) << std::setfill(' ') << info.selDepth;
     std::cout << "  ";
 
     // time
     if (info.time < Duration(1000))
     {
-        std::cout << "    " << std::right << std::setw(3) << std::setfill(' ') << info.time.count() << "ms";
+        std::cout << "    " << std::right << std::setw(3) << std::setfill(' ') << info.time.count()
+                  << "ms";
     }
     else
     {
-        std::cout
-            << std::right << std::setw(4) << std::setfill(' ') << info.time.count() / 1000 << '.'
-            << std::right << std::setw(2) << std::setfill('0') << info.time.count() / 10 % 100 << "s ";
+        std::cout << std::right << std::setw(4) << std::setfill(' ') << info.time.count() / 1000
+                  << '.' << std::right << std::setw(2) << std::setfill('0')
+                  << info.time.count() / 10 % 100 << "s ";
     }
     std::cout << "  ";
 
@@ -109,11 +109,13 @@ void UCI::prettyPrintSearchInfo(const SearchInfo& info) const
     {
         if (info.score > 0)
         {
-            std::cout << "    #" << std::left << std::setw(4) << std::setfill(' ') << ((SCORE_MATE - info.score) + 1) / 2;
+            std::cout << "    #" << std::left << std::setw(4) << std::setfill(' ')
+                      << ((SCORE_MATE - info.score) + 1) / 2;
         }
         else
         {
-            std::cout << "   #-" << std::left << std::setw(4) << std::setfill(' ') << (info.score + SCORE_MATE) / 2;
+            std::cout << "   #-" << std::left << std::setw(4) << std::setfill(' ')
+                      << (info.score + SCORE_MATE) / 2;
         }
     }
     else
@@ -275,7 +277,6 @@ UCI::Command UCI::getCommand(const std::string& command) const
     return Command::INVALID;
 }
 
-
 void UCI::uciCommand() const
 {
     auto lock = lockStdout();
@@ -288,16 +289,15 @@ void UCI::uciCommand() const
         {
             case UCIOption::Type::INT:
             {
-                std::cout << "spin default " << option.second.intData().defaultValue
-                    << " min " << option.second.intData().minValue
-                    << " max " << option.second.intData().maxValue
-                    << std::endl;
+                std::cout << "spin default " << option.second.intData().defaultValue << " min "
+                          << option.second.intData().minValue << " max "
+                          << option.second.intData().maxValue << std::endl;
                 break;
             }
             case UCIOption::Type::BOOL:
             {
                 std::cout << "check default " << std::boolalpha << option.second.boolValue()
-                    << std::endl;
+                          << std::endl;
                 break;
             }
             default:
@@ -431,7 +431,6 @@ void UCI::goCommand(std::istringstream& stream)
         }
         else if (tok == "infinite")
         {
-
         }
     }
     m_Search.run(limits, m_Board);
@@ -494,7 +493,8 @@ void UCI::perftCommand(std::istringstream& stream)
     uint64_t result = perft<true>(m_Board, depth);
     auto t2 = std::chrono::steady_clock::now();
     std::cout << "Nodes: " << result << std::endl;
-    std::cout << "Time: " << std::chrono::duration_cast<std::chrono::duration<float>>(t2 - t1).count() << std::endl;
+    std::cout << "Time: " << std::chrono::duration_cast<std::chrono::duration<float>>(t2 - t1).count()
+              << std::endl;
 }
 
 void UCI::evalCommand()
@@ -513,6 +513,5 @@ void UCI::benchCommand()
 {
     runBench(m_Search, BENCH_DEPTH);
 }
-
 
 }

--- a/Sirius/src/comm/uci.h
+++ b/Sirius/src/comm/uci.h
@@ -34,10 +34,10 @@ public:
         BENCH
     };
 
-
     void run(std::string cmd);
     virtual void reportSearchInfo(const SearchInfo& info) const override;
     virtual void reportBestMove(Move bestMove) const override;
+
 private:
     void prettyPrintSearchInfo(const SearchInfo& info) const;
     void printUCISearchInfo(const SearchInfo& info) const;
@@ -56,6 +56,5 @@ private:
 
     std::unordered_map<std::string, UCIOption> m_Options;
 };
-
 
 }

--- a/Sirius/src/comm/uci_option.h
+++ b/Sirius/src/comm/uci_option.h
@@ -1,11 +1,10 @@
 #pragma once
 
-#include <variant>
+#include <cassert>
+#include <functional>
 #include <string>
 #include <string_view>
-#include <functional>
-#include <cassert>
-
+#include <variant>
 
 // currently only supports integers
 class UCIOption
@@ -43,6 +42,7 @@ public:
     bool boolValue() const;
     const IntData& intData() const;
     const std::string& name() const;
+
 private:
     Type m_Type;
     std::string m_Name;
@@ -53,19 +53,16 @@ private:
 inline UCIOption::UCIOption()
     : m_Type(Type::NONE)
 {
-
 }
 
 inline UCIOption::UCIOption(std::string_view name, IntData data, Callback callback)
     : m_Type(Type::INT), m_Name(name), m_Callback(callback), m_Data(data)
 {
-
 }
 
 inline UCIOption::UCIOption(std::string_view name, BoolData data, Callback callback)
     : m_Type(Type::BOOL), m_Name(name), m_Callback(callback), m_Data(data)
 {
-
 }
 
 inline void UCIOption::setIntValue(int64_t value)

--- a/Sirius/src/cuckoo.cpp
+++ b/Sirius/src/cuckoo.cpp
@@ -35,13 +35,13 @@ void init()
                             pieceAttacks = attacks::knightAttacks(Square(from));
                             break;
                         case PieceType::BISHOP:
-                            pieceAttacks = attacks::bishopAttacks(Square(from), Bitboard(0));
+                            pieceAttacks = attacks::bishopAttacks(Square(from), EMPTY_BB);
                             break;
                         case PieceType::ROOK:
-                            pieceAttacks = attacks::rookAttacks(Square(from), Bitboard(0));
+                            pieceAttacks = attacks::rookAttacks(Square(from), EMPTY_BB);
                             break;
                         case PieceType::QUEEN:
-                            pieceAttacks = attacks::queenAttacks(Square(from), Bitboard(0));
+                            pieceAttacks = attacks::queenAttacks(Square(from), EMPTY_BB);
                             break;
                         case PieceType::KING:
                             pieceAttacks = attacks::kingAttacks(Square(from));

--- a/Sirius/src/cuckoo.cpp
+++ b/Sirius/src/cuckoo.cpp
@@ -1,6 +1,6 @@
 #include "cuckoo.h"
-#include "zobrist.h"
 #include "attacks.h"
+#include "zobrist.h"
 
 namespace cuckoo
 {
@@ -12,10 +12,10 @@ namespace cuckoo
 
 void init()
 {
-	moves.fill(Move::nullmove());
-	keyDiffs.fill(0);
+    moves.fill(Move::nullmove());
+    keyDiffs.fill(0);
 
-	uint32_t count = 0;
+    uint32_t count = 0;
 
     using enum Color;
     using enum PieceType;

--- a/Sirius/src/cuckoo.h
+++ b/Sirius/src/cuckoo.h
@@ -11,13 +11,12 @@ void init();
 
 constexpr uint64_t H1(uint64_t keyDiff)
 {
-	return keyDiff % 8192;
+    return keyDiff % 8192;
 }
 
 constexpr uint64_t H2(uint64_t keyDiff)
 {
-	return (keyDiff >> 16) % 8192;
+    return (keyDiff >> 16) % 8192;
 }
-
 
 }

--- a/Sirius/src/defs.h
+++ b/Sirius/src/defs.h
@@ -466,25 +466,25 @@ constexpr int CastlingRights::value() const
     return static_cast<int>(m_Value);
 }
 
-struct PackedScore
+struct ScorePair
 {
 public:
-    constexpr PackedScore() = default;
-    constexpr PackedScore(int mg, int eg);
-    constexpr PackedScore& operator+=(const PackedScore& other);
-    constexpr PackedScore& operator-=(const PackedScore& other);
+    constexpr ScorePair() = default;
+    constexpr ScorePair(int mg, int eg);
+    constexpr ScorePair& operator+=(const ScorePair& other);
+    constexpr ScorePair& operator-=(const ScorePair& other);
 
     constexpr int mg() const;
     constexpr int eg() const;
 
-    friend constexpr PackedScore operator+(const PackedScore& a, const PackedScore& b);
-    friend constexpr PackedScore operator-(const PackedScore& a, const PackedScore& b);
-    friend constexpr PackedScore operator-(const PackedScore& p);
-    friend constexpr PackedScore operator*(int a, const PackedScore& b);
-    friend constexpr PackedScore operator*(const PackedScore& a, int b);
+    friend constexpr ScorePair operator+(const ScorePair& a, const ScorePair& b);
+    friend constexpr ScorePair operator-(const ScorePair& a, const ScorePair& b);
+    friend constexpr ScorePair operator-(const ScorePair& p);
+    friend constexpr ScorePair operator*(int a, const ScorePair& b);
+    friend constexpr ScorePair operator*(const ScorePair& a, int b);
 
 private:
-    constexpr PackedScore(int value)
+    constexpr ScorePair(int value)
         : m_Value(value)
     {
     }
@@ -492,54 +492,54 @@ private:
     int32_t m_Value;
 };
 
-constexpr PackedScore::PackedScore(int mg, int eg)
+constexpr ScorePair::ScorePair(int mg, int eg)
     : m_Value((static_cast<int32_t>(static_cast<uint32_t>(eg) << 16) + mg))
 {
 }
 
-constexpr PackedScore& PackedScore::operator+=(const PackedScore& other)
+constexpr ScorePair& ScorePair::operator+=(const ScorePair& other)
 {
     m_Value += other.m_Value;
     return *this;
 }
 
-constexpr PackedScore& PackedScore::operator-=(const PackedScore& other)
+constexpr ScorePair& ScorePair::operator-=(const ScorePair& other)
 {
     m_Value -= other.m_Value;
     return *this;
 }
 
-constexpr int PackedScore::mg() const
+constexpr int ScorePair::mg() const
 {
     return static_cast<int16_t>(m_Value);
 }
 
-constexpr int PackedScore::eg() const
+constexpr int ScorePair::eg() const
 {
     return static_cast<int16_t>(static_cast<uint32_t>(m_Value + 0x8000) >> 16);
 }
 
-constexpr PackedScore operator+(const PackedScore& a, const PackedScore& b)
+constexpr ScorePair operator+(const ScorePair& a, const ScorePair& b)
 {
-    return PackedScore(a.m_Value + b.m_Value);
+    return ScorePair(a.m_Value + b.m_Value);
 }
 
-constexpr PackedScore operator-(const PackedScore& a, const PackedScore& b)
+constexpr ScorePair operator-(const ScorePair& a, const ScorePair& b)
 {
-    return PackedScore(a.m_Value - b.m_Value);
+    return ScorePair(a.m_Value - b.m_Value);
 }
 
-constexpr PackedScore operator-(const PackedScore& p)
+constexpr ScorePair operator-(const ScorePair& p)
 {
-    return PackedScore(-p.m_Value);
+    return ScorePair(-p.m_Value);
 }
 
-constexpr PackedScore operator*(int a, const PackedScore& b)
+constexpr ScorePair operator*(int a, const ScorePair& b)
 {
-    return PackedScore(a * b.m_Value);
+    return ScorePair(a * b.m_Value);
 }
 
-constexpr PackedScore operator*(const PackedScore& a, int b)
+constexpr ScorePair operator*(const ScorePair& a, int b)
 {
-    return PackedScore(a.m_Value * b);
+    return ScorePair(a.m_Value * b);
 }

--- a/Sirius/src/defs.h
+++ b/Sirius/src/defs.h
@@ -1,11 +1,10 @@
 #pragma once
 
-#include <cstdint>
-#include <iostream>
-#include <bitset>
 #include <bit>
+#include <bitset>
 #include <cassert>
 #include <cstdint>
+#include <iostream>
 
 enum class PieceType
 {
@@ -29,7 +28,8 @@ constexpr Color operator~(const Color& c)
     return static_cast<Color>(static_cast<int>(c) ^ 1);
 }
 
-enum class Piece : uint8_t {
+enum class Piece : uint8_t
+{
     NONE = static_cast<int>(PieceType::NONE)
 };
 
@@ -47,7 +47,6 @@ inline Color getPieceColor(Piece piece)
 {
     return static_cast<Color>(static_cast<int>(piece) >> 3);
 }
-
 
 enum class MoveType
 {
@@ -68,11 +67,7 @@ enum class Promotion
 inline PieceType promoPiece(Promotion promo)
 {
     static const PieceType promoPieces[4] = {
-        PieceType::KNIGHT,
-        PieceType::BISHOP,
-        PieceType::ROOK,
-        PieceType::QUEEN
-    };
+        PieceType::KNIGHT, PieceType::BISHOP, PieceType::ROOK, PieceType::QUEEN};
 
     return promoPieces[static_cast<int>(promo) >> 14];
 }
@@ -85,7 +80,6 @@ constexpr int RANK_5 = 4;
 constexpr int RANK_6 = 5;
 constexpr int RANK_7 = 6;
 constexpr int RANK_8 = 7;
-
 
 constexpr int FILE_A = 0;
 constexpr int FILE_B = 1;
@@ -135,6 +129,7 @@ public:
     static constexpr int chebyshev(Square a, Square b);
     static constexpr int manhattan(Square a, Square b);
     static constexpr Square average(Square a, Square b);
+
 private:
     uint8_t m_Value;
 };
@@ -148,7 +143,6 @@ constexpr Square::Square(int sq)
 constexpr Square::Square(int rank, int file)
     : m_Value(static_cast<uint8_t>(rank * 8 + file))
 {
-
 }
 
 constexpr Square& Square::operator+=(int other)
@@ -306,6 +300,7 @@ public:
     int fromTo() const;
     MoveType type() const;
     Promotion promotion() const;
+
 private:
     static constexpr int TYPE_MASK = 3 << 12;
     static constexpr int PROMOTION_MASK = 3 << 14;
@@ -321,7 +316,8 @@ inline Move::Move(Square from, Square to, MoveType type)
 inline Move::Move(Square from, Square to, MoveType type, Promotion promotion)
     : m_Data(0)
 {
-    m_Data = static_cast<uint16_t>(from.value() | (to.value() << 6) | static_cast<int>(type) | static_cast<int>(promotion));
+    m_Data = static_cast<uint16_t>(
+        from.value() | (to.value() << 6) | static_cast<int>(type) | static_cast<int>(promotion));
 }
 
 constexpr Move Move::nullmove()
@@ -401,18 +397,21 @@ public:
     constexpr bool has(Internal v) const;
 
     constexpr int value() const;
+
 private:
     Internal m_Value;
 };
 
 constexpr CastlingRights operator&(CastlingRights::Internal a, CastlingRights::Internal b)
 {
-    return CastlingRights(static_cast<CastlingRights::Internal>(static_cast<int>(a) & static_cast<int>(b)));
+    return CastlingRights(
+        static_cast<CastlingRights::Internal>(static_cast<int>(a) & static_cast<int>(b)));
 }
 
 constexpr CastlingRights operator|(CastlingRights::Internal a, CastlingRights::Internal b)
 {
-    return CastlingRights(static_cast<CastlingRights::Internal>(static_cast<int>(a) | static_cast<int>(b)));
+    return CastlingRights(
+        static_cast<CastlingRights::Internal>(static_cast<int>(a) | static_cast<int>(b)));
 }
 
 constexpr CastlingRights operator~(CastlingRights::Internal a)
@@ -423,13 +422,11 @@ constexpr CastlingRights operator~(CastlingRights::Internal a)
 constexpr CastlingRights::CastlingRights()
     : m_Value(Internal::NONE)
 {
-
 }
 
 constexpr CastlingRights::CastlingRights(Internal v)
     : m_Value(v)
 {
-
 }
 
 constexpr CastlingRights& CastlingRights::operator&=(const CastlingRights& other)
@@ -485,6 +482,7 @@ public:
     friend constexpr PackedScore operator-(const PackedScore& p);
     friend constexpr PackedScore operator*(int a, const PackedScore& b);
     friend constexpr PackedScore operator*(const PackedScore& a, int b);
+
 private:
     constexpr PackedScore(int value)
         : m_Value(value)
@@ -497,7 +495,6 @@ private:
 constexpr PackedScore::PackedScore(int mg, int eg)
     : m_Value((static_cast<int32_t>(static_cast<uint32_t>(eg) << 16) + mg))
 {
-
 }
 
 constexpr PackedScore& PackedScore::operator+=(const PackedScore& other)

--- a/Sirius/src/eval/combined_psqt.h
+++ b/Sirius/src/eval/combined_psqt.h
@@ -10,9 +10,9 @@
 namespace eval
 {
 
-constexpr auto init()
+constexpr auto initPsqt()
 {
-    MultiArray<PackedScore, 2, 2, 6, 64> combined = {};
+    MultiArray<ScorePair, 2, 2, 6, 64> combined = {};
     for (int bucket = 0; bucket < 2; bucket++)
         for (int piece = 0; piece < 6; piece++)
             for (int sq = 0; sq < 64; sq++)
@@ -25,9 +25,9 @@ constexpr auto init()
     return combined;
 }
 
-constexpr auto combinedPsqt = init();
+constexpr auto combinedPsqt = initPsqt();
 
-inline PackedScore combinedPsqtScore(int bucket, Color color, PieceType piece, Square square)
+inline ScorePair combinedPsqtScore(int bucket, Color color, PieceType piece, Square square)
 {
     return combinedPsqt[bucket][static_cast<int>(color)][static_cast<int>(piece)][square.value()];
 }

--- a/Sirius/src/eval/combined_psqt.h
+++ b/Sirius/src/eval/combined_psqt.h
@@ -1,9 +1,9 @@
 #pragma once
 
 #include "../defs.h"
+#include "../util/multi_array.h"
 #include "combined_psqt.h"
 #include "eval_constants.h"
-#include "../util/multi_array.h"
 
 #include <array>
 
@@ -18,7 +18,8 @@ constexpr auto init()
             for (int sq = 0; sq < 64; sq++)
             {
                 int mirror = bucket * 0b111;
-                combined[bucket][0][piece][sq] = (MATERIAL[piece] + PSQT[piece][sq ^ 0b111000 ^ mirror]);
+                combined[bucket][0][piece][sq] =
+                    (MATERIAL[piece] + PSQT[piece][sq ^ 0b111000 ^ mirror]);
                 combined[bucket][1][piece][sq] = -(MATERIAL[piece] + PSQT[piece][sq ^ mirror]);
             }
     return combined;
@@ -30,6 +31,5 @@ inline PackedScore combinedPsqtScore(int bucket, Color color, PieceType piece, S
 {
     return combinedPsqt[bucket][static_cast<int>(color)][static_cast<int>(piece)][square.value()];
 }
-
 
 }

--- a/Sirius/src/eval/endgame.cpp
+++ b/Sirius/src/eval/endgame.cpp
@@ -226,6 +226,7 @@ ColorArray<Endgame> scaleKPsvKEndgames = {
     Endgame(Color::WHITE, &scaleKPsvK, EndgameType::SCALE),
     Endgame(Color::BLACK, &scaleKPsvK, EndgameType::SCALE)
 };
+// clang-format on
 
 const Endgame* probeEvalFunc(const Board& board)
 {

--- a/Sirius/src/eval/endgame.cpp
+++ b/Sirius/src/eval/endgame.cpp
@@ -1,6 +1,6 @@
 #include "endgame.h"
-#include "eval_constants.h"
 #include "../attacks.h"
+#include "eval_constants.h"
 
 #include <algorithm>
 
@@ -34,10 +34,10 @@ int evalKXvK(const Board& board, const EvalState& evalState, Color strongSide)
 
     int result = evalState.psqtScore(board, strongSide).eg() + 13 * 20 - 20 * kingDist - 20 * cornerDist;
 
-    if (board.pieces(PieceType::QUEEN).any() ||
-        board.pieces(PieceType::ROOK).any() ||
-        (board.pieces(PieceType::BISHOP).any() && board.pieces(PieceType::KNIGHT).any()) ||
-        ((board.pieces(PieceType::BISHOP) & LIGHT_SQUARES_BB).any() && (board.pieces(PieceType::BISHOP) & DARK_SQUARES_BB).any()))
+    if (board.pieces(PieceType::QUEEN).any() || board.pieces(PieceType::ROOK).any()
+        || (board.pieces(PieceType::BISHOP).any() && board.pieces(PieceType::KNIGHT).any())
+        || ((board.pieces(PieceType::BISHOP) & LIGHT_SQUARES_BB).any()
+            && (board.pieces(PieceType::BISHOP) & DARK_SQUARES_BB).any()))
         result += 10000;
 
     return result;
@@ -78,11 +78,11 @@ int evalKQvKP(const Board& board, const EvalState&, Color strongSide)
     if (queeningSquares.has(queen) || queeningSquares.has(ourKing))
         eval += 10000;
 
-    if (pawn.relativeRank(weakSide) < RANK_7 ||
-        (FILE_B_BB | FILE_D_BB | FILE_E_BB | FILE_G_BB).has(pawn) ||
-        eval >= 10000)
+    if (pawn.relativeRank(weakSide) < RANK_7
+        || (FILE_B_BB | FILE_D_BB | FILE_E_BB | FILE_G_BB).has(pawn) || eval >= 10000)
     {
-        eval += MATERIAL[static_cast<int>(PieceType::QUEEN)].eg() - MATERIAL[static_cast<int>(PieceType::PAWN)].eg();
+        eval += MATERIAL[static_cast<int>(PieceType::QUEEN)].eg()
+            - MATERIAL[static_cast<int>(PieceType::PAWN)].eg();
     }
 
     return eval;
@@ -126,7 +126,8 @@ int scaleKBPsvK(const Board& board, const EvalState&, Color strongSide)
     if ((strongPawns & ~FILE_A_BB).empty() || (strongPawns & ~FILE_H_BB).empty())
     {
         Square queeningSquare = Square(queeningRank, strongPawns.lsb().file());
-        if (queeningSquare.darkSquare() != bishop.darkSquare() && Square::chebyshev(weakKing, queeningSquare) <= 1)
+        if (queeningSquare.darkSquare() != bishop.darkSquare()
+            && Square::chebyshev(weakKing, queeningSquare) <= 1)
             return SCALE_FACTOR_DRAW;
     }
     return SCALE_FACTOR_NORMAL;
@@ -139,8 +140,16 @@ Key genMaterialKey(std::string white, std::string black)
     assert(white.length() < 8);
     assert(black.length() < 8);
 
-    std::transform(white.begin(), white.end(), white.begin(), [](auto c) { return std::toupper(c); });
-    std::transform(black.begin(), black.end(), black.begin(), [](auto c) { return std::tolower(c); });
+    std::transform(white.begin(), white.end(), white.begin(),
+        [](auto c)
+        {
+            return std::toupper(c);
+        });
+    std::transform(black.begin(), black.end(), black.begin(),
+        [](auto c)
+        {
+            return std::tolower(c);
+        });
 
     std::string fen;
     fen += black;
@@ -175,7 +184,8 @@ void addEndgameEval(const std::string& strongCode, const std::string& weakCode, 
 {
     insertEndgame(genMaterialKey(strongCode, weakCode), Endgame(Color::WHITE, func, EndgameType::EVAL));
     if (strongCode != weakCode)
-        insertEndgame(genMaterialKey(weakCode, strongCode), Endgame(Color::BLACK, func, EndgameType::EVAL));
+        insertEndgame(
+            genMaterialKey(weakCode, strongCode), Endgame(Color::BLACK, func, EndgameType::EVAL));
 }
 
 bool isKXvK(const Board& board, Color strongSide)
@@ -184,10 +194,8 @@ bool isKXvK(const Board& board, Color strongSide)
         return false;
 
     Bitboard minors = board.pieces(PieceType::BISHOP) | board.pieces(PieceType::KNIGHT);
-    return
-        board.pieces(PieceType::QUEEN).any() ||
-        board.pieces(PieceType::ROOK).any() ||
-        minors.multiple();
+    return board.pieces(PieceType::QUEEN).any() || board.pieces(PieceType::ROOK).any()
+        || minors.multiple();
 }
 
 bool isKPsvK(const Board& board, Color strongSide)
@@ -203,16 +211,20 @@ bool isKBPsvK(const Board& board, Color strongSide)
     return (board.pieces(strongSide) ^ bishops ^ pawns).one() && bishops.one() && pawns.any();
 }
 
+// clang-format off
 ColorArray<Endgame> evalKXvKEndgames = {
-    Endgame(Color::WHITE, &evalKXvK, EndgameType::EVAL), Endgame(Color::BLACK, &evalKXvK, EndgameType::EVAL)
+    Endgame(Color::WHITE, &evalKXvK, EndgameType::EVAL),
+    Endgame(Color::BLACK, &evalKXvK, EndgameType::EVAL)
 };
 
 ColorArray<Endgame> scaleKBPsvKEndgames = {
-    Endgame(Color::WHITE, &scaleKBPsvK, EndgameType::SCALE), Endgame(Color::BLACK, &scaleKBPsvK, EndgameType::SCALE)
+    Endgame(Color::WHITE, &scaleKBPsvK, EndgameType::SCALE),
+    Endgame(Color::BLACK, &scaleKBPsvK, EndgameType::SCALE)
 };
 
 ColorArray<Endgame> scaleKPsvKEndgames = {
-    Endgame(Color::WHITE, &scaleKPsvK, EndgameType::SCALE), Endgame(Color::BLACK, &scaleKPsvK, EndgameType::SCALE)
+    Endgame(Color::WHITE, &scaleKPsvK, EndgameType::SCALE),
+    Endgame(Color::BLACK, &scaleKPsvK, EndgameType::SCALE)
 };
 
 const Endgame* probeEvalFunc(const Board& board)
@@ -260,6 +272,5 @@ void init()
     addEndgameEval("KQ", "KP", &evalKQvKP);
     addEndgameEval("KQ", "KR", &evalKQvKR);
 }
-
 
 }

--- a/Sirius/src/eval/endgame.h
+++ b/Sirius/src/eval/endgame.h
@@ -7,7 +7,6 @@ namespace eval
 constexpr int SCALE_FACTOR_NORMAL = 128;
 constexpr int SCALE_FACTOR_DRAW = 0;
 
-
 }
 
 namespace eval::endgames
@@ -26,12 +25,10 @@ struct Endgame
     Endgame()
         : func(nullptr), strongSide(Color::WHITE), key(0), type(EndgameType::EVAL)
     {
-
     }
     explicit Endgame(Color c, EndgameFunc* func, EndgameType type)
         : func(func), strongSide(c), key(0), type(type)
     {
-
     }
 
     int operator()(const Board& board, const EvalState& evalState) const

--- a/Sirius/src/eval/eval.cpp
+++ b/Sirius/src/eval/eval.cpp
@@ -1,8 +1,8 @@
 #include "eval.h"
 #include "../attacks.h"
 #include "../util/enum_array.h"
-#include "pawn_structure.h"
 #include "endgame.h"
+#include "pawn_structure.h"
 
 namespace eval
 {
@@ -30,18 +30,16 @@ PackedScore evaluatePieces(const Board& board, EvalData& evalData)
 
     PackedScore eval{0, 0};
     Bitboard pieces = board.pieces(us, piece);
-    if constexpr (piece == BISHOP)
-        if (pieces.multiple())
-            eval += BISHOP_PAIR;
+    if (piece == BISHOP && pieces.multiple())
+        eval += BISHOP_PAIR;
 
     Bitboard occupancy = board.allPieces();
-    if constexpr (piece == BISHOP)
+    if (piece == BISHOP)
         occupancy ^= board.pieces(us, BISHOP) | board.pieces(us, QUEEN);
-    else if constexpr (piece == ROOK)
+    else if (piece == ROOK)
         occupancy ^= board.pieces(us, ROOK) | board.pieces(us, QUEEN);
-    else if constexpr (piece == QUEEN)
+    else if (piece == QUEEN)
         occupancy ^= board.pieces(us, BISHOP) | board.pieces(us, ROOK);
-
 
     while (pieces.any())
     {
@@ -54,11 +52,13 @@ PackedScore evaluatePieces(const Board& board, EvalData& evalData)
         evalData.attackedBy2[us] |= evalData.attacked[us] & attacks;
         evalData.attacked[us] |= attacks;
 
-        eval += MOBILITY[static_cast<int>(piece) - static_cast<int>(KNIGHT)][(attacks & evalData.mobilityArea[us]).popcount()];
+        eval += MOBILITY[static_cast<int>(piece) - static_cast<int>(KNIGHT)]
+                        [(attacks & evalData.mobilityArea[us]).popcount()];
 
         if (Bitboard kingRingAtks = evalData.kingRing[them] & attacks; kingRingAtks.any())
         {
-            evalData.attackWeight[us] += KING_ATTACKER_WEIGHT[static_cast<int>(piece) - static_cast<int>(KNIGHT)];
+            evalData.attackWeight[us] +=
+                KING_ATTACKER_WEIGHT[static_cast<int>(piece) - static_cast<int>(KNIGHT)];
             evalData.attackCount[us] += kingRingAtks.popcount();
         }
 
@@ -76,10 +76,8 @@ PackedScore evaluateThreats(const Board& board, const EvalData& evalData)
 
     PackedScore eval{0, 0};
 
-    Bitboard defendedBB =
-        evalData.attackedBy2[them] |
-        evalData.attackedBy[them][PAWN] |
-        (evalData.attacked[them] & ~evalData.attackedBy2[us]);
+    Bitboard defendedBB = evalData.attackedBy2[them] | evalData.attackedBy[them][PAWN]
+        | (evalData.attacked[them] & ~evalData.attackedBy2[us]);
 
     Bitboard pawnThreats = evalData.attackedBy[us][PAWN] & board.pieces(them);
     while (pawnThreats.any())
@@ -133,16 +131,18 @@ PackedScore evaluateThreats(const Board& board, const EvalData& evalData)
 
     Bitboard nonPawnEnemies = board.pieces(them) & ~board.pieces(PAWN);
 
-    Bitboard safe = ~defendedBB | (evalData.attacked[us] & ~evalData.attackedBy[them][PAWN] & ~evalData.attackedBy2[them]);
+    Bitboard safe = ~defendedBB
+        | (evalData.attacked[us] & ~evalData.attackedBy[them][PAWN] & ~evalData.attackedBy2[them]);
     Bitboard pushes = attacks::pawnPushes<us>(board.pieces(us, PAWN)) & ~board.allPieces();
     pushes |= attacks::pawnPushes<us>(pushes & Bitboard::nthRank<us, RANK_3>()) & ~board.allPieces();
 
     Bitboard pushThreats = attacks::pawnAttacks<us>(pushes & safe) & nonPawnEnemies;
     eval += PUSH_THREAT * pushThreats.popcount();
 
-    Bitboard restriction = evalData.attackedBy2[us] & ~evalData.attackedBy2[them] & evalData.attacked[them];
+    Bitboard restriction =
+        evalData.attackedBy2[us] & ~evalData.attackedBy2[them] & evalData.attacked[them];
     eval += RESTRICTED_SQUARES * restriction.popcount();
-    
+
     Bitboard oppQueens = board.pieces(them, PieceType::QUEEN);
     if (oppQueens.one())
     {
@@ -153,11 +153,14 @@ PackedScore evaluateThreats(const Board& board, const EvalData& evalData)
 
         Bitboard targets = safe & ~board.pieces(us, PieceType::PAWN);
 
-        eval += KNIGHT_HIT_QUEEN * (targets & knightHits & evalData.attackedBy[us][PieceType::KNIGHT]).popcount();
+        eval += KNIGHT_HIT_QUEEN
+            * (targets & knightHits & evalData.attackedBy[us][PieceType::KNIGHT]).popcount();
 
         targets &= evalData.attackedBy2[us];
-        eval += BISHOP_HIT_QUEEN * (targets & bishopHits & evalData.attackedBy[us][PieceType::BISHOP]).popcount();
-        eval += ROOK_HIT_QUEEN * (targets & rookHits & evalData.attackedBy[us][PieceType::ROOK]).popcount();
+        eval += BISHOP_HIT_QUEEN
+            * (targets & bishopHits & evalData.attackedBy[us][PieceType::BISHOP]).popcount();
+        eval += ROOK_HIT_QUEEN
+            * (targets & rookHits & evalData.attackedBy[us][PieceType::ROOK]).popcount();
     }
 
     return eval;
@@ -187,7 +190,8 @@ PackedScore evaluateKings(const Board& board, const EvalData& evalData, const Ev
     Bitboard rookChecks = evalData.attackedBy[us][ROOK] & rookCheckSquares;
     Bitboard queenChecks = evalData.attackedBy[us][QUEEN] & (bishopCheckSquares | rookCheckSquares);
 
-    Bitboard weak = ~evalData.attacked[them] | (~evalData.attackedBy2[them] & evalData.attackedBy[them][KING]);
+    Bitboard weak =
+        ~evalData.attacked[them] | (~evalData.attackedBy2[them] & evalData.attackedBy[them][KING]);
     Bitboard safe = ~board.pieces(us) & (~evalData.attacked[them] | (weak & evalData.attackedBy2[us]));
 
     eval += SAFE_KNIGHT_CHECK * (knightChecks & safe).popcount();
@@ -217,8 +221,10 @@ PackedScore evaluateKings(const Board& board, const EvalData& evalData, const Ev
     Bitboard flankDefenses = evalData.kingFlank[them] & evalData.attacked[them];
     Bitboard flankDefenses2 = evalData.kingFlank[them] & evalData.attackedBy2[them];
 
-    eval += flankAttacks.popcount() * KING_FLANK_ATTACKS[0] + flankAttacks2.popcount() * KING_FLANK_ATTACKS[1];
-    eval += flankDefenses.popcount() * KING_FLANK_DEFENSES[0] + flankDefenses2.popcount() * KING_FLANK_DEFENSES[1];
+    eval += flankAttacks.popcount() * KING_FLANK_ATTACKS[0]
+        + flankAttacks2.popcount() * KING_FLANK_ATTACKS[1];
+    eval += flankDefenses.popcount() * KING_FLANK_DEFENSES[0]
+        + flankDefenses2.popcount() * KING_FLANK_DEFENSES[1];
 
     eval += SAFETY_OFFSET;
 
@@ -227,7 +233,8 @@ PackedScore evaluateKings(const Board& board, const EvalData& evalData, const Ev
 }
 
 template<Color us>
-PackedScore evaluatePassedPawns(const Board& board, const PawnStructure& pawnStructure, const EvalData& evalData)
+PackedScore evaluatePassedPawns(
+    const Board& board, const PawnStructure& pawnStructure, const EvalData& evalData)
 {
     constexpr Color them = ~us;
     Square ourKing = board.kingSq(us);
@@ -265,11 +272,9 @@ PackedScore evaluateComplexity(const Board& board, const PawnStructure& pawnStru
     bool pawnsBothSides = (pawns & KING_SIDE).any() && (pawns & QUEEN_SIDE).any();
     bool pawnEndgame = board.allPieces() == (pawns | board.pieces(KING));
 
-    PackedScore complexity =
-        COMPLEXITY_PAWNS * pawns.popcount() +
-        COMPLEXITY_PAWNS_BOTH_SIDES * pawnsBothSides +
-        COMPLEXITY_PAWN_ENDGAME * pawnEndgame +
-        COMPLEXITY_OFFSET;
+    PackedScore complexity = COMPLEXITY_PAWNS * pawns.popcount()
+        + COMPLEXITY_PAWNS_BOTH_SIDES * pawnsBothSides + COMPLEXITY_PAWN_ENDGAME * pawnEndgame
+        + COMPLEXITY_OFFSET;
 
     int egSign = (eval.eg() > 0) - (eval.eg() < 0);
 
@@ -302,14 +307,16 @@ void initEvalData(const Board& board, EvalData& evalData, const PawnStructure& p
     Bitboard blockedPawns = ourPawns & attacks::pawnPushes<them>(board.allPieces());
     Square ourKing = board.kingSq(us);
 
-    evalData.mobilityArea[us] = ~pawnStructure.pawnAttacks[them] & ~Bitboard::fromSquare(ourKing) & ~blockedPawns;
+    evalData.mobilityArea[us] =
+        ~pawnStructure.pawnAttacks[them] & ~Bitboard::fromSquare(ourKing) & ~blockedPawns;
     evalData.attacked[us] = evalData.attackedBy[us][PAWN] = pawnStructure.pawnAttacks[us];
 
     Bitboard ourKingAtks = attacks::kingAttacks(ourKing);
     evalData.attackedBy[us][KING] = ourKingAtks;
     evalData.attackedBy2[us] = evalData.attacked[us] & ourKingAtks;
     evalData.attacked[us] |= ourKingAtks;
-    evalData.kingRing[us] = (ourKingAtks | attacks::pawnPushes<us>(ourKingAtks)) & ~Bitboard::fromSquare(ourKing);
+    evalData.kingRing[us] =
+        (ourKingAtks | attacks::pawnPushes<us>(ourKingAtks)) & ~Bitboard::fromSquare(ourKing);
     if (FILE_H_BB.has(ourKing))
         evalData.kingRing[us] |= evalData.kingRing[us].west();
     if (FILE_A_BB.has(ourKing))
@@ -318,7 +325,9 @@ void initEvalData(const Board& board, EvalData& evalData, const PawnStructure& p
     evalData.kingFlank[us] = attacks::kingFlank(us, ourKing.file());
 }
 
-void nonIncrementalEval(const Board& board, const EvalState& evalState, const PawnStructure& pawnStructure, EvalData& evalData, PackedScore& eval)
+// clang-format off
+void nonIncrementalEval(const Board& board, const EvalState& evalState,
+    const PawnStructure& pawnStructure, EvalData& evalData, PackedScore& eval)
 {
     eval += evaluatePieces<WHITE, KNIGHT>(board, evalData) - evaluatePieces<BLACK, KNIGHT>(board, evalData);
     eval += evaluatePieces<WHITE, BISHOP>(board, evalData) - evaluatePieces<BLACK, BISHOP>(board, evalData);
@@ -352,7 +361,11 @@ int evaluate(const Board& board, search::SearchThread* thread)
 
     eval += (color == WHITE ? TEMPO : -TEMPO);
 
-    return (color == WHITE ? 1 : -1) * eval::getFullEval(eval.mg(), eval.eg() * scale / SCALE_FACTOR_NORMAL, thread->evalState.phase());
+    int mg = eval.mg();
+    int eg = eval.eg() * scale / SCALE_FACTOR_NORMAL;
+    int phase = thread->evalState.phase();
+
+    return (color == WHITE ? 1 : -1) * eval::getFullEval(mg, eg, phase);
 }
 
 int evaluateSingle(const Board& board)
@@ -379,8 +392,11 @@ int evaluateSingle(const Board& board)
 
     eval += (color == WHITE ? TEMPO : -TEMPO);
 
-    return (color == WHITE ? 1 : -1) * eval::getFullEval(eval.mg(), eval.eg() * scale / SCALE_FACTOR_NORMAL, evalState.phase());
-}
+    int mg = eval.mg();
+    int eg = eval.eg() * scale / SCALE_FACTOR_NORMAL;
+    int phase = evalState.phase();
 
+    return (color == WHITE ? 1 : -1) * eval::getFullEval(mg, eg, phase);
+}
 
 }

--- a/Sirius/src/eval/eval.cpp
+++ b/Sirius/src/eval/eval.cpp
@@ -315,13 +315,7 @@ void initEvalData(const Board& board, EvalData& evalData, const PawnStructure& p
     evalData.attackedBy[us][KING] = ourKingAtks;
     evalData.attackedBy2[us] = evalData.attacked[us] & ourKingAtks;
     evalData.attacked[us] |= ourKingAtks;
-    evalData.kingRing[us] =
-        (ourKingAtks | attacks::pawnPushes<us>(ourKingAtks)) & ~Bitboard::fromSquare(ourKing);
-    if (FILE_H_BB.has(ourKing))
-        evalData.kingRing[us] |= evalData.kingRing[us].west();
-    if (FILE_A_BB.has(ourKing))
-        evalData.kingRing[us] |= evalData.kingRing[us].east();
-
+    evalData.kingRing[us] = attacks::kingRing<us>(ourKing);
     evalData.kingFlank[us] = attacks::kingFlank(us, ourKing.file());
 }
 
@@ -339,6 +333,7 @@ void nonIncrementalEval(const Board& board, const EvalState& evalState,
     eval += evaluateThreats<WHITE>(board, evalData) - evaluateThreats<BLACK>(board, evalData);
     eval += evaluateComplexity(board, pawnStructure, eval);
 }
+// clang-format on
 
 int evaluate(const Board& board, search::SearchThread* thread)
 {

--- a/Sirius/src/eval/eval.h
+++ b/Sirius/src/eval/eval.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include "phase.h"
-#include "../search.h"
 #include "../board.h"
+#include "../search.h"
+#include "phase.h"
 
 namespace eval
 {

--- a/Sirius/src/eval/eval_constants.h
+++ b/Sirius/src/eval/eval_constants.h
@@ -6,11 +6,11 @@ namespace eval
 {
 
 // clang-format off
-#define S(mg, eg) PackedScore(mg, eg)
+#define S(mg, eg) ScorePair(mg, eg)
 
-constexpr PackedScore MATERIAL[6] = {S(  61,  131), S( 286,  431), S( 306,  444), S( 386,  789), S( 745, 1618), S(0, 0)};
+constexpr ScorePair MATERIAL[6] = {S(  61,  131), S( 286,  431), S( 306,  444), S( 386,  789), S( 745, 1618), S(0, 0)};
 
-constexpr PackedScore PSQT[6][64] = {
+constexpr ScorePair PSQT[6][64] = {
     {
         S(   0,    0), S(   0,    0), S(   0,    0), S(   0,    0), S(   0,    0), S(   0,    0), S(   0,    0), S(   0,    0),
         S(  54,   79), S(  37,   90), S(  21,  101), S(  55,   77), S(  73,   61), S(  57,   76), S(  47,   95), S(  68,   77),
@@ -73,48 +73,48 @@ constexpr PackedScore PSQT[6][64] = {
     },
 };
 
-constexpr PackedScore MOBILITY[4][28] = {
+constexpr ScorePair MOBILITY[4][28] = {
     {S(  -3,  -29), S( -39,  -47), S( -18,  -16), S(  -9,    0), S(   1,    9), S(   6,   19), S(  13,   22), S(  20,   26), S(  29,   19), S(   0,    0), S(   0,    0), S(   0,    0), S(   0,    0), S(   0,    0), S(   0,    0), S(   0,    0), S(   0,    0), S(   0,    0), S(   0,    0), S(   0,    0), S(   0,    0), S(   0,    0), S(   0,    0), S(   0,    0), S(   0,    0), S(   0,    0), S(   0,    0), S(   0,    0)},
     {S( -10,  -46), S( -30,  -61), S( -18,  -32), S( -11,  -14), S(  -3,   -4), S(   2,    6), S(   4,   15), S(   7,   19), S(   7,   21), S(   9,   22), S(  10,   22), S(  14,   17), S(  12,   23), S(  17,    4), S(   0,    0), S(   0,    0), S(   0,    0), S(   0,    0), S(   0,    0), S(   0,    0), S(   0,    0), S(   0,    0), S(   0,    0), S(   0,    0), S(   0,    0), S(   0,    0), S(   0,    0), S(   0,    0)},
     {S( -12,  -44), S( -29,  -70), S( -14,  -53), S(  -2,  -31), S(   0,  -17), S(  -2,   -6), S(  -1,    2), S(   1,    8), S(   3,   11), S(   6,   17), S(   3,   27), S(   4,   34), S(   6,   38), S(   9,   39), S(  16,   36), S(   0,    0), S(   0,    0), S(   0,    0), S(   0,    0), S(   0,    0), S(   0,    0), S(   0,    0), S(   0,    0), S(   0,    0), S(   0,    0), S(   0,    0), S(   0,    0), S(   0,    0)},
     {S(   0,    8), S( -32,  -72), S( -61, -112), S( -19, -198), S( -24,  -63), S( -16,  -11), S(  -6,  -23), S(  -4,   -5), S(  -3,   13), S(   0,   22), S(   2,   25), S(   6,   28), S(   6,   38), S(  10,   37), S(  10,   43), S(  12,   44), S(  13,   46), S(  15,   47), S(  15,   46), S(  21,   38), S(  25,   29), S(  31,   13), S(  28,   18), S(  34,   -5), S(  34,   -8), S(   9,   -7), S( -13,  -11), S(-116,   10)}
 };
 
-constexpr PackedScore THREAT_BY_PAWN[6] = {S(   4,  -20), S(  66,   28), S(  60,   60), S(  81,   24), S(  72,   -2), S(   0,    0)};
-constexpr PackedScore THREAT_BY_KNIGHT[2][6] = {
+constexpr ScorePair THREAT_BY_PAWN[6] = {S(   4,  -20), S(  66,   28), S(  60,   60), S(  81,   24), S(  72,   -2), S(   0,    0)};
+constexpr ScorePair THREAT_BY_KNIGHT[2][6] = {
     {S(   3,   28), S(  14,   36), S(  35,   43), S(  73,   13), S(  53,  -30), S(   0,    0)},
     {S(  -7,    9), S(   6,   36), S(  29,   29), S(  64,   34), S(  60,   -1), S(   0,    0)}
 };
-constexpr PackedScore THREAT_BY_BISHOP[2][6] = {
+constexpr ScorePair THREAT_BY_BISHOP[2][6] = {
     {S(  -3,   34), S(  38,   32), S( -15,   36), S(  67,   15), S(  68,   44), S(   0,    0)},
     {S(  -4,    6), S(  17,   22), S( -26,  -11), S(  44,   44), S(  47,  111), S(   0,    0)}
 };
-constexpr PackedScore THREAT_BY_ROOK[2][6] = {
+constexpr ScorePair THREAT_BY_ROOK[2][6] = {
     {S(  -2,   40), S(  15,   57), S(  25,   53), S( -13,  -28), S(  60,   13), S(   0,    0)},
     {S(  -8,    7), S(   1,   15), S(  14,    3), S( -12,  -66), S(  42,   62), S(   0,    0)}
 };
-constexpr PackedScore THREAT_BY_QUEEN[2][6] = {
+constexpr ScorePair THREAT_BY_QUEEN[2][6] = {
     {S(   6,    5), S(  23,   19), S(  10,   42), S(  14,    2), S(  10,  -56), S(  99,   54)},
     {S(  -3,   12), S(   0,    8), S(  -5,   15), S(  -3,    3), S( -15,  -74), S( 118,   53)}
 };
-constexpr PackedScore THREAT_BY_KING[6] = {S( -14,   43), S(   8,   48), S(  28,   41), S(  83,    8), S(   0,    0), S(   0,    0)};
-constexpr PackedScore KNIGHT_HIT_QUEEN = S(  10,    3);
-constexpr PackedScore BISHOP_HIT_QUEEN = S(  16,    9);
-constexpr PackedScore ROOK_HIT_QUEEN = S(  18,   -5);
-constexpr PackedScore PUSH_THREAT = S(  14,   18);
-constexpr PackedScore RESTRICTED_SQUARES = S(   2,    3);
+constexpr ScorePair THREAT_BY_KING[6] = {S( -14,   43), S(   8,   48), S(  28,   41), S(  83,    8), S(   0,    0), S(   0,    0)};
+constexpr ScorePair KNIGHT_HIT_QUEEN = S(  10,    3);
+constexpr ScorePair BISHOP_HIT_QUEEN = S(  16,    9);
+constexpr ScorePair ROOK_HIT_QUEEN = S(  18,   -5);
+constexpr ScorePair PUSH_THREAT = S(  14,   18);
+constexpr ScorePair RESTRICTED_SQUARES = S(   2,    3);
 
-constexpr PackedScore ISOLATED_PAWN[8] = {S(  -8,    6), S(  -3,  -16), S( -12,   -8), S( -10,  -16), S( -12,  -14), S(  -8,   -7), S(  -4,  -14), S( -12,    7)};
-constexpr PackedScore DOUBLED_PAWN[8] = {S(   0,  -61), S(  13,  -37), S(   0,  -27), S(  -2,  -17), S(  -5,  -12), S(  -8,  -20), S(   5,  -38), S(   6,  -71)};
-constexpr PackedScore BACKWARDS_PAWN[8] = {S(   0,    0), S(  -8,  -12), S(  -2,  -14), S(  -7,  -12), S(   1,  -18), S(  32,  -13), S(   0,    0), S(   0,    0)};
-constexpr PackedScore PAWN_PHALANX[8] = {S(   0,    0), S(   5,   -4), S(  11,   -2), S(  20,    8), S(  39,   41), S( 117,  213), S(   6,  340), S(   0,    0)};
-constexpr PackedScore DEFENDED_PAWN[8] = {S(   0,    0), S(   0,    0), S(  18,    6), S(  11,    8), S(  17,   21), S(  33,   64), S( 141,   76), S(   0,    0)};
-constexpr PackedScore CANDIDATE_PASSER[2][8] = {
+constexpr ScorePair ISOLATED_PAWN[8] = {S(  -8,    6), S(  -3,  -16), S( -12,   -8), S( -10,  -16), S( -12,  -14), S(  -8,   -7), S(  -4,  -14), S( -12,    7)};
+constexpr ScorePair DOUBLED_PAWN[8] = {S(   0,  -61), S(  13,  -37), S(   0,  -27), S(  -2,  -17), S(  -5,  -12), S(  -8,  -20), S(   5,  -38), S(   6,  -71)};
+constexpr ScorePair BACKWARDS_PAWN[8] = {S(   0,    0), S(  -8,  -12), S(  -2,  -14), S(  -7,  -12), S(   1,  -18), S(  32,  -13), S(   0,    0), S(   0,    0)};
+constexpr ScorePair PAWN_PHALANX[8] = {S(   0,    0), S(   5,   -4), S(  11,   -2), S(  20,    8), S(  39,   41), S( 117,  213), S(   6,  340), S(   0,    0)};
+constexpr ScorePair DEFENDED_PAWN[8] = {S(   0,    0), S(   0,    0), S(  18,    6), S(  11,    8), S(  17,   21), S(  33,   64), S( 141,   76), S(   0,    0)};
+constexpr ScorePair CANDIDATE_PASSER[2][8] = {
     {S(   0,    0), S( -31,  -17), S( -18,   -7), S(   0,   26), S(  25,   52), S(  65,  114), S(   0,    0), S(   0,    0)},
     {S(   0,    0), S( -17,  -10), S(  -8,   14), S(  -4,   28), S(  18,   41), S(  26,  181), S(   0,    0), S(   0,    0)}
 };
 
-constexpr PackedScore PASSED_PAWN[2][2][8] = {
+constexpr ScorePair PASSED_PAWN[2][2][8] = {
     {
         {S(   0,    0), S(   0,    0), S(   0,    0), S( -36,  -41), S( -16,   22), S(  11,  159), S(  67,  218), S(   0,    0)},
         {S(   0,    0), S(   0,    0), S(   0,    0), S( -22,  -53), S(   3,  -20), S(  37,   41), S(  70,   25), S(   0,    0)}
@@ -124,10 +124,10 @@ constexpr PackedScore PASSED_PAWN[2][2][8] = {
         {S(   0,    0), S(   0,    0), S(   0,    0), S( -30,  -56), S(  -7,  -24), S(  16,   19), S(  -9,  -11), S(   0,    0)}
     }
 };
-constexpr PackedScore OUR_PASSER_PROXIMITY[8] = {S(  79,   98), S(  71,  100), S(  46,   72), S(   6,   58), S(   5,   38), S(   7,   25), S(  12,   17), S(  -8,   24)};
-constexpr PackedScore THEIR_PASSER_PROXIMITY[8] = {S( -44,  -10), S(  -2,    3), S(  25,    0), S(  20,   31), S(  14,   64), S(  18,   78), S(  25,   80), S(  30,   69)};
+constexpr ScorePair OUR_PASSER_PROXIMITY[8] = {S(  79,   98), S(  71,  100), S(  46,   72), S(   6,   58), S(   5,   38), S(   7,   25), S(  12,   17), S(  -8,   24)};
+constexpr ScorePair THEIR_PASSER_PROXIMITY[8] = {S( -44,  -10), S(  -2,    3), S(  25,    0), S(  20,   31), S(  14,   64), S(  18,   78), S(  25,   80), S(  30,   69)};
 
-constexpr PackedScore PAWN_STORM[2][4][8] = {
+constexpr ScorePair PAWN_STORM[2][4][8] = {
     {
         {S(  40,   36), S(-110,  -51), S( -40,  -35), S(  59,    1), S(  27,   21), S(  -1,   30), S( -10,   30), S(   0,    0)},
         {S(  32,    6), S(  43, -124), S(  92,  -83), S(  58,  -20), S(  16,   -2), S( -21,    8), S(   4,    6), S(   0,    0)},
@@ -141,41 +141,41 @@ constexpr PackedScore PAWN_STORM[2][4][8] = {
         {S(   0,    0), S(   0,    0), S(  87,   17), S(  16,   25), S( -25,   25), S( -24,   22), S(  -3,   17), S(   0,    0)}
     }
 };
-constexpr PackedScore PAWN_SHIELD[4][8] = {
+constexpr ScorePair PAWN_SHIELD[4][8] = {
     {S(  46,   36), S( -20,   51), S( -12,   41), S(  39,   30), S(  44,   16), S( -27,   -2), S( -67,  -19), S(   0,    0)},
     {S(  49,    9), S( -24,   19), S(   9,    7), S(  53,   -1), S(  43,  -16), S(  14,  -20), S( -42,  -32), S(   0,    0)},
     {S(  22,   -3), S(  15,  118), S(  12,   -2), S(  34,  -22), S(  23,  -20), S(  -6,  -26), S( -59,  -42), S(   0,    0)},
     {S(  14,   16), S(   2,   12), S(   1,   10), S(  27,    4), S(  33,    1), S(   8,    5), S( -84,    7), S(   0,    0)}
 };
-constexpr PackedScore SAFE_KNIGHT_CHECK = S( 109,    7);
-constexpr PackedScore SAFE_BISHOP_CHECK = S(  71,   18);
-constexpr PackedScore SAFE_ROOK_CHECK = S( 115,   15);
-constexpr PackedScore SAFE_QUEEN_CHECK = S(  55,   26);
-constexpr PackedScore UNSAFE_KNIGHT_CHECK = S(  16,    2);
-constexpr PackedScore UNSAFE_BISHOP_CHECK = S(  38,   10);
-constexpr PackedScore UNSAFE_ROOK_CHECK = S(  39,    3);
-constexpr PackedScore UNSAFE_QUEEN_CHECK = S(  15,    4);
-constexpr PackedScore QUEENLESS_ATTACK = S(-145,  145);
-constexpr PackedScore KING_ATTACKER_WEIGHT[4] = {S(  56,   -4), S(  21,    0), S(  29,  -13), S(   4,   -9)};
-constexpr PackedScore KING_ATTACKS = S(   7,    0);
-constexpr PackedScore WEAK_KING_RING = S(   8,   -1);
-constexpr PackedScore KING_FLANK_ATTACKS[2] = {S(  12,   -3), S(   5,   -1)};
-constexpr PackedScore KING_FLANK_DEFENSES[2] = {S(  -7,    0), S(  -8,    3)};
-constexpr PackedScore SAFETY_OFFSET = S(  78,  207);
+constexpr ScorePair SAFE_KNIGHT_CHECK = S( 109,    7);
+constexpr ScorePair SAFE_BISHOP_CHECK = S(  71,   18);
+constexpr ScorePair SAFE_ROOK_CHECK = S( 115,   15);
+constexpr ScorePair SAFE_QUEEN_CHECK = S(  55,   26);
+constexpr ScorePair UNSAFE_KNIGHT_CHECK = S(  16,    2);
+constexpr ScorePair UNSAFE_BISHOP_CHECK = S(  38,   10);
+constexpr ScorePair UNSAFE_ROOK_CHECK = S(  39,    3);
+constexpr ScorePair UNSAFE_QUEEN_CHECK = S(  15,    4);
+constexpr ScorePair QUEENLESS_ATTACK = S(-145,  145);
+constexpr ScorePair KING_ATTACKER_WEIGHT[4] = {S(  56,   -4), S(  21,    0), S(  29,  -13), S(   4,   -9)};
+constexpr ScorePair KING_ATTACKS = S(   7,    0);
+constexpr ScorePair WEAK_KING_RING = S(   8,   -1);
+constexpr ScorePair KING_FLANK_ATTACKS[2] = {S(  12,   -3), S(   5,   -1)};
+constexpr ScorePair KING_FLANK_DEFENSES[2] = {S(  -7,    0), S(  -8,    3)};
+constexpr ScorePair SAFETY_OFFSET = S(  78,  207);
 
-constexpr PackedScore MINOR_BEHIND_PAWN = S(   5,   12);
-constexpr PackedScore KNIGHT_OUTPOST = S(  23,   16);
-constexpr PackedScore BISHOP_PAWNS[7] = {S(   4,   20), S(   5,   19), S(   4,   11), S(   1,    4), S(  -2,   -5), S(  -2,  -18), S(  -5,  -30)};
-constexpr PackedScore BISHOP_PAIR = S(  19,   60);
-constexpr PackedScore LONG_DIAG_BISHOP = S(  15,    8);
-constexpr PackedScore ROOK_OPEN[2] = {S(  24,    3), S(  12,    5)};
+constexpr ScorePair MINOR_BEHIND_PAWN = S(   5,   12);
+constexpr ScorePair KNIGHT_OUTPOST = S(  23,   16);
+constexpr ScorePair BISHOP_PAWNS[7] = {S(   4,   20), S(   5,   19), S(   4,   11), S(   1,    4), S(  -2,   -5), S(  -2,  -18), S(  -5,  -30)};
+constexpr ScorePair BISHOP_PAIR = S(  19,   60);
+constexpr ScorePair LONG_DIAG_BISHOP = S(  15,    8);
+constexpr ScorePair ROOK_OPEN[2] = {S(  24,    3), S(  12,    5)};
 
-constexpr PackedScore TEMPO = S(  32,   34);
+constexpr ScorePair TEMPO = S(  32,   34);
 
-constexpr PackedScore COMPLEXITY_PAWNS = S(   0,   10);
-constexpr PackedScore COMPLEXITY_PAWNS_BOTH_SIDES = S(   0,   63);
-constexpr PackedScore COMPLEXITY_PAWN_ENDGAME = S(   0,   80);
-constexpr PackedScore COMPLEXITY_OFFSET = S(   0, -134);
+constexpr ScorePair COMPLEXITY_PAWNS = S(   0,   10);
+constexpr ScorePair COMPLEXITY_PAWNS_BOTH_SIDES = S(   0,   63);
+constexpr ScorePair COMPLEXITY_PAWN_ENDGAME = S(   0,   80);
+constexpr ScorePair COMPLEXITY_OFFSET = S(   0, -134);
 
 #undef S
 // clang-format on

--- a/Sirius/src/eval/eval_constants.h
+++ b/Sirius/src/eval/eval_constants.h
@@ -5,6 +5,7 @@
 namespace eval
 {
 
+// clang-format off
 #define S(mg, eg) PackedScore(mg, eg)
 
 constexpr PackedScore MATERIAL[6] = {S(  61,  131), S( 286,  431), S( 306,  444), S( 386,  789), S( 745, 1618), S(0, 0)};
@@ -177,6 +178,6 @@ constexpr PackedScore COMPLEXITY_PAWN_ENDGAME = S(   0,   80);
 constexpr PackedScore COMPLEXITY_OFFSET = S(   0, -134);
 
 #undef S
-
+// clang-format on
 
 }

--- a/Sirius/src/eval/eval_state.cpp
+++ b/Sirius/src/eval/eval_state.cpp
@@ -117,14 +117,14 @@ void EvalState::pop()
     m_CurrEntry--;
 }
 
-PackedScore EvalState::score(const Board& board) const
+ScorePair EvalState::score(const Board& board) const
 {
     return currEntry().psqtState.evaluate(board) + currEntry().pawnStructure.score
         + currEntry().knightOutposts + currEntry().bishopPawns + currEntry().rookOpen
         + currEntry().minorBehindPawn;
 }
 
-PackedScore EvalState::psqtScore(const Board& board, Color c) const
+ScorePair EvalState::psqtScore(const Board& board, Color c) const
 {
     auto psqt = currEntry().psqtState.evaluate(board);
     if (c == Color::BLACK)
@@ -132,7 +132,7 @@ PackedScore EvalState::psqtScore(const Board& board, Color c) const
     return psqt;
 }
 
-PackedScore EvalState::pawnShieldStormScore(Color c) const
+ScorePair EvalState::pawnShieldStormScore(Color c) const
 {
     return currEntry().pawnShieldStorm[c];
 }

--- a/Sirius/src/eval/eval_state.cpp
+++ b/Sirius/src/eval/eval_state.cpp
@@ -33,28 +33,30 @@ void EvalState::init(const Board& board, PawnTable* pawnTable)
 
     currEntry().psqtState.init();
     for (Color c : {WHITE, BLACK})
+    {
         for (PieceType pt : {PAWN, KNIGHT, BISHOP, ROOK, QUEEN, KING})
         {
             Bitboard pieces = board.pieces(c, pt);
             while (pieces.any())
                 currEntry().psqtState.addPiece(c, pt, pieces.poplsb());
         }
+    }
 
     evaluatePawns(board, currEntry().pawnStructure, m_PawnTable);
-    currEntry().pawnShieldStorm[Color::WHITE] = evaluateStormShield<Color::WHITE>(board);
-    currEntry().pawnShieldStorm[Color::BLACK] = evaluateStormShield<Color::BLACK>(board);
-    currEntry().knightOutposts = evaluateKnightOutposts<Color::WHITE>(board, currEntry().pawnStructure)
-        - evaluateKnightOutposts<Color::BLACK>(board, currEntry().pawnStructure);
-    currEntry().bishopPawns =
-        evaluateBishopPawns<Color::WHITE>(board) - evaluateBishopPawns<Color::BLACK>(board);
-    currEntry().rookOpen =
-        evaluateRookOpen<Color::WHITE>(board) - evaluateRookOpen<Color::BLACK>(board);
+    currEntry().pawnShieldStorm[WHITE] = evaluateStormShield<WHITE>(board);
+    currEntry().pawnShieldStorm[BLACK] = evaluateStormShield<BLACK>(board);
+    currEntry().knightOutposts = evaluateKnightOutposts<WHITE>(board, currEntry().pawnStructure)
+        - evaluateKnightOutposts<BLACK>(board, currEntry().pawnStructure);
+    currEntry().bishopPawns = evaluateBishopPawns<WHITE>(board) - evaluateBishopPawns<BLACK>(board);
+    currEntry().rookOpen = evaluateRookOpen<WHITE>(board) - evaluateRookOpen<BLACK>(board);
     currEntry().minorBehindPawn =
-        evaluateMinorBehindPawn<Color::WHITE>(board) - evaluateMinorBehindPawn<Color::BLACK>(board);
+        evaluateMinorBehindPawn<WHITE>(board) - evaluateMinorBehindPawn<BLACK>(board);
 }
 
 void EvalState::push(const Board& board, const EvalUpdates& updates)
 {
+    using enum Color;
+
     const auto& oldEntry = currEntry();
     m_CurrEntry++;
 
@@ -80,34 +82,31 @@ void EvalState::push(const Board& board, const EvalUpdates& updates)
 
     if (updates.changedPieces.hasAny(eval_terms::pawnShieldStorm.deps))
     {
-        currEntry().pawnShieldStorm[Color::WHITE] = evaluateStormShield<Color::WHITE>(board);
-        currEntry().pawnShieldStorm[Color::BLACK] = evaluateStormShield<Color::BLACK>(board);
+        currEntry().pawnShieldStorm[WHITE] = evaluateStormShield<WHITE>(board);
+        currEntry().pawnShieldStorm[BLACK] = evaluateStormShield<BLACK>(board);
     }
     else
         currEntry().pawnShieldStorm = oldEntry.pawnShieldStorm;
 
     if (updates.changedPieces.hasAny(eval_terms::knightOutposts.deps))
-        currEntry().knightOutposts =
-            evaluateKnightOutposts<Color::WHITE>(board, currEntry().pawnStructure)
-            - evaluateKnightOutposts<Color::BLACK>(board, currEntry().pawnStructure);
+        currEntry().knightOutposts = evaluateKnightOutposts<WHITE>(board, currEntry().pawnStructure)
+            - evaluateKnightOutposts<BLACK>(board, currEntry().pawnStructure);
     else
         currEntry().knightOutposts = oldEntry.knightOutposts;
 
     if (updates.changedPieces.hasAny(eval_terms::bishopPawns.deps))
-        currEntry().bishopPawns =
-            evaluateBishopPawns<Color::WHITE>(board) - evaluateBishopPawns<Color::BLACK>(board);
+        currEntry().bishopPawns = evaluateBishopPawns<WHITE>(board) - evaluateBishopPawns<BLACK>(board);
     else
         currEntry().bishopPawns = oldEntry.bishopPawns;
 
     if (updates.changedPieces.hasAny(eval_terms::rookOpen.deps))
-        currEntry().rookOpen =
-            evaluateRookOpen<Color::WHITE>(board) - evaluateRookOpen<Color::BLACK>(board);
+        currEntry().rookOpen = evaluateRookOpen<WHITE>(board) - evaluateRookOpen<BLACK>(board);
     else
         currEntry().rookOpen = oldEntry.rookOpen;
 
     if (updates.changedPieces.hasAny(eval_terms::minorBehindPawn.deps))
-        currEntry().minorBehindPawn = evaluateMinorBehindPawn<Color::WHITE>(board)
-            - evaluateMinorBehindPawn<Color::BLACK>(board);
+        currEntry().minorBehindPawn =
+            evaluateMinorBehindPawn<WHITE>(board) - evaluateMinorBehindPawn<BLACK>(board);
     else
         currEntry().minorBehindPawn = oldEntry.minorBehindPawn;
 }

--- a/Sirius/src/eval/eval_state.cpp
+++ b/Sirius/src/eval/eval_state.cpp
@@ -1,6 +1,6 @@
 #include "eval_state.h"
-#include "eval_terms.h"
 #include "../board.h"
+#include "eval_terms.h"
 #include <algorithm>
 
 namespace eval
@@ -43,12 +43,14 @@ void EvalState::init(const Board& board, PawnTable* pawnTable)
     evaluatePawns(board, currEntry().pawnStructure, m_PawnTable);
     currEntry().pawnShieldStorm[Color::WHITE] = evaluateStormShield<Color::WHITE>(board);
     currEntry().pawnShieldStorm[Color::BLACK] = evaluateStormShield<Color::BLACK>(board);
-    currEntry().knightOutposts =
-        evaluateKnightOutposts<Color::WHITE>(board, currEntry().pawnStructure) -
-        evaluateKnightOutposts<Color::BLACK>(board, currEntry().pawnStructure);
-    currEntry().bishopPawns = evaluateBishopPawns<Color::WHITE>(board) - evaluateBishopPawns<Color::BLACK>(board);
-    currEntry().rookOpen = evaluateRookOpen<Color::WHITE>(board) - evaluateRookOpen<Color::BLACK>(board);
-    currEntry().minorBehindPawn = evaluateMinorBehindPawn<Color::WHITE>(board) - evaluateMinorBehindPawn<Color::BLACK>(board);
+    currEntry().knightOutposts = evaluateKnightOutposts<Color::WHITE>(board, currEntry().pawnStructure)
+        - evaluateKnightOutposts<Color::BLACK>(board, currEntry().pawnStructure);
+    currEntry().bishopPawns =
+        evaluateBishopPawns<Color::WHITE>(board) - evaluateBishopPawns<Color::BLACK>(board);
+    currEntry().rookOpen =
+        evaluateRookOpen<Color::WHITE>(board) - evaluateRookOpen<Color::BLACK>(board);
+    currEntry().minorBehindPawn =
+        evaluateMinorBehindPawn<Color::WHITE>(board) - evaluateMinorBehindPawn<Color::BLACK>(board);
 }
 
 void EvalState::push(const Board& board, const EvalUpdates& updates)
@@ -86,23 +88,26 @@ void EvalState::push(const Board& board, const EvalUpdates& updates)
 
     if (updates.changedPieces.hasAny(eval_terms::knightOutposts.deps))
         currEntry().knightOutposts =
-            evaluateKnightOutposts<Color::WHITE>(board, currEntry().pawnStructure) -
-            evaluateKnightOutposts<Color::BLACK>(board, currEntry().pawnStructure);
+            evaluateKnightOutposts<Color::WHITE>(board, currEntry().pawnStructure)
+            - evaluateKnightOutposts<Color::BLACK>(board, currEntry().pawnStructure);
     else
         currEntry().knightOutposts = oldEntry.knightOutposts;
 
     if (updates.changedPieces.hasAny(eval_terms::bishopPawns.deps))
-        currEntry().bishopPawns = evaluateBishopPawns<Color::WHITE>(board) - evaluateBishopPawns<Color::BLACK>(board);
+        currEntry().bishopPawns =
+            evaluateBishopPawns<Color::WHITE>(board) - evaluateBishopPawns<Color::BLACK>(board);
     else
         currEntry().bishopPawns = oldEntry.bishopPawns;
 
     if (updates.changedPieces.hasAny(eval_terms::rookOpen.deps))
-        currEntry().rookOpen = evaluateRookOpen<Color::WHITE>(board) - evaluateRookOpen<Color::BLACK>(board);
+        currEntry().rookOpen =
+            evaluateRookOpen<Color::WHITE>(board) - evaluateRookOpen<Color::BLACK>(board);
     else
         currEntry().rookOpen = oldEntry.rookOpen;
 
     if (updates.changedPieces.hasAny(eval_terms::minorBehindPawn.deps))
-        currEntry().minorBehindPawn = evaluateMinorBehindPawn<Color::WHITE>(board) - evaluateMinorBehindPawn<Color::BLACK>(board);
+        currEntry().minorBehindPawn = evaluateMinorBehindPawn<Color::WHITE>(board)
+            - evaluateMinorBehindPawn<Color::BLACK>(board);
     else
         currEntry().minorBehindPawn = oldEntry.minorBehindPawn;
 }
@@ -114,13 +119,9 @@ void EvalState::pop()
 
 PackedScore EvalState::score(const Board& board) const
 {
-    return
-        currEntry().psqtState.evaluate(board) +
-        currEntry().pawnStructure.score +
-        currEntry().knightOutposts +
-        currEntry().bishopPawns +
-        currEntry().rookOpen +
-        currEntry().minorBehindPawn;
+    return currEntry().psqtState.evaluate(board) + currEntry().pawnStructure.score
+        + currEntry().knightOutposts + currEntry().bishopPawns + currEntry().rookOpen
+        + currEntry().minorBehindPawn;
 }
 
 PackedScore EvalState::psqtScore(const Board& board, Color c) const
@@ -145,6 +146,5 @@ int EvalState::phase() const
 {
     return currEntry().psqtState.phase;
 }
-
 
 }

--- a/Sirius/src/eval/eval_state.h
+++ b/Sirius/src/eval/eval_state.h
@@ -1,10 +1,10 @@
 #pragma once
 
-#include "psqt_state.h"
+#include "../util/piece_set.h"
+#include "../util/static_vector.h"
 #include "pawn_structure.h"
 #include "pawn_table.h"
-#include "../util/static_vector.h"
-#include "../util/piece_set.h"
+#include "psqt_state.h"
 #include <optional>
 
 namespace eval
@@ -50,6 +50,7 @@ public:
     PackedScore pawnShieldStormScore(Color c) const;
     const PawnStructure& pawnStructure() const;
     int phase() const;
+
 private:
     void init(const Board& board, PawnTable* pawnTable);
     struct StackEntry
@@ -79,6 +80,5 @@ private:
     StackEntry* m_CurrEntry;
     PawnTable* m_PawnTable;
 };
-
 
 }

--- a/Sirius/src/eval/eval_state.h
+++ b/Sirius/src/eval/eval_state.h
@@ -45,9 +45,9 @@ public:
     void push(const Board& board, const EvalUpdates& updates);
     void pop();
 
-    PackedScore score(const Board& board) const;
-    PackedScore psqtScore(const Board& board, Color c) const;
-    PackedScore pawnShieldStormScore(Color c) const;
+    ScorePair score(const Board& board) const;
+    ScorePair psqtScore(const Board& board, Color c) const;
+    ScorePair pawnShieldStormScore(Color c) const;
     const PawnStructure& pawnStructure() const;
     int phase() const;
 
@@ -59,11 +59,11 @@ private:
 
         PsqtState psqtState;
         PawnStructure pawnStructure;
-        ColorArray<PackedScore> pawnShieldStorm;
-        PackedScore knightOutposts;
-        PackedScore bishopPawns;
-        PackedScore rookOpen;
-        PackedScore minorBehindPawn;
+        ColorArray<ScorePair> pawnShieldStorm;
+        ScorePair knightOutposts;
+        ScorePair bishopPawns;
+        ScorePair rookOpen;
+        ScorePair minorBehindPawn;
     };
 
     StackEntry& currEntry()

--- a/Sirius/src/eval/eval_terms.cpp
+++ b/Sirius/src/eval/eval_terms.cpp
@@ -1,11 +1,11 @@
 #include "eval_terms.h"
 
-#include "../board.h"
 #include "../attacks.h"
+#include "../board.h"
 
+#include "eval_constants.h"
 #include "pawn_structure.h"
 #include "pawn_table.h"
-#include "eval_constants.h"
 
 #include <algorithm>
 
@@ -55,9 +55,9 @@ PackedScore evalKingPawnFile(uint32_t file, Bitboard ourPawns, Bitboard theirPaw
     }
     {
         Bitboard filePawns = theirPawns & Bitboard::fileBB(file);
-        int rank = filePawns.any() ?
-            (us == Color::WHITE ? filePawns.msb() : filePawns.lsb()).relativeRank<them>() :
-            0;
+        int rank = filePawns.any()
+            ? (us == Color::WHITE ? filePawns.msb() : filePawns.lsb()).relativeRank<them>()
+            : 0;
         eval += PAWN_SHIELD[edgeDist][rank];
     }
     return eval;
@@ -85,7 +85,8 @@ PackedScore evaluateKnightOutposts(const Board& board, const PawnStructure& pawn
 {
     constexpr Color them = ~us;
     Bitboard outpostRanks = RANK_4_BB | RANK_5_BB | (us == Color::WHITE ? RANK_6_BB : RANK_3_BB);
-    Bitboard outposts = outpostRanks & ~pawnStructure.pawnAttackSpans[them] & pawnStructure.pawnAttacks[us];
+    Bitboard outposts =
+        outpostRanks & ~pawnStructure.pawnAttackSpans[them] & pawnStructure.pawnAttacks[us];
     return KNIGHT_OUTPOST * (board.pieces(us, PieceType::KNIGHT) & outposts).popcount();
 }
 
@@ -99,7 +100,8 @@ PackedScore evaluateBishopPawns(const Board& board)
     {
         Square sq = bishops.poplsb();
         bool lightSquare = LIGHT_SQUARES_BB.has(sq);
-        Bitboard sameColorPawns = board.pieces(us, PieceType::PAWN) & (lightSquare ? LIGHT_SQUARES_BB : DARK_SQUARES_BB);
+        Bitboard sameColorPawns =
+            board.pieces(us, PieceType::PAWN) & (lightSquare ? LIGHT_SQUARES_BB : DARK_SQUARES_BB);
         eval += BISHOP_PAWNS[std::min(sameColorPawns.popcount(), 6u)];
     }
     return eval;
@@ -133,14 +135,18 @@ PackedScore evaluateMinorBehindPawn(const Board& board)
     return MINOR_BEHIND_PAWN * shielded.popcount();
 }
 
-template PackedScore evalKingPawnFile<Color::WHITE>(uint32_t file, Bitboard ourPawns, Bitboard theirPawns);
-template PackedScore evalKingPawnFile<Color::BLACK>(uint32_t file, Bitboard ourPawns, Bitboard theirPawns);
+template PackedScore evalKingPawnFile<Color::WHITE>(
+    uint32_t file, Bitboard ourPawns, Bitboard theirPawns);
+template PackedScore evalKingPawnFile<Color::BLACK>(
+    uint32_t file, Bitboard ourPawns, Bitboard theirPawns);
 
 template PackedScore evaluateStormShield<Color::WHITE>(const Board& board);
 template PackedScore evaluateStormShield<Color::BLACK>(const Board& board);
 
-template PackedScore evaluateKnightOutposts<Color::WHITE>(const Board& board, const PawnStructure& pawnStructure);
-template PackedScore evaluateKnightOutposts<Color::BLACK>(const Board& board, const PawnStructure& pawnStructure);
+template PackedScore evaluateKnightOutposts<Color::WHITE>(
+    const Board& board, const PawnStructure& pawnStructure);
+template PackedScore evaluateKnightOutposts<Color::BLACK>(
+    const Board& board, const PawnStructure& pawnStructure);
 
 template PackedScore evaluateBishopPawns<Color::WHITE>(const Board& board);
 template PackedScore evaluateBishopPawns<Color::BLACK>(const Board& board);

--- a/Sirius/src/eval/eval_terms.cpp
+++ b/Sirius/src/eval/eval_terms.cpp
@@ -35,11 +35,11 @@ void evaluatePawns(const Board& board, PawnStructure& pawnStructure, PawnTable* 
 }
 
 template<Color us>
-PackedScore evalKingPawnFile(uint32_t file, Bitboard ourPawns, Bitboard theirPawns)
+ScorePair evalKingPawnFile(uint32_t file, Bitboard ourPawns, Bitboard theirPawns)
 {
     constexpr Color them = ~us;
 
-    PackedScore eval{0, 0};
+    ScorePair eval = ScorePair(0, 0);
     int edgeDist = std::min(file, 7 - file);
     {
         Bitboard filePawns = ourPawns & Bitboard::fileBB(file);
@@ -64,24 +64,23 @@ PackedScore evalKingPawnFile(uint32_t file, Bitboard ourPawns, Bitboard theirPaw
 }
 
 template<Color us>
-PackedScore evaluateStormShield(const Board& board)
+ScorePair evaluateStormShield(const Board& board)
 {
     constexpr Color them = ~us;
-    PackedScore eval{0, 0};
+    ScorePair eval = ScorePair(0, 0);
     Bitboard ourPawns = board.pieces(us, PieceType::PAWN);
     Bitboard theirPawns = board.pieces(them, PieceType::PAWN);
     Square theirKing = board.kingSq(them);
 
-    uint32_t leftFile = std::clamp(theirKing.file() - 1, FILE_A, FILE_F);
-    uint32_t rightFile = std::clamp(theirKing.file() + 1, FILE_C, FILE_H);
-    for (uint32_t file = leftFile; file <= rightFile; file++)
+    uint32_t middleFile = std::clamp(theirKing.file(), FILE_B, FILE_G);
+    for (uint32_t file = middleFile - 1; file <= middleFile + 1; file++)
         eval += evalKingPawnFile<us>(file, ourPawns, theirPawns);
 
     return eval;
 }
 
 template<Color us>
-PackedScore evaluateKnightOutposts(const Board& board, const PawnStructure& pawnStructure)
+ScorePair evaluateKnightOutposts(const Board& board, const PawnStructure& pawnStructure)
 {
     constexpr Color them = ~us;
     Bitboard outpostRanks = RANK_4_BB | RANK_5_BB | (us == Color::WHITE ? RANK_6_BB : RANK_3_BB);
@@ -91,11 +90,11 @@ PackedScore evaluateKnightOutposts(const Board& board, const PawnStructure& pawn
 }
 
 template<Color us>
-PackedScore evaluateBishopPawns(const Board& board)
+ScorePair evaluateBishopPawns(const Board& board)
 {
     Bitboard bishops = board.pieces(us, PieceType::BISHOP);
 
-    PackedScore eval{0, 0};
+    ScorePair eval = ScorePair(0, 0);
     while (bishops.any())
     {
         Square sq = bishops.poplsb();
@@ -108,14 +107,14 @@ PackedScore evaluateBishopPawns(const Board& board)
 }
 
 template<Color us>
-PackedScore evaluateRookOpen(const Board& board)
+ScorePair evaluateRookOpen(const Board& board)
 {
     constexpr Color them = ~us;
     Bitboard ourPawns = board.pieces(us, PieceType::PAWN);
     Bitboard theirPawns = board.pieces(them, PieceType::PAWN);
     Bitboard rooks = board.pieces(us, PieceType::ROOK);
 
-    PackedScore eval{0, 0};
+    ScorePair eval = ScorePair(0, 0);
     while (rooks.any())
     {
         Bitboard fileBB = Bitboard::fileBB(rooks.poplsb().file());
@@ -126,35 +125,35 @@ PackedScore evaluateRookOpen(const Board& board)
 }
 
 template<Color us>
-PackedScore evaluateMinorBehindPawn(const Board& board)
+ScorePair evaluateMinorBehindPawn(const Board& board)
 {
+    constexpr Color them = ~us;
+
     Bitboard pawns = board.pieces(PieceType::PAWN);
     Bitboard minors = board.pieces(us, PieceType::KNIGHT) | board.pieces(us, PieceType::BISHOP);
 
-    Bitboard shielded = minors & (us == Color::WHITE ? pawns.south() : pawns.north());
+    Bitboard shielded = minors & attacks::pawnPushes<them>(pawns);
     return MINOR_BEHIND_PAWN * shielded.popcount();
 }
 
-template PackedScore evalKingPawnFile<Color::WHITE>(
-    uint32_t file, Bitboard ourPawns, Bitboard theirPawns);
-template PackedScore evalKingPawnFile<Color::BLACK>(
-    uint32_t file, Bitboard ourPawns, Bitboard theirPawns);
+template ScorePair evalKingPawnFile<Color::WHITE>(uint32_t file, Bitboard ourPawns, Bitboard theirPawns);
+template ScorePair evalKingPawnFile<Color::BLACK>(uint32_t file, Bitboard ourPawns, Bitboard theirPawns);
 
-template PackedScore evaluateStormShield<Color::WHITE>(const Board& board);
-template PackedScore evaluateStormShield<Color::BLACK>(const Board& board);
+template ScorePair evaluateStormShield<Color::WHITE>(const Board& board);
+template ScorePair evaluateStormShield<Color::BLACK>(const Board& board);
 
-template PackedScore evaluateKnightOutposts<Color::WHITE>(
+template ScorePair evaluateKnightOutposts<Color::WHITE>(
     const Board& board, const PawnStructure& pawnStructure);
-template PackedScore evaluateKnightOutposts<Color::BLACK>(
+template ScorePair evaluateKnightOutposts<Color::BLACK>(
     const Board& board, const PawnStructure& pawnStructure);
 
-template PackedScore evaluateBishopPawns<Color::WHITE>(const Board& board);
-template PackedScore evaluateBishopPawns<Color::BLACK>(const Board& board);
+template ScorePair evaluateBishopPawns<Color::WHITE>(const Board& board);
+template ScorePair evaluateBishopPawns<Color::BLACK>(const Board& board);
 
-template PackedScore evaluateRookOpen<Color::WHITE>(const Board& board);
-template PackedScore evaluateRookOpen<Color::BLACK>(const Board& board);
+template ScorePair evaluateRookOpen<Color::WHITE>(const Board& board);
+template ScorePair evaluateRookOpen<Color::BLACK>(const Board& board);
 
-template PackedScore evaluateMinorBehindPawn<Color::WHITE>(const Board& board);
-template PackedScore evaluateMinorBehindPawn<Color::BLACK>(const Board& board);
+template ScorePair evaluateMinorBehindPawn<Color::WHITE>(const Board& board);
+template ScorePair evaluateMinorBehindPawn<Color::BLACK>(const Board& board);
 
 }

--- a/Sirius/src/eval/eval_terms.h
+++ b/Sirius/src/eval/eval_terms.h
@@ -36,21 +36,21 @@ constexpr EvalTerm minorBehindPawn = {PieceSet(PAWN, KNIGHT, BISHOP)};
 void evaluatePawns(const Board& board, PawnStructure& pawnStructure, PawnTable* pawnTable);
 
 template<Color us>
-PackedScore evalKingPawnFile(uint32_t file, Bitboard ourPawns, Bitboard theirPawns);
+ScorePair evalKingPawnFile(uint32_t file, Bitboard ourPawns, Bitboard theirPawns);
 
 template<Color us>
-PackedScore evaluateStormShield(const Board& board);
+ScorePair evaluateStormShield(const Board& board);
 
 template<Color us>
-PackedScore evaluateKnightOutposts(const Board& board, const PawnStructure& pawnStructure);
+ScorePair evaluateKnightOutposts(const Board& board, const PawnStructure& pawnStructure);
 
 template<Color us>
-PackedScore evaluateBishopPawns(const Board& board);
+ScorePair evaluateBishopPawns(const Board& board);
 
 template<Color us>
-PackedScore evaluateRookOpen(const Board& board);
+ScorePair evaluateRookOpen(const Board& board);
 
 template<Color us>
-PackedScore evaluateMinorBehindPawn(const Board& board);
+ScorePair evaluateMinorBehindPawn(const Board& board);
 
 }

--- a/Sirius/src/eval/eval_terms.h
+++ b/Sirius/src/eval/eval_terms.h
@@ -1,10 +1,10 @@
 #pragma once
 
+#include "../bitboard.h"
+#include "../defs.h"
+#include "../util/piece_set.h"
 #include <bitset>
 #include <type_traits>
-#include "../defs.h"
-#include "../bitboard.h"
-#include "../util/piece_set.h"
 
 class Board;
 struct PawnStructure;
@@ -31,7 +31,6 @@ constexpr EvalTerm bishopPawns = {PieceSet(PAWN, BISHOP)};
 constexpr EvalTerm rookOpen = {PieceSet(PAWN, ROOK)};
 constexpr EvalTerm minorBehindPawn = {PieceSet(PAWN, KNIGHT, BISHOP)};
 
-
 } // namespace eval_terms
 
 void evaluatePawns(const Board& board, PawnStructure& pawnStructure, PawnTable* pawnTable);
@@ -53,6 +52,5 @@ PackedScore evaluateRookOpen(const Board& board);
 
 template<Color us>
 PackedScore evaluateMinorBehindPawn(const Board& board);
-
 
 }

--- a/Sirius/src/eval/pawn_structure.cpp
+++ b/Sirius/src/eval/pawn_structure.cpp
@@ -11,27 +11,27 @@ PawnStructure::PawnStructure(const Board& board)
     Bitboard bpawns = board.pieces(Color::BLACK, PieceType::PAWN);
     pawnAttacks[Color::WHITE] = attacks::pawnAttacks<Color::WHITE>(wpawns);
     pawnAttackSpans[Color::WHITE] = attacks::fillUp<Color::WHITE>(pawnAttacks[Color::WHITE]);
-    passedPawns = Bitboard(0);
 
     pawnAttacks[Color::BLACK] = attacks::pawnAttacks<Color::BLACK>(bpawns);
     pawnAttackSpans[Color::BLACK] = attacks::fillUp<Color::BLACK>(pawnAttacks[Color::BLACK]);
+
     passedPawns = Bitboard(0);
 }
 
-PackedScore PawnStructure::evaluate(const Board& board)
+ScorePair PawnStructure::evaluate(const Board& board)
 {
     score = evaluate<Color::WHITE>(board) - evaluate<Color::BLACK>(board);
     return score;
 }
 
 template<Color us>
-PackedScore PawnStructure::evaluate(const Board& board)
+ScorePair PawnStructure::evaluate(const Board& board)
 {
     constexpr Color them = ~us;
     Bitboard ourPawns = board.pieces(us, PieceType::PAWN);
     Bitboard theirPawns = board.pieces(them, PieceType::PAWN);
 
-    PackedScore eval{0, 0};
+    ScorePair eval = ScorePair(0, 0);
 
     Bitboard pawns = ourPawns;
     while (pawns.any())

--- a/Sirius/src/eval/pawn_structure.cpp
+++ b/Sirius/src/eval/pawn_structure.cpp
@@ -39,7 +39,8 @@ PackedScore PawnStructure::evaluate(const Board& board)
         Square sq = pawns.poplsb();
         Square push = sq + attacks::pawnPushOffset<us>();
         Bitboard attacks = attacks::pawnAttacks(us, sq);
-        Bitboard support = attacks::passedPawnMask(them, push) & attacks::isolatedPawnMask(sq) & ourPawns;
+        Bitboard support =
+            attacks::passedPawnMask(them, push) & attacks::isolatedPawnMask(sq) & ourPawns;
         Bitboard threats = attacks & theirPawns;
         Bitboard pushThreats = attacks::pawnPushes<us>(attacks) & theirPawns;
         Bitboard defenders = attacks::pawnAttacks(them, sq) & ourPawns;

--- a/Sirius/src/eval/pawn_structure.cpp
+++ b/Sirius/src/eval/pawn_structure.cpp
@@ -15,7 +15,7 @@ PawnStructure::PawnStructure(const Board& board)
     pawnAttacks[Color::BLACK] = attacks::pawnAttacks<Color::BLACK>(bpawns);
     pawnAttackSpans[Color::BLACK] = attacks::fillUp<Color::BLACK>(pawnAttacks[Color::BLACK]);
 
-    passedPawns = Bitboard(0);
+    passedPawns = EMPTY_BB;
 }
 
 ScorePair PawnStructure::evaluate(const Board& board)

--- a/Sirius/src/eval/pawn_structure.h
+++ b/Sirius/src/eval/pawn_structure.h
@@ -17,10 +17,10 @@ struct PawnStructure
     ColorArray<Bitboard> pawnAttackSpans;
     Bitboard passedPawns;
     PackedScore score;
+
 private:
     template<Color us>
     PackedScore evaluate(const Board& board);
 };
-
 
 }

--- a/Sirius/src/eval/pawn_structure.h
+++ b/Sirius/src/eval/pawn_structure.h
@@ -11,16 +11,16 @@ struct PawnStructure
     PawnStructure() = default;
     PawnStructure(const Board& board);
 
-    PackedScore evaluate(const Board& board);
+    ScorePair evaluate(const Board& board);
 
     ColorArray<Bitboard> pawnAttacks;
     ColorArray<Bitboard> pawnAttackSpans;
     Bitboard passedPawns;
-    PackedScore score;
+    ScorePair score;
 
 private:
     template<Color us>
-    PackedScore evaluate(const Board& board);
+    ScorePair evaluate(const Board& board);
 };
 
 }

--- a/Sirius/src/eval/pawn_table.h
+++ b/Sirius/src/eval/pawn_table.h
@@ -1,9 +1,9 @@
 #pragma once
 
-#include <vector>
-#include "../zobrist.h"
 #include "../defs.h"
+#include "../zobrist.h"
 #include "pawn_structure.h"
+#include <vector>
 
 struct PawnEntry
 {
@@ -22,6 +22,7 @@ public:
     void store(PawnEntry entry);
 
     void clear();
+
 private:
     std::vector<PawnEntry> m_Entries;
 };
@@ -29,7 +30,6 @@ private:
 inline PawnTable::PawnTable()
     : m_Entries(SIZE)
 {
-
 }
 
 inline PawnEntry PawnTable::probe(ZKey pawnKey) const

--- a/Sirius/src/eval/phase.cpp
+++ b/Sirius/src/eval/phase.cpp
@@ -17,8 +17,7 @@ constexpr int PHASE_WEIGHTS[] = {
     // queen
     QUEEN_PHASE,
     // king
-    0
-};
+    0};
 
 int getPiecePhase(PieceType piece)
 {

--- a/Sirius/src/eval/phase.h
+++ b/Sirius/src/eval/phase.h
@@ -12,11 +12,7 @@ constexpr int ROOK_PHASE = 2;
 constexpr int QUEEN_PHASE = 4;
 
 constexpr int TOTAL_PHASE =
-    PAWN_PHASE * 16 +
-    KNIGHT_PHASE * 4 +
-    BISHOP_PHASE * 4 +
-    ROOK_PHASE * 4 +
-    QUEEN_PHASE * 2;
+    PAWN_PHASE * 16 + KNIGHT_PHASE * 4 + BISHOP_PHASE * 4 + ROOK_PHASE * 4 + QUEEN_PHASE * 2;
 
 int getPiecePhase(PieceType piece);
 int getFullEval(int mg, int eg, int phase);

--- a/Sirius/src/eval/psqt_state.cpp
+++ b/Sirius/src/eval/psqt_state.cpp
@@ -4,7 +4,7 @@
 namespace eval
 {
 
-PackedScore PsqtState::evaluate(const Board& board) const
+ScorePair PsqtState::evaluate(const Board& board) const
 {
     int whiteBucket = getKingBucket(board.kingSq(Color::WHITE));
     int blackBucket = getKingBucket(board.kingSq(Color::BLACK));

--- a/Sirius/src/eval/psqt_state.cpp
+++ b/Sirius/src/eval/psqt_state.cpp
@@ -8,10 +8,8 @@ PackedScore PsqtState::evaluate(const Board& board) const
 {
     int whiteBucket = getKingBucket(board.kingSq(Color::WHITE));
     int blackBucket = getKingBucket(board.kingSq(Color::BLACK));
-    return
-        accumulators[static_cast<int>(Color::WHITE)].materialPsqt[whiteBucket] +
-        accumulators[static_cast<int>(Color::BLACK)].materialPsqt[blackBucket];
+    return accumulators[static_cast<int>(Color::WHITE)].materialPsqt[whiteBucket]
+        + accumulators[static_cast<int>(Color::BLACK)].materialPsqt[blackBucket];
 }
-
 
 }

--- a/Sirius/src/eval/psqt_state.h
+++ b/Sirius/src/eval/psqt_state.h
@@ -1,8 +1,10 @@
 #pragma once
 
 #include "../defs.h"
+#include "../util/enum_array.h"
 #include "combined_psqt.h"
 #include "phase.h"
+
 
 #include <iostream>
 
@@ -44,7 +46,7 @@ struct Accumulator
 struct PsqtState
 {
     int phase;
-    std::array<Accumulator, 2> accumulators;
+    ColorArray<Accumulator> accumulators;
 
     void init();
     ScorePair evaluate(const Board& board) const;
@@ -61,19 +63,19 @@ inline void PsqtState::init()
 
 inline void PsqtState::addPiece(Color color, PieceType piece, Square square)
 {
-    accumulators[static_cast<int>(color)].addPiece(color, piece, square);
+    accumulators[color].addPiece(color, piece, square);
     phase -= getPiecePhase(piece);
 }
 
 inline void PsqtState::removePiece(Color color, PieceType piece, Square square)
 {
-    accumulators[static_cast<int>(color)].removePiece(color, piece, square);
+    accumulators[color].removePiece(color, piece, square);
     phase += getPiecePhase(piece);
 }
 
 inline void PsqtState::movePiece(Color color, PieceType piece, Square src, Square dst)
 {
-    accumulators[static_cast<int>(color)].movePiece(color, piece, src, dst);
+    accumulators[color].movePiece(color, piece, src, dst);
 }
 
 }

--- a/Sirius/src/eval/psqt_state.h
+++ b/Sirius/src/eval/psqt_state.h
@@ -5,7 +5,6 @@
 #include "combined_psqt.h"
 #include "phase.h"
 
-
 #include <iostream>
 
 class Board;

--- a/Sirius/src/eval/psqt_state.h
+++ b/Sirius/src/eval/psqt_state.h
@@ -19,7 +19,7 @@ inline int getKingBucket(Square kingSq)
 
 struct Accumulator
 {
-    std::array<PackedScore, BUCKET_COUNT> materialPsqt;
+    std::array<ScorePair, BUCKET_COUNT> materialPsqt;
 
     void addPiece(Color color, PieceType piece, Square square)
     {
@@ -47,7 +47,7 @@ struct PsqtState
     std::array<Accumulator, 2> accumulators;
 
     void init();
-    PackedScore evaluate(const Board& board) const;
+    ScorePair evaluate(const Board& board) const;
     void addPiece(Color color, PieceType piece, Square square);
     void removePiece(Color color, PieceType piece, Square square);
     void movePiece(Color color, PieceType piece, Square src, Square dst);
@@ -56,7 +56,7 @@ struct PsqtState
 inline void PsqtState::init()
 {
     phase = TOTAL_PHASE;
-    accumulators.fill({{PackedScore(0, 0), PackedScore(0, 0)}});
+    accumulators.fill({{ScorePair(0, 0), ScorePair(0, 0)}});
 }
 
 inline void PsqtState::addPiece(Color color, PieceType piece, Square square)

--- a/Sirius/src/eval/psqt_state.h
+++ b/Sirius/src/eval/psqt_state.h
@@ -36,7 +36,8 @@ struct Accumulator
     void movePiece(Color color, PieceType piece, Square src, Square dst)
     {
         for (int bucket = 0; bucket < BUCKET_COUNT; bucket++)
-            materialPsqt[bucket] += combinedPsqtScore(bucket, color, piece, dst) - combinedPsqtScore(bucket, color, piece, src);
+            materialPsqt[bucket] += combinedPsqtScore(bucket, color, piece, dst)
+                - combinedPsqtScore(bucket, color, piece, src);
     }
 };
 
@@ -50,7 +51,6 @@ struct PsqtState
     void addPiece(Color color, PieceType piece, Square square);
     void removePiece(Color color, PieceType piece, Square square);
     void movePiece(Color color, PieceType piece, Square src, Square dst);
-
 };
 
 inline void PsqtState::init()

--- a/Sirius/src/history.h
+++ b/Sirius/src/history.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "defs.h"
 #include "board.h"
+#include "defs.h"
 #include "search_params.h"
 #include <algorithm>
 
@@ -15,9 +15,8 @@ inline Piece movingPiece(const Board& board, Move move)
 
 inline Piece capturedPiece(const Board& board, Move move)
 {
-    return move.type() == MoveType::ENPASSANT ?
-        makePiece(PieceType::PAWN, ~board.sideToMove()) :
-        board.pieceAt(move.toSq());
+    return move.type() == MoveType::ENPASSANT ? makePiece(PieceType::PAWN, ~board.sideToMove())
+                                              : board.pieceAt(move.toSq());
 }
 
 // pieces are currently stored as type + 8 * color internally
@@ -45,6 +44,7 @@ public:
     operator int() const;
 
     void update(int bonus);
+
 private:
     int16_t m_Value;
 };
@@ -78,6 +78,7 @@ public:
     operator int() const;
 
     void update(int target, int weight);
+
 private:
     int16_t m_Value;
 };
@@ -95,7 +96,8 @@ inline CorrHistEntry::operator int() const
 inline void CorrHistEntry::update(int target, int weight)
 {
     int newValue = (m_Value * (256 - weight) + target * weight) / 256;
-    newValue = std::clamp(newValue, m_Value - search::maxCorrHistUpdate, m_Value + search::maxCorrHistUpdate);
+    newValue = std::clamp(
+        newValue, m_Value - search::maxCorrHistUpdate, m_Value + search::maxCorrHistUpdate);
     m_Value = static_cast<int16_t>(std::clamp(newValue, -search::maxCorrHist, search::maxCorrHist));
 }
 
@@ -110,16 +112,12 @@ using ContHist = MultiArray<CHEntry, 12, 64>;
 using CaptHist = MultiArray<HistoryEntry<HISTORY_MAX>, 7, 12, 64, 2, 2>;
 
 // correction history(~104 elo)
-constexpr int PAWN_CORR_HIST_ENTRIES = 16384;
-constexpr int NON_PAWN_CORR_HIST_ENTRIES = 16384;
-constexpr int THREATS_CORR_HIST_ENTRIES = 16384;
-constexpr int MINOR_PIECE_CORR_HIST_ENTRIES = 16384;
-constexpr int MAJOR_PIECE_CORR_HIST_ENTRIES = 16384;
-using PawnCorrHist = MultiArray<CorrHistEntry, 2, PAWN_CORR_HIST_ENTRIES>;
-using NonPawnCorrHist = MultiArray<CorrHistEntry, 2, 2, NON_PAWN_CORR_HIST_ENTRIES>;
-using ThreatsCorrHist = MultiArray<CorrHistEntry, 2, THREATS_CORR_HIST_ENTRIES>;
-using MinorPieceCorrHist = MultiArray<CorrHistEntry, 2, MINOR_PIECE_CORR_HIST_ENTRIES>;
-using MajorPieceCorrHist = MultiArray<CorrHistEntry, 2, MAJOR_PIECE_CORR_HIST_ENTRIES>;
+constexpr int CORR_HIST_ENTRIES = 16384;
+using PawnCorrHist = MultiArray<CorrHistEntry, 2, CORR_HIST_ENTRIES>;
+using NonPawnCorrHist = MultiArray<CorrHistEntry, 2, 2, CORR_HIST_ENTRIES>;
+using ThreatsCorrHist = MultiArray<CorrHistEntry, 2, CORR_HIST_ENTRIES>;
+using MinorPieceCorrHist = MultiArray<CorrHistEntry, 2, CORR_HIST_ENTRIES>;
+using MajorPieceCorrHist = MultiArray<CorrHistEntry, 2, CORR_HIST_ENTRIES>;
 using ContCorrEntry = MultiArray<CorrHistEntry, 12, 64>;
 using ContCorrHist = MultiArray<ContCorrEntry, 12, 64>;
 
@@ -144,18 +142,21 @@ public:
     ContCorrEntry& contCorrEntry(const Board& board, Move move)
     {
         if (move == Move::nullmove())
-            return m_ContCorrHist[packPieceIndices(makePiece(PieceType::PAWN, board.sideToMove()))][move.toSq().value()];
+            return m_ContCorrHist[packPieceIndices(makePiece(PieceType::PAWN, board.sideToMove()))]
+                                 [move.toSq().value()];
         return m_ContCorrHist[packPieceIndices(movingPiece(board, move))][move.toSq().value()];
     }
 
     const ContCorrEntry& contCorrEntry(const Board& board, Move move) const
     {
         if (move == Move::nullmove())
-            return m_ContCorrHist[packPieceIndices(makePiece(PieceType::PAWN, board.sideToMove()))][move.toSq().value()];
+            return m_ContCorrHist[packPieceIndices(makePiece(PieceType::PAWN, board.sideToMove()))]
+                                 [move.toSq().value()];
         return m_ContCorrHist[packPieceIndices(movingPiece(board, move))][move.toSq().value()];
     }
 
-    int getQuietStats(Move move, Bitboard threats, Piece movingPiece, const SearchStack* stack, int ply) const;
+    int getQuietStats(
+        Move move, Bitboard threats, Piece movingPiece, const SearchStack* stack, int ply) const;
     int getNoisyStats(const Board& board, Move move) const;
     int correctStaticEval(const Board& board, int staticEval, const SearchStack* stack, int ply) const;
 
@@ -164,6 +165,7 @@ public:
     void updateContHist(Move move, Piece movingPiece, const SearchStack* stack, int ply, int bonus);
     void updateNoisyStats(const Board& board, Move move, int bonus);
     void updateCorrHist(const Board& board, int bonus, int depth, const SearchStack* stack, int ply);
+
 private:
     int getMainHist(Move move, Bitboard threats, Color color) const;
     int getContHist(Move move, Piece movingPiece, const CHEntry* entry) const;

--- a/Sirius/src/main.cpp
+++ b/Sirius/src/main.cpp
@@ -2,14 +2,14 @@
 #include <string>
 
 #include "attacks.h"
-#include "comm/icomm.h"
+#include "bench.h"
 #include "comm/cmdline.h"
+#include "comm/icomm.h"
 #include "comm/uci.h"
 #include "cuckoo.h"
-#include "eval/eval.h"
 #include "eval/endgame.h"
+#include "eval/eval.h"
 #include "search_params.h"
-#include "bench.h"
 #include "sirius.h"
 
 int main(int argc, char** argv)

--- a/Sirius/src/misc.cpp
+++ b/Sirius/src/misc.cpp
@@ -1,12 +1,12 @@
 #include "misc.h"
 #include "comm/move.h"
-#include "movegen.h"
 #include "move_ordering.h"
-#include <chrono>
+#include "movegen.h"
 #include <algorithm>
 #include <charconv>
-#include <vector>
+#include <chrono>
 #include <fstream>
+#include <vector>
 
 void printBoard(const Board& board)
 {
@@ -31,12 +31,14 @@ void printBoard(const Board& board)
         std::cout << '-';
     }
     std::cout << std::endl;
-    std::cout << "Side to move: " << (board.sideToMove() == Color::WHITE ? "WHITE" : "BLACK") << std::endl;
+    std::cout << "Side to move: " << (board.sideToMove() == Color::WHITE ? "WHITE" : "BLACK")
+              << std::endl;
     if (board.epSquare() != -1)
-        std::cout << "Ep square: " << static_cast<char>((board.epSquare() & 7) + 'a') << static_cast<char>((board.epSquare() >> 3) + '1') << std::endl;
+        std::cout << "Ep square: " << static_cast<char>((board.epSquare() & 7) + 'a')
+                  << static_cast<char>((board.epSquare() >> 3) + '1') << std::endl;
     else
         std::cout << "Ep square: N/A" << std::endl;
-    std::cout << "Fen: " <<  board.fenStr() << std::endl;
+    std::cout << "Fen: " << board.fenStr() << std::endl;
 
     std::cout << "Zobrist hash: " << board.zkey().value << std::endl;
     std::cout << "Pawn structure hash: " << board.pawnKey().value << std::endl;
@@ -183,31 +185,38 @@ void testIsPseudoLegal(Board& board, int depth)
             for (int to = 0; to < 64; to++)
             {
                 Move move(Square(from), Square(to), MoveType::NONE);
-                if (std::find(moves.begin(), moves.end(), move) == moves.end() && board.isPseudoLegal(move))
+                if (std::find(moves.begin(), moves.end(), move) == moves.end()
+                    && board.isPseudoLegal(move))
                     throw std::runtime_error("bruh2");
 
                 move = Move(Square(from), Square(to), MoveType::ENPASSANT);
-                if (std::find(moves.begin(), moves.end(), move) == moves.end() && board.isPseudoLegal(move))
+                if (std::find(moves.begin(), moves.end(), move) == moves.end()
+                    && board.isPseudoLegal(move))
                     throw std::runtime_error("bruh2");
 
                 move = Move(Square(from), Square(to), MoveType::CASTLE);
-                if (std::find(moves.begin(), moves.end(), move) == moves.end() && board.isPseudoLegal(move))
+                if (std::find(moves.begin(), moves.end(), move) == moves.end()
+                    && board.isPseudoLegal(move))
                     throw std::runtime_error("bruh2");
 
                 move = Move(Square(from), Square(to), MoveType::PROMOTION, Promotion::KNIGHT);
-                if (std::find(moves.begin(), moves.end(), move) == moves.end() && board.isPseudoLegal(move))
+                if (std::find(moves.begin(), moves.end(), move) == moves.end()
+                    && board.isPseudoLegal(move))
                     throw std::runtime_error("bruh2");
 
                 move = Move(Square(from), Square(to), MoveType::PROMOTION, Promotion::BISHOP);
-                if (std::find(moves.begin(), moves.end(), move) == moves.end() && board.isPseudoLegal(move))
+                if (std::find(moves.begin(), moves.end(), move) == moves.end()
+                    && board.isPseudoLegal(move))
                     throw std::runtime_error("bruh2");
 
                 move = Move(Square(from), Square(to), MoveType::PROMOTION, Promotion::ROOK);
-                if (std::find(moves.begin(), moves.end(), move) == moves.end() && board.isPseudoLegal(move))
+                if (std::find(moves.begin(), moves.end(), move) == moves.end()
+                    && board.isPseudoLegal(move))
                     throw std::runtime_error("bruh2");
 
                 move = Move(Square(from), Square(to), MoveType::PROMOTION, Promotion::QUEEN);
-                if (std::find(moves.begin(), moves.end(), move) == moves.end() && board.isPseudoLegal(move))
+                if (std::find(moves.begin(), moves.end(), move) == moves.end()
+                    && board.isPseudoLegal(move))
                     throw std::runtime_error("bruh2");
             }
         }
@@ -354,7 +363,8 @@ void runTests(Board& board, bool fast)
             i++;
         test.fen = line.substr(0, i);
 
-        std::from_chars(line.data() + i + 4, line.data() + line.size(), test.results[line[i + 2] - '1']);
+        std::from_chars(
+            line.data() + i + 4, line.data() + line.size(), test.results[line[i + 2] - '1']);
 
         while (true)
         {
@@ -362,7 +372,8 @@ void runTests(Board& board, bool fast)
             if (idx == std::string::npos)
                 break;
             i = static_cast<int>(idx);
-            std::from_chars(line.data() + i + 4, line.data() + line.size(), test.results[line[i + 2] - '1']);
+            std::from_chars(
+                line.data() + i + 4, line.data() + line.size(), test.results[line[i + 2] - '1']);
         }
         tests.push_back(test);
     }
@@ -393,7 +404,8 @@ void runTests(Board& board, bool fast)
             }
             else
             {
-                std::cout << "\tFailed: depth " << j + 1 << ", Expected: " << test.results[j] << ", got: " << nodes << std::endl;
+                std::cout << "\tFailed: depth " << j + 1 << ", Expected: " << test.results[j]
+                          << ", got: " << nodes << std::endl;
                 failCount++;
             }
         }
@@ -406,12 +418,8 @@ void runTests(Board& board, bool fast)
 
 void testSANFind(const Board& board, const MoveList& moveList, int len)
 {
-    static constexpr std::array<char, 25> chars = {
-        'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h',
-        '1', '2', '3', '4', '5', '6', '7', '8',
-        'K', 'Q', 'R', 'B', 'N', 'q', 'r', 'n',
-        'x'
-    };
+    static constexpr std::array<char, 25> chars = {'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', '1', '2',
+        '3', '4', '5', '6', '7', '8', 'K', 'Q', 'R', 'B', 'N', 'q', 'r', 'n', 'x'};
     static constexpr uint64_t charCount = 25;
     char* buf = new char[len + 1];
     buf[len] = '\0';

--- a/Sirius/src/move_ordering.cpp
+++ b/Sirius/src/move_ordering.cpp
@@ -10,10 +10,9 @@ int mvv(const Board& board, Move move)
 {
     constexpr int MVV_VALUES[6] = {800, 2400, 2400, 4800, 7200};
 
-    int dstPiece = static_cast<int>(move.type() == MoveType::ENPASSANT ?
-        PieceType::PAWN :
-        getPieceType(board.pieceAt(move.toSq()))
-    );
+    int dstPiece = static_cast<int>(move.type() == MoveType::ENPASSANT
+            ? PieceType::PAWN
+            : getPieceType(board.pieceAt(move.toSq())));
     return MVV_VALUES[dstPiece];
 }
 
@@ -26,19 +25,15 @@ int promotionBonus(Move move)
 
 bool moveIsQuiet(const Board& board, Move move)
 {
-	return move.type() == MoveType::CASTLE || (
-        move.type() != MoveType::PROMOTION &&
-		move.type() != MoveType::ENPASSANT &&
-		board.pieceAt(move.toSq()) == Piece::NONE
-    );
+    return move.type() == MoveType::CASTLE
+        || (move.type() != MoveType::PROMOTION && move.type() != MoveType::ENPASSANT
+            && board.pieceAt(move.toSq()) == Piece::NONE);
 }
 
 bool moveIsCapture(const Board& board, Move move)
 {
-    return move.type() != MoveType::CASTLE && (
-        move.type() == MoveType::ENPASSANT ||
-        board.pieceAt(move.toSq()) != Piece::NONE
-    );
+    return move.type() != MoveType::CASTLE
+        && (move.type() == MoveType::ENPASSANT || board.pieceAt(move.toSq()) != Piece::NONE);
 }
 
 int MoveOrdering::scoreNoisy(Move move) const
@@ -80,10 +75,16 @@ MoveOrdering::MoveOrdering(const Board& board, Move ttMove, const History& histo
 {
 }
 
-MoveOrdering::MoveOrdering(const Board& board, Move ttMove, const std::array<Move, 2>& killers, SearchStack* stack, int ply, const History& history)
-    : m_Board(board), m_TTMove(ttMove),
-    m_History(history), m_Stack(stack), m_Ply(ply), m_Killers(killers),
-    m_Curr(0), m_Stage(MovePickStage::TT_MOVE)
+MoveOrdering::MoveOrdering(const Board& board, Move ttMove, const std::array<Move, 2>& killers,
+    SearchStack* stack, int ply, const History& history)
+    : m_Board(board),
+      m_TTMove(ttMove),
+      m_History(history),
+      m_Stack(stack),
+      m_Ply(ply),
+      m_Killers(killers),
+      m_Curr(0),
+      m_Stage(MovePickStage::TT_MOVE)
 {
 }
 
@@ -125,9 +126,8 @@ ScoredMove MoveOrdering::selectMove()
             // fallthrough
         case FIRST_KILLER:
             ++m_Stage;
-            if (m_Killers[0] != Move::nullmove() &&
-                m_Board.isPseudoLegal(m_Killers[0]) &&
-                moveIsQuiet(m_Board, m_Killers[0]))
+            if (m_Killers[0] != Move::nullmove() && m_Board.isPseudoLegal(m_Killers[0])
+                && moveIsQuiet(m_Board, m_Killers[0]))
             {
                 if (m_Killers[0] != m_TTMove)
                     return ScoredMove{m_Killers[0], FIRST_KILLER_SCORE};
@@ -140,9 +140,8 @@ ScoredMove MoveOrdering::selectMove()
             // fallthrough
         case SECOND_KILLER:
             ++m_Stage;
-            if (m_Killers[1] != Move::nullmove() &&
-                m_Board.isPseudoLegal(m_Killers[1]) &&
-                moveIsQuiet(m_Board, m_Killers[1]))
+            if (m_Killers[1] != Move::nullmove() && m_Board.isPseudoLegal(m_Killers[1])
+                && moveIsQuiet(m_Board, m_Killers[1]))
             {
                 if (m_Killers[1] != m_TTMove)
                     return ScoredMove{m_Killers[1], SECOND_KILLER_SCORE};
@@ -164,17 +163,16 @@ ScoredMove MoveOrdering::selectMove()
             while (m_Curr < m_Moves.size())
             {
                 ScoredMove scoredMove = selectHighest();
-                if (scoredMove.move != m_TTMove &&
-                    scoredMove.move != m_Killers[0] &&
-                    scoredMove.move != m_Killers[1])
+                if (scoredMove.move != m_TTMove && scoredMove.move != m_Killers[0]
+                    && scoredMove.move != m_Killers[1])
                     return scoredMove;
             }
             return ScoredMove{Move::nullmove(), NO_MOVE};
 
-
         case QS_TT_MOVE:
             ++m_Stage;
-            if (m_TTMove != Move::nullmove() && m_Board.isPseudoLegal(m_TTMove) && !moveIsQuiet(m_Board, m_TTMove))
+            if (m_TTMove != Move::nullmove() && m_Board.isPseudoLegal(m_TTMove)
+                && !moveIsQuiet(m_Board, m_TTMove))
                 return ScoredMove{m_TTMove, 10000000};
 
             // fallthrough

--- a/Sirius/src/move_ordering.h
+++ b/Sirius/src/move_ordering.h
@@ -1,8 +1,8 @@
 #pragma once
 
 #include "board.h"
-#include "movegen.h"
 #include "history.h"
+#include "movegen.h"
 #include <array>
 
 struct SearchStack;
@@ -48,10 +48,12 @@ public:
     static constexpr int CAPTURE_SCORE = 500000;
 
     MoveOrdering(const Board& board, Move ttMove, const History& history);
-    MoveOrdering(const Board& board, Move hashMove, const std::array<Move, 2>& killers, SearchStack* stack, int ply, const History& history);
+    MoveOrdering(const Board& board, Move hashMove, const std::array<Move, 2>& killers,
+        SearchStack* stack, int ply, const History& history);
 
     ScoredMove selectMove();
     ScoredMove selectHighest();
+
 private:
     int scoreNoisy(Move move) const;
     int scoreQuiet(Move move) const;

--- a/Sirius/src/movegen.cpp
+++ b/Sirius/src/movegen.cpp
@@ -50,8 +50,7 @@ void genMoves(const Board& board, MoveList& moves)
     if (!checkers.multiple())
     {
         Bitboard moveMask = ~board.pieces(color)
-            & (checkers.any() ? attacks::moveMask(board.kingSq(color), checkers.lsb())
-                              : Bitboard(~0ull));
+            & (checkers.any() ? attacks::moveMask(board.kingSq(color), checkers.lsb()) : ALL_BB);
         genPawnMoves<type, color>(board, moves, moveMask);
         if constexpr (type == MoveGenType::NOISY)
             moveMask &= board.pieces(~color);

--- a/Sirius/src/movegen.cpp
+++ b/Sirius/src/movegen.cpp
@@ -43,16 +43,15 @@ void genPieceMoves(const Board& board, MoveList& moves, Bitboard moveMask);
 template<MoveGenType type, Color color>
 void genPawnMoves(const Board& board, MoveList& moves, Bitboard moveMask);
 
-
-
 template<MoveGenType type, Color color>
 void genMoves(const Board& board, MoveList& moves)
 {
     Bitboard checkers = board.checkers();
     if (!checkers.multiple())
     {
-        Bitboard moveMask = ~board.pieces(color) &
-            (checkers.any() ? attacks::moveMask(board.kingSq(color), checkers.lsb()) : Bitboard(~0ull));
+        Bitboard moveMask = ~board.pieces(color)
+            & (checkers.any() ? attacks::moveMask(board.kingSq(color), checkers.lsb())
+                              : Bitboard(~0ull));
         genPawnMoves<type, color>(board, moves, moveMask);
         if constexpr (type == MoveGenType::NOISY)
             moveMask &= board.pieces(~color);
@@ -95,14 +94,14 @@ void genKingMoves(const Board& board, MoveList& moves)
             Square kingSideRook = board.castlingRookSq(color, CastleSide::KING_SIDE);
             Square queenSideRook = board.castlingRookSq(color, CastleSide::QUEEN_SIDE);
 
-            if ((board.castlingRights().value() & kscBit) &&
-                !board.castlingBlocked(color, CastleSide::KING_SIDE))
+            if ((board.castlingRights().value() & kscBit)
+                && !board.castlingBlocked(color, CastleSide::KING_SIDE))
             {
                 moves.push_back(Move(kingSq, kingSideRook, MoveType::CASTLE));
             }
 
-            if ((board.castlingRights().value() & qscBit) &&
-                !board.castlingBlocked(color, CastleSide::QUEEN_SIDE))
+            if ((board.castlingRights().value() & qscBit)
+                && !board.castlingBlocked(color, CastleSide::QUEEN_SIDE))
             {
                 moves.push_back(Move(kingSq, queenSideRook, MoveType::CASTLE));
             }
@@ -131,6 +130,8 @@ void genPieceMoves(const Board& board, MoveList& moves, Bitboard moveMask)
 template<MoveGenType type, Color color>
 void genPawnMoves(const Board& board, MoveList& moves, Bitboard moveMask)
 {
+    constexpr int PUSH_OFFSET = attacks::pawnPushOffset<color>();
+
     Bitboard pawns = board.pieces(color, PieceType::PAWN);
     Bitboard allPieces = board.allPieces();
     Bitboard oppBB = board.pieces(~color);
@@ -140,7 +141,8 @@ void genPawnMoves(const Board& board, MoveList& moves, Bitboard moveMask)
         Bitboard pawnPushes = attacks::pawnPushes<color>(pawns);
         pawnPushes &= ~allPieces;
 
-        Bitboard doublePushes = attacks::pawnPushes<color>(pawnPushes & Bitboard::nthRank<color, RANK_3>());
+        Bitboard doublePushes =
+            attacks::pawnPushes<color>(pawnPushes & Bitboard::nthRank<color, RANK_3>());
         doublePushes &= ~allPieces;
         doublePushes &= moveMask;
 
@@ -153,22 +155,25 @@ void genPawnMoves(const Board& board, MoveList& moves, Bitboard moveMask)
         while (pawnPushes.any())
         {
             Square push = pawnPushes.poplsb();
-            moves.push_back(Move(push - attacks::pawnPushOffset<color>(), push, MoveType::NONE));
+            Square from = push - PUSH_OFFSET;
+            moves.push_back(Move(from, push, MoveType::NONE));
         }
 
         while (doublePushes.any())
         {
             Square dPush = doublePushes.poplsb();
-            moves.push_back(Move(dPush - 2 * attacks::pawnPushOffset<color>(), dPush, MoveType::NONE));
+            Square from = dPush - 2 * PUSH_OFFSET;
+            moves.push_back(Move(from, dPush, MoveType::NONE));
         }
 
         while (promotions.any())
         {
             Square promotion = promotions.poplsb();
-            moves.push_back(Move(promotion - attacks::pawnPushOffset<color>(), promotion, MoveType::PROMOTION, Promotion::QUEEN));
-            moves.push_back(Move(promotion - attacks::pawnPushOffset<color>(), promotion, MoveType::PROMOTION, Promotion::ROOK));
-            moves.push_back(Move(promotion - attacks::pawnPushOffset<color>(), promotion, MoveType::PROMOTION, Promotion::BISHOP));
-            moves.push_back(Move(promotion - attacks::pawnPushOffset<color>(), promotion, MoveType::PROMOTION, Promotion::KNIGHT));
+            Square from = promotion - PUSH_OFFSET;
+            moves.push_back(Move(from, promotion, MoveType::PROMOTION, Promotion::QUEEN));
+            moves.push_back(Move(from, promotion, MoveType::PROMOTION, Promotion::ROOK));
+            moves.push_back(Move(from, promotion, MoveType::PROMOTION, Promotion::BISHOP));
+            moves.push_back(Move(from, promotion, MoveType::PROMOTION, Promotion::KNIGHT));
         }
     }
     else if constexpr (type == MoveGenType::NOISY)
@@ -182,10 +187,11 @@ void genPawnMoves(const Board& board, MoveList& moves, Bitboard moveMask)
         while (promotions.any())
         {
             Square promotion = promotions.poplsb();
-            moves.push_back(Move(promotion - attacks::pawnPushOffset<color>(), promotion, MoveType::PROMOTION, Promotion::QUEEN));
-            moves.push_back(Move(promotion - attacks::pawnPushOffset<color>(), promotion, MoveType::PROMOTION, Promotion::ROOK));
-            moves.push_back(Move(promotion - attacks::pawnPushOffset<color>(), promotion, MoveType::PROMOTION, Promotion::BISHOP));
-            moves.push_back(Move(promotion - attacks::pawnPushOffset<color>(), promotion, MoveType::PROMOTION, Promotion::KNIGHT));
+            Square from = promotion - PUSH_OFFSET;
+            moves.push_back(Move(from, promotion, MoveType::PROMOTION, Promotion::QUEEN));
+            moves.push_back(Move(from, promotion, MoveType::PROMOTION, Promotion::ROOK));
+            moves.push_back(Move(from, promotion, MoveType::PROMOTION, Promotion::BISHOP));
+            moves.push_back(Move(from, promotion, MoveType::PROMOTION, Promotion::KNIGHT));
         }
     }
     else if constexpr (type == MoveGenType::QUIET)
@@ -205,24 +211,29 @@ void genPawnMoves(const Board& board, MoveList& moves, Bitboard moveMask)
         while (pawnPushes.any())
         {
             Square push = pawnPushes.poplsb();
-            moves.push_back(Move(push - attacks::pawnPushOffset<color>(), push, MoveType::NONE));
+            Square from = push - PUSH_OFFSET;
+            moves.push_back(Move(from, push, MoveType::NONE));
         }
 
         while (doublePushes.any())
         {
             Square dPush = doublePushes.poplsb();
-            moves.push_back(Move(dPush - 2 * attacks::pawnPushOffset<color>(), dPush, MoveType::NONE));
+            Square from = dPush - 2 * PUSH_OFFSET;
+            moves.push_back(Move(from, dPush, MoveType::NONE));
         }
 
         // rest of the pawn movegen is captures/promos
         return;
     }
 
-
-
     Bitboard eastCaptures = attacks::pawnEastAttacks<color>(pawns);
-    if (board.epSquare() != -1 && eastCaptures.has(Square(board.epSquare())) && moveMask.has(Square(board.epSquare()) - attacks::pawnPushOffset<color>()))
-        moves.push_back(Move(Square(board.epSquare()) - attacks::pawnPushOffset<color>() - 1, Square(board.epSquare()), MoveType::ENPASSANT));
+    if (board.epSquare() != -1 && eastCaptures.has(Square(board.epSquare()))
+        && moveMask.has(Square(board.epSquare()) - PUSH_OFFSET))
+    {
+        Square to = Square(board.epSquare());
+        Square from = to - PUSH_OFFSET - 1;
+        moves.push_back(Move(from, to, MoveType::ENPASSANT));
+    }
 
     eastCaptures &= oppBB;
     eastCaptures &= moveMask;
@@ -233,22 +244,28 @@ void genPawnMoves(const Board& board, MoveList& moves, Bitboard moveMask)
     while (eastCaptures.any())
     {
         Square capture = eastCaptures.poplsb();
-        moves.push_back(Move(capture - attacks::pawnPushOffset<color>() - 1, capture, MoveType::NONE));
+        Square from = capture - PUSH_OFFSET - 1;
+        moves.push_back(Move(from, capture, MoveType::NONE));
     }
 
     while (promotions.any())
     {
         Square promotion = promotions.poplsb();
-        moves.push_back(Move(promotion - attacks::pawnPushOffset<color>() - 1, promotion, MoveType::PROMOTION, Promotion::QUEEN));
-        moves.push_back(Move(promotion - attacks::pawnPushOffset<color>() - 1, promotion, MoveType::PROMOTION, Promotion::ROOK));
-        moves.push_back(Move(promotion - attacks::pawnPushOffset<color>() - 1, promotion, MoveType::PROMOTION, Promotion::BISHOP));
-        moves.push_back(Move(promotion - attacks::pawnPushOffset<color>() - 1, promotion, MoveType::PROMOTION, Promotion::KNIGHT));
+        Square from = promotion - PUSH_OFFSET - 1;
+        moves.push_back(Move(from, promotion, MoveType::PROMOTION, Promotion::QUEEN));
+        moves.push_back(Move(from, promotion, MoveType::PROMOTION, Promotion::ROOK));
+        moves.push_back(Move(from, promotion, MoveType::PROMOTION, Promotion::BISHOP));
+        moves.push_back(Move(from, promotion, MoveType::PROMOTION, Promotion::KNIGHT));
     }
 
-
     Bitboard westCaptures = attacks::pawnWestAttacks<color>(pawns);
-    if (board.epSquare() != -1 && westCaptures.has(Square(board.epSquare())) && moveMask.has(Square(board.epSquare()) - attacks::pawnPushOffset<color>()))
-        moves.push_back(Move(Square(board.epSquare()) - attacks::pawnPushOffset<color>() + 1, Square(board.epSquare()), MoveType::ENPASSANT));
+    if (board.epSquare() != -1 && westCaptures.has(Square(board.epSquare()))
+        && moveMask.has(Square(board.epSquare()) - PUSH_OFFSET))
+    {
+        Square to = Square(board.epSquare());
+        Square from = to - PUSH_OFFSET + 1;
+        moves.push_back(Move(from, to, MoveType::ENPASSANT));
+    }
 
     westCaptures &= oppBB;
     westCaptures &= moveMask;
@@ -259,15 +276,17 @@ void genPawnMoves(const Board& board, MoveList& moves, Bitboard moveMask)
     while (westCaptures.any())
     {
         Square capture = westCaptures.poplsb();
-        moves.push_back(Move(capture - attacks::pawnPushOffset<color>() + 1, capture, MoveType::NONE));
+        Square from = capture - PUSH_OFFSET + 1;
+        moves.push_back(Move(from, capture, MoveType::NONE));
     }
 
     while (promotions.any())
     {
         Square promotion = promotions.poplsb();
-        moves.push_back(Move(promotion - attacks::pawnPushOffset<color>() + 1, promotion, MoveType::PROMOTION, Promotion::QUEEN));
-        moves.push_back(Move(promotion - attacks::pawnPushOffset<color>() + 1, promotion, MoveType::PROMOTION, Promotion::ROOK));
-        moves.push_back(Move(promotion - attacks::pawnPushOffset<color>() + 1, promotion, MoveType::PROMOTION, Promotion::BISHOP));
-        moves.push_back(Move(promotion - attacks::pawnPushOffset<color>() + 1, promotion, MoveType::PROMOTION, Promotion::KNIGHT));
+        Square from = promotion - PUSH_OFFSET + 1;
+        moves.push_back(Move(from, promotion, MoveType::PROMOTION, Promotion::QUEEN));
+        moves.push_back(Move(from, promotion, MoveType::PROMOTION, Promotion::ROOK));
+        moves.push_back(Move(from, promotion, MoveType::PROMOTION, Promotion::BISHOP));
+        moves.push_back(Move(from, promotion, MoveType::PROMOTION, Promotion::KNIGHT));
     }
 }

--- a/Sirius/src/search.cpp
+++ b/Sirius/src/search.cpp
@@ -1,15 +1,15 @@
 #include "search.h"
-#include "eval/eval.h"
-#include "movegen.h"
-#include "move_ordering.h"
-#include "comm/move.h"
 #include "comm/icomm.h"
+#include "comm/move.h"
+#include "eval/eval.h"
+#include "move_ordering.h"
+#include "movegen.h"
 #include "search_params.h"
 
-#include <cstring>
-#include <climits>
 #include <algorithm>
+#include <climits>
 #include <cmath>
+#include <cstring>
 
 namespace search
 {
@@ -21,7 +21,9 @@ MultiArray<int, 64, 64> genLMRTable()
     {
         for (int i = 1; i < 64; i++)
         {
-            lmrTable[d][i] = static_cast<int>(lmrBase / 100.0 + std::log(static_cast<double>(d)) * std::log(static_cast<double>(i)) / (lmrDivisor / 100.0));
+            lmrTable[d][i] = static_cast<int>(lmrBase / 100.0
+                + std::log(static_cast<double>(d)) * std::log(static_cast<double>(i))
+                    / (lmrDivisor / 100.0));
         }
     }
     return lmrTable;
@@ -38,7 +40,6 @@ void init()
 SearchThread::SearchThread(uint32_t id, std::thread&& thread)
     : id(id), thread(std::move(thread)), wakeFlag(WakeFlag::SEARCH), limits(), stack(), history()
 {
-
 }
 
 void SearchThread::reset()
@@ -79,28 +80,31 @@ void SearchThread::initRootMoves()
 
 void SearchThread::sortRootMoves()
 {
-    std::stable_sort(rootMoves.begin(), rootMoves.end(), [](const RootMove& a, const RootMove& b)
-    {
-        return a.score == b.score ? a.previousScore > b.previousScore : a.score > b.score;
-    });
+    std::stable_sort(rootMoves.begin(), rootMoves.end(),
+        [](const RootMove& a, const RootMove& b)
+        {
+            return a.score == b.score ? a.previousScore > b.previousScore : a.score > b.score;
+        });
 }
 
 RootMove& SearchThread::findRootMove(Move move)
 {
-    auto it = std::find_if(rootMoves.begin(), rootMoves.end(), [=](const RootMove& rm)
-    {
-        return rm.move == move;
-    });
+    auto it = std::find_if(rootMoves.begin(), rootMoves.end(),
+        [=](const RootMove& rm)
+        {
+            return rm.move == move;
+        });
     return *it;
 }
 
 void SearchThread::wait()
 {
     std::unique_lock<std::mutex> uniqueLock(mutex);
-    cv.wait(uniqueLock, [&]
-    {
-        return wakeFlag == WakeFlag::NONE;
-    });
+    cv.wait(uniqueLock,
+        [&]
+        {
+            return wakeFlag == WakeFlag::NONE;
+        });
 }
 
 void SearchThread::join()
@@ -182,10 +186,11 @@ void Search::setThreads(int count)
         {
             m_Threads.push_back(std::make_unique<SearchThread>(i, std::thread()));
             auto& searchThread = m_Threads.back();
-            searchThread->thread = std::thread([this, &searchThread]
-            {
-                threadLoop(*searchThread);
-            });
+            searchThread->thread = std::thread(
+                [this, &searchThread]
+                {
+                    threadLoop(*searchThread);
+                });
             searchThread->wait();
         }
     }
@@ -219,10 +224,11 @@ void Search::threadLoop(SearchThread& thread)
         thread.cv.notify_one();
 
         thread.wakeFlag = WakeFlag::NONE;
-        thread.cv.wait(uniqueLock, [&thread]
-        {
-            return thread.wakeFlag != WakeFlag::NONE;
-        });
+        thread.cv.wait(uniqueLock,
+            [&thread]
+            {
+                return thread.wakeFlag != WakeFlag::NONE;
+            });
 
         WakeFlag flag = thread.wakeFlag;
         uniqueLock.unlock();
@@ -348,7 +354,8 @@ int Search::aspWindows(SearchThread& thread, int depth, Move& bestMove, int prev
 
     while (true)
     {
-        int searchScore = search(thread, std::max(aspDepth, 1), &thread.stack[0], alpha, beta, true, false);
+        int searchScore =
+            search(thread, std::max(aspDepth, 1), &thread.stack[0], alpha, beta, true, false);
         if (m_ShouldStop)
             return searchScore;
 
@@ -395,7 +402,8 @@ BenchData Search::benchSearch(int depth, const Board& board)
     return data;
 }
 
-int Search::search(SearchThread& thread, int depth, SearchStack* stack, int alpha, int beta, bool pvNode, bool cutnode)
+int Search::search(SearchThread& thread, int depth, SearchStack* stack, int alpha, int beta,
+    bool pvNode, bool cutnode)
 {
     if (thread.isMainThread() && m_TimeMan.stopHard(thread.limits, thread.nodes))
     {
@@ -450,11 +458,10 @@ int Search::search(SearchThread& thread, int depth, SearchStack* stack, int alph
         ttHit = m_TT.probe(board.zkey(), rootPly, ttData);
 
         // TT Cutoffs(~101 elo)
-        if (ttHit && !pvNode && ttData.depth >= depth && (
-            ttData.bound == TTEntry::Bound::EXACT ||
-            (ttData.bound == TTEntry::Bound::LOWER_BOUND && ttData.score >= beta) ||
-            (ttData.bound == TTEntry::Bound::UPPER_BOUND && ttData.score <= alpha)
-        ))
+        if (ttHit && !pvNode && ttData.depth >= depth
+            && (ttData.bound == TTEntry::Bound::EXACT
+                || (ttData.bound == TTEntry::Bound::LOWER_BOUND && ttData.score >= beta)
+                || (ttData.bound == TTEntry::Bound::UPPER_BOUND && ttData.score <= alpha)))
             return ttData.score;
 
         if (inCheck)
@@ -469,11 +476,10 @@ int Search::search(SearchThread& thread, int depth, SearchStack* stack, int alph
             stack->staticEval = history.correctStaticEval(board, rawStaticEval, stack, rootPly);
             stack->eval = stack->staticEval;
             // use tt score as a better eval(~8 elo)
-            if (ttHit && (
-                ttData.bound == TTEntry::Bound::EXACT ||
-                (ttData.bound == TTEntry::Bound::LOWER_BOUND && ttData.score >= stack->eval) ||
-                (ttData.bound == TTEntry::Bound::UPPER_BOUND && ttData.score <= stack->eval)
-            ))
+            if (ttHit
+                && (ttData.bound == TTEntry::Bound::EXACT
+                    || (ttData.bound == TTEntry::Bound::LOWER_BOUND && ttData.score >= stack->eval)
+                    || (ttData.bound == TTEntry::Bound::UPPER_BOUND && ttData.score <= stack->eval)))
                 stack->eval = ttData.score;
         }
     }
@@ -481,9 +487,8 @@ int Search::search(SearchThread& thread, int depth, SearchStack* stack, int alph
     bool ttPV = pvNode || (ttHit && ttData.pv);
     // Improving heuristic(~31 elo)
     bool improving = !inCheck && rootPly > 1 && stack->staticEval > (stack - 2)->staticEval;
-    bool oppWorsening =
-        !inCheck && rootPly > 0 &&
-        (stack - 1)->staticEval != SCORE_NONE && stack->staticEval > -(stack - 1)->staticEval + 1;
+    bool oppWorsening = !inCheck && rootPly > 0 && (stack - 1)->staticEval != SCORE_NONE
+        && stack->staticEval > -(stack - 1)->staticEval + 1;
 
     (stack + 1)->killers = {};
     Bitboard threats = board.threats();
@@ -492,9 +497,9 @@ int Search::search(SearchThread& thread, int depth, SearchStack* stack, int alph
     if (!pvNode && !inCheck && !excluded)
     {
         // reverse futility pruning(~86 elo)
-        int rfpMargin = (improving ? rfpImpMargin : rfpNonImpMargin) * depth - rfpOppWorsening * oppWorsening + (stack - 1)->histScore / rfpHistDivisor;
-        if (depth <= rfpMaxDepth &&
-            stack->eval >= std::max(rfpMargin, 20) + beta)
+        int rfpMargin = (improving ? rfpImpMargin : rfpNonImpMargin) * depth
+            - rfpOppWorsening * oppWorsening + (stack - 1)->histScore / rfpHistDivisor;
+        if (depth <= rfpMaxDepth && stack->eval >= std::max(rfpMargin, 20) + beta)
             return stack->eval;
 
         // razoring(~6 elo)
@@ -506,12 +511,15 @@ int Search::search(SearchThread& thread, int depth, SearchStack* stack, int alph
         }
 
         // null move pruning(~31 elo)
-        Bitboard nonPawns = board.pieces(board.sideToMove()) ^ board.pieces(board.sideToMove(), PieceType::PAWN);
-        if (board.pliesFromNull() > 0 && rootPly >= thread.nmpMinPly && depth >= nmpMinDepth &&
-            stack->eval >= beta && stack->staticEval >= beta + nmpEvalBaseMargin - nmpEvalDepthMargin * depth &&
-            nonPawns.multiple())
+        Bitboard nonPawns =
+            board.pieces(board.sideToMove()) ^ board.pieces(board.sideToMove(), PieceType::PAWN);
+        if (board.pliesFromNull() > 0 && rootPly >= thread.nmpMinPly && depth >= nmpMinDepth
+            && stack->eval >= beta
+            && stack->staticEval >= beta + nmpEvalBaseMargin - nmpEvalDepthMargin * depth
+            && nonPawns.multiple())
         {
-            int r = nmpBaseReduction + depth / nmpDepthReductionScale + std::min((stack->eval - beta) / nmpEvalReductionScale, nmpMaxEvalReduction);
+            int r = nmpBaseReduction + depth / nmpDepthReductionScale
+                + std::min((stack->eval - beta) / nmpEvalReductionScale, nmpMaxEvalReduction);
             makeNullMove(thread, stack);
             int nullScore = -search(thread, depth - r, stack + 1, -beta, -beta + 1, false, !cutnode);
             unmakeNullMove(thread, stack);
@@ -531,9 +539,8 @@ int Search::search(SearchThread& thread, int depth, SearchStack* stack, int alph
 
         // probcut(~3 elo)
         int probcutBeta = beta + probcutBetaMargin;
-        if (depth >= probcutMinDepth &&
-            !isMateScore(beta) &&
-            (!ttHit || ttData.score >= probcutBeta || ttData.depth + 3 < depth))
+        if (depth >= probcutMinDepth && !isMateScore(beta)
+            && (!ttHit || ttData.score >= probcutBeta || ttData.depth + 3 < depth))
         {
             MoveOrdering ordering(board, ttData.move, thread.history);
             ScoredMove scoredMove = {};
@@ -553,16 +560,18 @@ int Search::search(SearchThread& thread, int depth, SearchStack* stack, int alph
 
                 int score = -qsearch(thread, stack + 1, -probcutBeta, -probcutBeta + 1, false);
                 if (score >= probcutBeta && probcutDepth >= 0)
-                    score = -search(thread, probcutDepth, stack + 1, -probcutBeta, -probcutBeta + 1, false, !cutnode);
+                    score = -search(thread, probcutDepth, stack + 1, -probcutBeta, -probcutBeta + 1,
+                        false, !cutnode);
 
                 unmakeMove(thread, stack);
-                
+
                 if (m_ShouldStop)
                     return alpha;
 
                 if (score >= probcutBeta)
                 {
-                    m_TT.store(board.zkey(), probcutDepth + 1, rootPly, score, rawStaticEval, move, ttPV, TTEntry::Bound::LOWER_BOUND);
+                    m_TT.store(board.zkey(), probcutDepth + 1, rootPly, score, rawStaticEval, move,
+                        ttPV, TTEntry::Bound::LOWER_BOUND);
                     return score;
                 }
             }
@@ -570,18 +579,11 @@ int Search::search(SearchThread& thread, int depth, SearchStack* stack, int alph
     }
 
     // internal iterative reductions(~8 elo)
-    if (depth >= minIIRDepth && !inCheck && !excluded &&
-        (!ttHit || (ttData.move != Move::nullmove() && ttData.depth <= depth - 5)))
+    if (depth >= minIIRDepth && !inCheck && !excluded
+        && (!ttHit || (ttData.move != Move::nullmove() && ttData.depth <= depth - 5)))
         depth--;
 
-    MoveOrdering ordering(
-        board,
-        ttData.move,
-        stack->killers,
-        stack,
-        rootPly,
-        thread.history
-    );
+    MoveOrdering ordering(board, ttData.move, stack->killers, stack, rootPly, thread.history);
 
     (stack + 1)->failHighCount = 0;
 
@@ -609,7 +611,8 @@ int Search::search(SearchThread& thread, int depth, SearchStack* stack, int alph
 
         Piece movedPiece = movingPiece(board, move);
         int baseLMR = lmrTable[std::min(depth, 63)][std::min(movesPlayed, 63)];
-        int histScore = quiet ? history.getQuietStats(move, threats, movedPiece, stack, rootPly) : history.getNoisyStats(board, move);
+        int histScore = quiet ? history.getQuietStats(move, threats, movedPiece, stack, rootPly)
+                              : history.getNoisyStats(board, move);
         baseLMR -= histScore / (quiet ? lmrQuietHistDivisor : lmrNoisyHistDivisor);
 
         // move loop pruning(~184 elo)
@@ -617,23 +620,18 @@ int Search::search(SearchThread& thread, int depth, SearchStack* stack, int alph
         {
             // futility pruning(~1 elo)
             int lmrDepth = std::max(depth - baseLMR, 0);
-            int fpMargin = std::max(fpBaseMargin + fpDepthMargin * lmrDepth + histScore / fpHistDivisor, 20);
-            if (lmrDepth <= fpMaxDepth &&
-                quiet &&
-                !inCheck &&
-                alpha < SCORE_WIN &&
-                stack->staticEval + fpMargin <= alpha)
+            int fpMargin =
+                std::max(fpBaseMargin + fpDepthMargin * lmrDepth + histScore / fpHistDivisor, 20);
+            if (lmrDepth <= fpMaxDepth && quiet && !inCheck && alpha < SCORE_WIN
+                && stack->staticEval + fpMargin <= alpha)
             {
                 continue;
             }
 
             // capture futility pruning
             fpMargin = noisyFpDepthMargin * depth + noisyFpMovesPlayedMargin * movesPlayed / 128;
-            if (depth <= noisyFpMaxDepth &&
-                !quiet &&
-                !inCheck &&
-                alpha < SCORE_WIN &&
-                stack->staticEval + fpMargin <= alpha)
+            if (depth <= noisyFpMaxDepth && !quiet && !inCheck && alpha < SCORE_WIN
+                && stack->staticEval + fpMargin <= alpha)
             {
                 if (!isMateScore(bestScore) && bestScore <= stack->staticEval + fpMargin)
                     bestScore = stack->staticEval + fpMargin;
@@ -641,34 +639,26 @@ int Search::search(SearchThread& thread, int depth, SearchStack* stack, int alph
             }
 
             // late move pruning(~23 elo)
-            if (!pvNode &&
-                !inCheck &&
-                movesPlayed >= lmpMinMovesBase + depth * depth / (improving ? 1 : 2))
+            if (!pvNode && !inCheck
+                && movesPlayed >= lmpMinMovesBase + depth * depth / (improving ? 1 : 2))
                 break;
 
             // static exchange evaluation pruning(~5 elo)
-            int seeMargin = quiet ?
-                depth * seePruneMarginQuiet :
-                depth * seePruneMarginNoisy - std::clamp(histScore / seeCaptHistDivisor, -seeCaptHistMax * depth, seeCaptHistMax * depth);
-            if (!pvNode &&
-                !board.see(move, seeMargin))
+            int seeMargin = quiet ? depth * seePruneMarginQuiet
+                                  : depth * seePruneMarginNoisy
+                    - std::clamp(histScore / seeCaptHistDivisor, -seeCaptHistMax * depth,
+                        seeCaptHistMax * depth);
+            if (!pvNode && !board.see(move, seeMargin))
                 continue;
 
             // history pruning(~14 elo)
-            if (quiet &&
-                depth <= maxHistPruningDepth &&
-                histScore < -histPruningMargin * depth)
+            if (quiet && depth <= maxHistPruningDepth && histScore < -histPruningMargin * depth)
                 break;
         }
 
-        bool doSE = !root &&
-            rootPly < 2 * thread.rootDepth &&
-            !excluded &&
-            depth >= seMinDepth &&
-            ttData.move == move &&
-            ttData.depth >= depth - seTTDepthMargin &&
-            ttData.bound != TTEntry::Bound::UPPER_BOUND &&
-            !isMateScore(ttData.score);
+        bool doSE = !root && rootPly < 2 * thread.rootDepth && !excluded && depth >= seMinDepth
+            && ttData.move == move && ttData.depth >= depth - seTTDepthMargin
+            && ttData.bound != TTEntry::Bound::UPPER_BOUND && !isMateScore(ttData.score);
 
         int extension = 0;
 
@@ -703,7 +693,7 @@ int Search::search(SearchThread& thread, int depth, SearchStack* stack, int alph
 
         makeMove(thread, stack, move, histScore);
         movesPlayed++;
-        
+
         bool givesCheck = board.checkers().any();
         // check extensions(~13 elo)
         if (!doSE && givesCheck)
@@ -718,9 +708,8 @@ int Search::search(SearchThread& thread, int depth, SearchStack* stack, int alph
         int score = 0;
 
         // late move reductions(~111 elo)
-        if (movesPlayed >= (pvNode ? lmrMinMovesPv : lmrMinMovesNonPv) &&
-            depth >= lmrMinDepth &&
-            moveScore <= MoveOrdering::FIRST_KILLER_SCORE)
+        if (movesPlayed >= (pvNode ? lmrMinMovesPv : lmrMinMovesNonPv) && depth >= lmrMinDepth
+            && moveScore <= MoveOrdering::FIRST_KILLER_SCORE)
         {
             int reduction = baseLMR;
 
@@ -737,7 +726,8 @@ int Search::search(SearchThread& thread, int depth, SearchStack* stack, int alph
             score = -search(thread, reduced, stack + 1, -alpha - 1, -alpha, false, true);
             if (score > alpha && reduced < newDepth)
             {
-                bool doDeeper = score > bestScore + doDeeperMarginBase + doDeeperMarginDepth * newDepth / 16;
+                bool doDeeper =
+                    score > bestScore + doDeeperMarginBase + doDeeperMarginDepth * newDepth / 16;
                 bool doShallower = score < bestScore + doShallowerMargin;
                 newDepth += doDeeper - doShallower;
                 score = -search(thread, newDepth, stack + 1, -alpha - 1, -alpha, false, !cutnode);
@@ -847,9 +837,9 @@ int Search::search(SearchThread& thread, int depth, SearchStack* stack, int alph
 
     if (!excluded)
     {
-        if (!inCheck && (bestMove == Move::nullmove() || moveIsQuiet(board, bestMove)) &&
-            !(bound == TTEntry::Bound::LOWER_BOUND && stack->staticEval >= bestScore) &&
-            !(bound == TTEntry::Bound::UPPER_BOUND && stack->staticEval <= bestScore))
+        if (!inCheck && (bestMove == Move::nullmove() || moveIsQuiet(board, bestMove))
+            && !(bound == TTEntry::Bound::LOWER_BOUND && stack->staticEval >= bestScore)
+            && !(bound == TTEntry::Bound::UPPER_BOUND && stack->staticEval <= bestScore))
             history.updateCorrHist(board, bestScore - stack->staticEval, depth, stack, rootPly);
 
         m_TT.store(board.zkey(), depth, rootPly, bestScore, rawStaticEval, bestMove, ttPV, bound);
@@ -877,11 +867,10 @@ int Search::qsearch(SearchThread& thread, SearchStack* stack, int alpha, int bet
     bool ttPV = pvNode || (ttHit && ttData.pv);
 
     // tt cutoffs(~101 elo)
-    if (ttHit && !pvNode && (
-        ttData.bound == TTEntry::Bound::EXACT ||
-        (ttData.bound == TTEntry::Bound::LOWER_BOUND && ttData.score >= beta) ||
-        (ttData.bound == TTEntry::Bound::UPPER_BOUND && ttData.score <= alpha)
-    ))
+    if (ttHit && !pvNode
+        && (ttData.bound == TTEntry::Bound::EXACT
+            || (ttData.bound == TTEntry::Bound::LOWER_BOUND && ttData.score >= beta)
+            || (ttData.bound == TTEntry::Bound::UPPER_BOUND && ttData.score <= alpha)))
         return ttData.score;
 
     bool inCheck = board.checkers().any();
@@ -896,15 +885,16 @@ int Search::qsearch(SearchThread& thread, SearchStack* stack, int alpha, int bet
     {
         rawStaticEval = ttHit ? ttData.staticEval : eval::evaluate(board, &thread);
         // Correction history(~104 elo)
-        stack->staticEval = inCheck ? SCORE_NONE : thread.history.correctStaticEval(board, rawStaticEval, stack, rootPly);
+        stack->staticEval = inCheck
+            ? SCORE_NONE
+            : thread.history.correctStaticEval(board, rawStaticEval, stack, rootPly);
 
         // use tt score as a better eval(~8 elo)
         stack->eval = stack->staticEval;
-        if (ttHit && (
-            ttData.bound == TTEntry::Bound::EXACT ||
-            (ttData.bound == TTEntry::Bound::LOWER_BOUND && ttData.score >= stack->eval) ||
-            (ttData.bound == TTEntry::Bound::UPPER_BOUND && ttData.score <= stack->eval)
-        ))
+        if (ttHit
+            && (ttData.bound == TTEntry::Bound::EXACT
+                || (ttData.bound == TTEntry::Bound::LOWER_BOUND && ttData.score >= stack->eval)
+                || (ttData.bound == TTEntry::Bound::UPPER_BOUND && ttData.score <= stack->eval)))
             stack->eval = ttData.score;
     }
 
@@ -950,7 +940,7 @@ int Search::qsearch(SearchThread& thread, SearchStack* stack, int alpha, int bet
 
         makeMove(thread, stack, move, 0);
         movesPlayed++;
-        
+
         int score = -qsearch(thread, stack + 1, -beta, -alpha, pvNode);
 
         unmakeMove(thread, stack);
@@ -991,6 +981,5 @@ int Search::qsearch(SearchThread& thread, SearchStack* stack, int alpha, int bet
 
     return bestScore;
 }
-
 
 }

--- a/Sirius/src/search.h
+++ b/Sirius/src/search.h
@@ -2,18 +2,18 @@
 
 #include "board.h"
 #include "defs.h"
-#include "tt.h"
-#include "time_man.h"
-#include "history.h"
-#include "eval/pawn_table.h"
 #include "eval/eval_state.h"
+#include "eval/pawn_table.h"
+#include "history.h"
+#include "time_man.h"
+#include "tt.h"
 
 #include <array>
-#include <deque>
-#include <thread>
-#include <mutex>
-#include <condition_variable>
 #include <atomic>
+#include <condition_variable>
+#include <deque>
+#include <mutex>
+#include <thread>
 #include <vector>
 
 struct SearchStack
@@ -44,7 +44,7 @@ struct SearchInfo
     int hashfull;
     uint64_t nodes;
     Duration time;
-    const Move* pvBegin, * pvEnd;
+    const Move *pvBegin, *pvEnd;
     int score;
 };
 
@@ -78,7 +78,6 @@ struct RootMove
 inline RootMove::RootMove(Move move)
     : move(move)
 {
-
 }
 
 struct SearchThread
@@ -107,7 +106,6 @@ struct SearchThread
     std::mutex mutex;
     std::condition_variable cv;
     WakeFlag wakeFlag;
-
 
     Board board;
 
@@ -144,6 +142,7 @@ public:
     {
         m_TT.resize(mb, m_Threads.size());
     }
+
 private:
     void joinThreads();
     void threadLoop(SearchThread& thread);
@@ -151,7 +150,8 @@ private:
     int iterDeep(SearchThread& thread, bool report, bool normalSearch);
     int aspWindows(SearchThread& thread, int depth, Move& bestMove, int prevScore);
 
-    int search(SearchThread& thread, int depth, SearchStack* stack, int alpha, int beta, bool pvNode, bool cutnode);
+    int search(SearchThread& thread, int depth, SearchStack* stack, int alpha, int beta,
+        bool pvNode, bool cutnode);
     int qsearch(SearchThread& thread, SearchStack* stack, int alpha, int beta, bool pvNode);
 
     void makeMove(SearchThread& thread, SearchStack* stack, Move move, int histScore);
@@ -167,6 +167,5 @@ private:
 
     std::vector<std::unique_ptr<SearchThread>> m_Threads;
 };
-
 
 }

--- a/Sirius/src/search_params.cpp
+++ b/Sirius/src/search_params.cpp
@@ -4,8 +4,8 @@
 #include "comm/uci.h"
 #endif
 
-#include <cmath>
 #include "util/multi_array.h"
+#include <cmath>
 
 namespace search
 {
@@ -21,7 +21,8 @@ std::deque<SearchParam>& searchParams()
     return params;
 }
 
-SearchParam& addSearchParam(std::string name, int value, int min, int max, int step, std::function<void()> callback)
+SearchParam& addSearchParam(
+    std::string name, int value, int min, int max, int step, std::function<void()> callback)
 {
     searchParams().push_back({name, value, value, min, max, step, callback});
     SearchParam& param = searchParams().back();
@@ -51,12 +52,9 @@ void printOpenBenchConfig()
 {
     for (auto& param : searchParams())
     {
-        std::cout << param.name << ", int, "
-            << param.defaultValue << ", "
-            << param.min << ", "
-            << param.max << ", "
-            << param.step << ", "
-            << "0.002" << std::endl;
+        std::cout << param.name << ", int, " << param.defaultValue << ", " << param.min << ", "
+                  << param.max << ", " << param.step << ", "
+                  << "0.002" << std::endl;
     }
 }
 
@@ -68,6 +66,5 @@ void updateLmrTable()
 {
     lmrTable = genLMRTable();
 }
-
 
 }

--- a/Sirius/src/search_params.h
+++ b/Sirius/src/search_params.h
@@ -1,15 +1,14 @@
 #pragma once
 
 #include <cstdint>
-#include <string>
 #include <deque>
 #include <functional>
+#include <string>
 
 namespace search
 {
 
 #ifdef EXTERNAL_TUNE
-
 
 struct SearchParam
 {
@@ -23,7 +22,8 @@ struct SearchParam
 };
 
 std::deque<SearchParam>& searchParams();
-SearchParam& addSearchParam(std::string name, int value, int min, int max, int step, std::function<void()> callback = std::function<void()>());
+SearchParam& addSearchParam(std::string name, int value, int min, int max, int step,
+    std::function<void()> callback = std::function<void()>());
 void printWeatherFactoryConfig();
 void printOpenBenchConfig();
 void updateLmrTable();
@@ -36,7 +36,8 @@ void updateLmrTable();
     inline const int& name = name##Param.value
 #else
 #define SEARCH_PARAM(name, val, min, max, step) constexpr int name = val;
-#define SEARCH_PARAM_CALLBACK(name, val, min, max, step, callback) SEARCH_PARAM(name, val, min, max, step)
+#define SEARCH_PARAM_CALLBACK(name, val, min, max, step, callback) \
+    SEARCH_PARAM(name, val, min, max, step)
 #endif
 
 SEARCH_PARAM(hardTimeScale, 61, 20, 100, 5);
@@ -150,6 +151,5 @@ SEARCH_PARAM(doDeeperMarginDepth, 36, 8, 96, 5);
 SEARCH_PARAM(doShallowerMargin, 8, 2, 15, 1);
 
 SEARCH_PARAM(qsFpMargin, 61, 0, 250, 16);
-
 
 }

--- a/Sirius/src/time_man.cpp
+++ b/Sirius/src/time_man.cpp
@@ -12,9 +12,9 @@ void TimeManager::setLimits(const SearchLimits& limits, Color us)
             std::max(Duration(1), limits.clock.timeLeft[static_cast<int>(us)] - limits.overhead);
         Duration inc = limits.clock.increments[static_cast<int>(us)];
 
+        auto baseTime = (time / search::baseTimeScale + inc * search::incrementScale / 100.0);
         // formulas from stormphrax
-        m_SoftBound = std::chrono::duration_cast<Duration>(search::softTimeScale / 100.0
-            * (time / search::baseTimeScale + inc * search::incrementScale / 100.0));
+        m_SoftBound = std::chrono::duration_cast<Duration>(search::softTimeScale / 100.0 * baseTime);
         m_HardBound = std::chrono::duration_cast<Duration>(time * (search::hardTimeScale / 100.0));
     }
 }
@@ -57,13 +57,26 @@ bool TimeManager::stopSoft(
     m_PrevBestMove = bestMove;
 
     double nodeFrac = static_cast<double>(bmNodes) / static_cast<double>(totalNodes);
-    double scale = ((search::nodeTMBase / 100.0) - nodeFrac) * (search::nodeTMScale / 100.0);
+    double nodeScale = [&]()
+    {
+        double base = static_cast<double>(search::nodeTMBase) / 100.0;
+        double scale = static_cast<double>(search::nodeTMScale) / 100.0;
+        return (base - nodeFrac) * scale;
+    }();
 
-    double bmStabilityScale = static_cast<double>(search::bmStabilityBase) / 100.0
-        + static_cast<double>(search::bmStabilityScale) / 100.0
-            * std::pow(m_Stability + static_cast<double>(search::bmStabilityOffset) / 100.0,
-                static_cast<double>(search::bmStabilityPower) / 100.0);
-    scale *= std::max(bmStabilityScale, static_cast<double>(search::bmStabilityMin) / 100);
+    double bmStabilityScale = [&]()
+    {
+        double base = static_cast<double>(search::bmStabilityBase) / 100.0;
+        double scale = static_cast<double>(search::bmStabilityScale) / 100.0;
+        double offset = static_cast<double>(search::bmStabilityOffset) / 100.0;
+        double power = static_cast<double>(search::bmStabilityPower) / 100.0;
+        double min = static_cast<double>(search::bmStabilityMin) / 100;
+
+        double result = base + scale * std::pow(m_Stability + offset, power);
+        return std::max(result, min);
+    }();
+
+    double scale = nodeScale * bmStabilityScale;
     if (searchLimits.clock.enabled && elapsed() > m_SoftBound * scale)
         return true;
     return false;

--- a/Sirius/src/time_man.cpp
+++ b/Sirius/src/time_man.cpp
@@ -1,18 +1,20 @@
 #include "time_man.h"
 #include "search.h"
 #include "search_params.h"
-#include <iostream>
 #include <cmath>
+#include <iostream>
 
 void TimeManager::setLimits(const SearchLimits& limits, Color us)
 {
     if (limits.clock.enabled)
     {
-        Duration time = std::max(Duration(1), limits.clock.timeLeft[static_cast<int>(us)] - limits.overhead);
+        Duration time =
+            std::max(Duration(1), limits.clock.timeLeft[static_cast<int>(us)] - limits.overhead);
         Duration inc = limits.clock.increments[static_cast<int>(us)];
 
         // formulas from stormphrax
-        m_SoftBound = std::chrono::duration_cast<Duration>(search::softTimeScale / 100.0 * (time / search::baseTimeScale + inc * search::incrementScale / 100.0));
+        m_SoftBound = std::chrono::duration_cast<Duration>(search::softTimeScale / 100.0
+            * (time / search::baseTimeScale + inc * search::incrementScale / 100.0));
         m_HardBound = std::chrono::duration_cast<Duration>(time * (search::hardTimeScale / 100.0));
     }
 }
@@ -45,7 +47,8 @@ bool TimeManager::stopHard(const SearchLimits& searchLimits, uint64_t nodes)
     return false;
 }
 
-bool TimeManager::stopSoft(Move bestMove, uint64_t bmNodes, uint64_t totalNodes, const SearchLimits& searchLimits)
+bool TimeManager::stopSoft(
+    Move bestMove, uint64_t bmNodes, uint64_t totalNodes, const SearchLimits& searchLimits)
 {
     if (bestMove == m_PrevBestMove)
         m_Stability++;
@@ -56,12 +59,10 @@ bool TimeManager::stopSoft(Move bestMove, uint64_t bmNodes, uint64_t totalNodes,
     double nodeFrac = static_cast<double>(bmNodes) / static_cast<double>(totalNodes);
     double scale = ((search::nodeTMBase / 100.0) - nodeFrac) * (search::nodeTMScale / 100.0);
 
-    double bmStabilityScale =
-        static_cast<double>(search::bmStabilityBase) / 100.0 +
-        static_cast<double>(search::bmStabilityScale) / 100.0 * std::pow(
-            m_Stability + static_cast<double>(search::bmStabilityOffset) / 100.0,
-            static_cast<double>(search::bmStabilityPower) / 100.0
-        );
+    double bmStabilityScale = static_cast<double>(search::bmStabilityBase) / 100.0
+        + static_cast<double>(search::bmStabilityScale) / 100.0
+            * std::pow(m_Stability + static_cast<double>(search::bmStabilityOffset) / 100.0,
+                static_cast<double>(search::bmStabilityPower) / 100.0);
     scale *= std::max(bmStabilityScale, static_cast<double>(search::bmStabilityMin) / 100);
     if (searchLimits.clock.enabled && elapsed() > m_SoftBound * scale)
         return true;

--- a/Sirius/src/time_man.h
+++ b/Sirius/src/time_man.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include <chrono>
-#include <array>
 #include "defs.h"
+#include <array>
+#include <chrono>
 
 using TimePoint = std::chrono::steady_clock::time_point;
 using Duration = std::chrono::milliseconds;
@@ -33,7 +33,9 @@ public:
 
     void startSearch();
     bool stopHard(const SearchLimits& searchLimits, uint64_t nodes);
-    bool stopSoft(Move bestMove, uint64_t bmNodes, uint64_t totalNodes, const SearchLimits& searchLimits);
+    bool stopSoft(
+        Move bestMove, uint64_t bmNodes, uint64_t totalNodes, const SearchLimits& searchLimits);
+
 private:
     static constexpr uint32_t TIME_CHECK_INTERVAL = 2048;
 

--- a/Sirius/src/tt.cpp
+++ b/Sirius/src/tt.cpp
@@ -44,7 +44,8 @@ uint64_t mulhi64(uint64_t a, uint64_t b)
 }
 #endif
 
-void* alignedAlloc(size_t alignment, size_t size) {
+void* alignedAlloc(size_t alignment, size_t size)
+{
 #ifdef _WIN32
     return _aligned_malloc(size, alignment);
 #else
@@ -52,7 +53,8 @@ void* alignedAlloc(size_t alignment, size_t size) {
 #endif
 }
 
-void alignedFree(void* ptr) {
+void alignedFree(void* ptr)
+{
     if (ptr == nullptr)
         return;
 #ifdef _WIN32
@@ -61,7 +63,6 @@ void alignedFree(void* ptr) {
     return std::free(ptr);
 #endif
 }
-
 
 TT::TT(size_t sizeMB)
     : m_Buckets(nullptr), m_Size(0), m_CurrAge(0)
@@ -137,7 +138,8 @@ bool TT::probe(ZKey key, int ply, ProbedTTData& ttData)
     return true;
 }
 
-void TT::store(ZKey key, int depth, int ply, int score, int staticEval, Move move, bool pv, TTEntry::Bound bound)
+void TT::store(ZKey key, int depth, int ply, int score, int staticEval, Move move, bool pv,
+    TTEntry::Bound bound)
 {
     // 16 bit keys to save space
     // idea from JW
@@ -161,23 +163,21 @@ void TT::store(ZKey key, int depth, int ply, int score, int staticEval, Move mov
         }
     }
 
-    // only overwrite the move if new move is not a null move or the entry is from a different position
-    // idea from stockfish and ethereal
+    // only overwrite the move if new move is not a null move or the entry is from a different
+    // position idea from stockfish and ethereal
     TTEntry& replace = bucket.entries[replaceIdx];
     if (move != Move() || replace.key16 != key16)
         replace.bestMove = move;
 
-    // only overwrite if we have exact bound, different position, or same position and depth is not significantly worse
-    // idea from stockfish and ethereal
+    // only overwrite if we have exact bound, different position, or same position and depth is not
+    // significantly worse idea from stockfish and ethereal
     /*if (bound != TTEntry::Bound::EXACT &&
         entry.key16 == key16 &&
         depth < entry.depth - 2)
         return;*/
 
-    if (bound == TTEntry::Bound::EXACT ||
-        replace.key16 != key16 ||
-        depth >= replace.depth - 2 - 2 * pv ||
-        replace.gen() != m_CurrAge)
+    if (bound == TTEntry::Bound::EXACT || replace.key16 != key16
+        || depth >= replace.depth - 2 - 2 * pv || replace.gen() != m_CurrAge)
     {
         replace.key16 = key16;
         replace.staticEval = staticEval;
@@ -210,8 +210,10 @@ uint32_t TT::index(uint64_t key) const
 int TT::hashfull() const
 {
     int count = 0;
-    for (int i = 0; i < 1000; i++) {
-        for (int j = 0; j < ENTRY_COUNT; j++) {
+    for (int i = 0; i < 1000; i++)
+    {
+        for (int j = 0; j < ENTRY_COUNT; j++)
+        {
             const auto& entry = m_Buckets[i].entries[j];
             if (entry.bound() != TTEntry::Bound::NONE && entry.gen() == m_CurrAge)
                 count++;

--- a/Sirius/src/tt.h
+++ b/Sirius/src/tt.h
@@ -16,7 +16,7 @@ struct TTEntry
     int16_t staticEval;
     Move bestMove;
     uint8_t depth;
-    // 2 bits bound(lower), 6 bits gen(upper)
+    // 2 bits bound, 1 bit pv, 5 bits gen
     uint8_t genBoundPV;
 
     enum class Bound : uint8_t
@@ -42,9 +42,9 @@ struct TTEntry
         return static_cast<Bound>(genBoundPV & 3);
     }
 
-    static uint8_t makeGenBoundPV(bool pv, uint8_t gen, Bound bound)
+    void setGenBoundPV(bool pv, uint8_t gen, Bound bound)
     {
-        return static_cast<int>(bound) | (pv << 2) | (gen << 3);
+        genBoundPV = static_cast<int>(bound) | (pv << 2) | (gen << 3);
     }
 };
 
@@ -105,8 +105,9 @@ public:
             threads.emplace_back(
                 [i, this, numThreads]()
                 {
-                    std::fill(m_Buckets + m_Size * i / numThreads,
-                        m_Buckets + m_Size * (i + 1) / numThreads, TTBucket{});
+                    auto begin = m_Buckets + m_Size * i / numThreads;
+                    auto end = m_Buckets + m_Size * (i + 1) / numThreads;
+                    std::fill(begin, end, TTBucket{});
                 });
         }
     }

--- a/Sirius/src/tt.h
+++ b/Sirius/src/tt.h
@@ -1,13 +1,13 @@
 #pragma once
 
-#include "zobrist.h"
 #include "defs.h"
+#include "zobrist.h"
 
-#include <cstring>
-#include <vector>
-#include <array>
 #include <algorithm>
+#include <array>
+#include <cstring>
 #include <thread>
+#include <vector>
 
 struct TTEntry
 {
@@ -84,7 +84,8 @@ public:
     TT& operator=(const TT&) = delete;
 
     bool probe(ZKey key, int ply, ProbedTTData& ttData);
-    void store(ZKey key, int ply, int depth, int score, int staticEval, Move move, bool pv, TTEntry::Bound type);
+    void store(ZKey key, int ply, int depth, int score, int staticEval, Move move, bool pv,
+        TTEntry::Bound type);
     int quality(int age, int depth) const;
     void prefetch(ZKey key) const;
 
@@ -101,14 +102,17 @@ public:
 
         for (int i = 0; i < numThreads; i++)
         {
-            threads.emplace_back([i, this, numThreads]()
-            {
-                std::fill(m_Buckets + m_Size * i / numThreads, m_Buckets + m_Size * (i + 1) / numThreads, TTBucket{});
-            });
+            threads.emplace_back(
+                [i, this, numThreads]()
+                {
+                    std::fill(m_Buckets + m_Size * i / numThreads,
+                        m_Buckets + m_Size * (i + 1) / numThreads, TTBucket{});
+                });
         }
     }
 
     int hashfull() const;
+
 private:
     uint32_t index(uint64_t key) const;
 

--- a/Sirius/src/util/multi_array.h
+++ b/Sirius/src/util/multi_array.h
@@ -6,18 +6,18 @@
 // stormphrax yoink
 namespace internal
 {
-    template<typename T, size_t N, size_t ...Ns>
-    struct MultiArrayImpl
-    {
-        using Type = std::array<typename MultiArrayImpl<T, Ns...>::Type, N>;
-    };
+template<typename T, size_t N, size_t... Ns>
+struct MultiArrayImpl
+{
+    using Type = std::array<typename MultiArrayImpl<T, Ns...>::Type, N>;
+};
 
-    template<typename T, size_t N>
-    struct MultiArrayImpl<T, N>
-    {
-        using Type = std::array<T, N>;
-    };
+template<typename T, size_t N>
+struct MultiArrayImpl<T, N>
+{
+    using Type = std::array<T, N>;
+};
 }
 
-template<typename T, size_t ...Ns>
+template<typename T, size_t... Ns>
 using MultiArray = typename internal::MultiArrayImpl<T, Ns...>::Type;

--- a/Sirius/src/util/piece_set.h
+++ b/Sirius/src/util/piece_set.h
@@ -8,14 +8,14 @@ public:
     constexpr PieceSet()
         : m_Value(0)
     {
-
     }
 
     template<typename Type, typename... Types>
     constexpr PieceSet(Type type, Types... types)
         : m_Value(PieceSet(types...).m_Value)
     {
-        static_assert(std::is_same_v<Type, PieceType>, "Piece set constructor argument must be a Piecetype");
+        static_assert(
+            std::is_same_v<Type, PieceType>, "Piece set constructor argument must be a Piecetype");
         add(type);
     }
 
@@ -37,7 +37,7 @@ public:
     {
         return (m_Value & other.m_Value) > 0;
     }
+
 private:
     uint8_t m_Value;
 };
-

--- a/Sirius/src/util/piece_set.h
+++ b/Sirius/src/util/piece_set.h
@@ -15,17 +15,17 @@ public:
         : m_Value(PieceSet(types...).m_Value)
     {
         static_assert(
-            std::is_same_v<Type, PieceType>, "Piece set constructor argument must be a Piecetype");
+            std::is_same_v<Type, PieceType>, "Piece set constructor argument must be a PieceType");
         add(type);
     }
 
     constexpr void add(PieceType piece)
     {
-        m_Value |= (1ull << static_cast<int>(piece));
+        m_Value |= 1 << static_cast<int>(piece);
     }
     constexpr void remove(PieceType piece)
     {
-        m_Value &= ~(1ull << static_cast<int>(piece));
+        m_Value &= ~(1 << static_cast<int>(piece));
     }
 
     constexpr bool has(PieceType piece) const

--- a/Sirius/src/util/prng.h
+++ b/Sirius/src/util/prng.h
@@ -10,6 +10,7 @@ public:
     constexpr PRNG() = default;
     constexpr void seed(uint64_t s);
     constexpr uint64_t next64();
+
 private:
     uint64_t a, b, c, counter;
 };

--- a/Sirius/src/util/static_vector.h
+++ b/Sirius/src/util/static_vector.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <array>
 #include <algorithm>
+#include <array>
 #include <cassert>
 #include <cstddef>
 
@@ -32,7 +32,6 @@ public:
     {
         std::fill(begin(), end(), value);
     }
-
 
     size_t size() const
     {
@@ -95,6 +94,7 @@ public:
     {
         m_Size = size;
     }
+
 private:
     std::array<T, Capacity> m_Data;
     size_t m_Size = 0;

--- a/Sirius/src/util/string_split.h
+++ b/Sirius/src/util/string_split.h
@@ -1,10 +1,11 @@
-#include <vector>
+#include <sstream>
 #include <string>
 #include <string_view>
-#include <sstream>
+#include <vector>
 
 // https://stackoverflow.com/a/236803
-std::vector<std::string> splitBySpaces(const std::string_view& str) {
+std::vector<std::string> splitBySpaces(const std::string_view& str)
+{
     std::istringstream iss{std::string(str)};
     std::string token;
     std::vector<std::string> result;

--- a/Sirius/src/zobrist.h
+++ b/Sirius/src/zobrist.h
@@ -1,9 +1,9 @@
 #pragma once
 
-#include <cstdint>
 #include "defs.h"
 #include "util/multi_array.h"
 #include "util/prng.h"
+#include <cstdint>
 
 namespace zobrist
 {
@@ -65,17 +65,20 @@ inline void ZKey::flipSideToMove()
 
 inline void ZKey::addPiece(PieceType piece, Color color, Square square)
 {
-    value ^= zobrist::keys.pieceSquares[static_cast<int>(color)][static_cast<int>(piece)][square.value()];
+    value ^=
+        zobrist::keys.pieceSquares[static_cast<int>(color)][static_cast<int>(piece)][square.value()];
 }
 
 inline void ZKey::removePiece(PieceType piece, Color color, Square square)
 {
-    value ^= zobrist::keys.pieceSquares[static_cast<int>(color)][static_cast<int>(piece)][square.value()];
+    value ^=
+        zobrist::keys.pieceSquares[static_cast<int>(color)][static_cast<int>(piece)][square.value()];
 }
 
 inline void ZKey::movePiece(PieceType piece, Color color, Square src, Square dst)
 {
-    value ^= zobrist::keys.pieceSquares[static_cast<int>(color)][static_cast<int>(piece)][src.value()] ^ zobrist::keys.pieceSquares[static_cast<int>(color)][static_cast<int>(piece)][dst.value()];
+    value ^= zobrist::keys.pieceSquares[static_cast<int>(color)][static_cast<int>(piece)][src.value()]
+        ^ zobrist::keys.pieceSquares[static_cast<int>(color)][static_cast<int>(piece)][dst.value()];
 }
 
 inline void ZKey::updateCastlingRights(CastlingRights castlingRights)


### PR DESCRIPTION
Finally bit the bullet and added clang-format
This also includes a few minor cleanups
- Renaming "PackedScore" to "ScorePair", which is a much better name
- A few minor cleanups of the evaluation code
- Removing any instance of `Bitboard(0)` and `Bitboard(~0ull)`, and replacing them with `EMPTY_BB` and `ALL_BB`, respectively.
- Some minor changes in the transposition table code
- Some minor changes in search
- Added .vscode to gitignore
- A few changes in the board, castling, history, search, move generation, and time management code to make the formatting more readable

No functional change

Bench: 6643957