### PR TITLE
Simplify noisy futility pruning

### DIFF
--- a/Sirius/src/search.cpp
+++ b/Sirius/src/search.cpp
@@ -627,7 +627,7 @@ int Search::search(SearchThread& thread, int depth, SearchStack* stack, int alph
             }
 
             // capture futility pruning
-            fpMargin = noisyFpDepthMargin * depth + noisyFpMovesPlayedMargin * movesPlayed / 128;
+            fpMargin = noisyFPBaseMargin + noisyFpDepthMargin * depth;
             if (depth <= noisyFpMaxDepth && !quiet && !inCheck && alpha < SCORE_WIN
                 && stack->staticEval + fpMargin <= alpha)
             {

--- a/Sirius/src/search_params.h
+++ b/Sirius/src/search_params.h
@@ -116,8 +116,8 @@ SEARCH_PARAM(fpHistDivisor, 400, 256, 512, 16);
 SEARCH_PARAM(fpMaxDepth, 8, 4, 9, 1);
 
 SEARCH_PARAM(noisyFpMaxDepth, 5, 2, 9, 1);
+SEARCH_PARAM(noisyFPBaseMargin, 5, -100, 200, 10);
 SEARCH_PARAM(noisyFpDepthMargin, 122, 10, 360, 12);
-SEARCH_PARAM(noisyFpMovesPlayedMargin, 371, 20, 2000, 40);
 
 SEARCH_PARAM(lmpMinMovesBase, 2, 2, 7, 1);
 


### PR DESCRIPTION
```
Elo   | -0.21 +- 2.12 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.04 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 34416 W: 8886 L: 8907 D: 16623
Penta | [366, 4244, 8032, 4177, 389]
```
https://mcthouacbb.pythonanywhere.com/test/813/

Bench: 6445901