### PR TITLE
Slight corrhist refactor

### DIFF
--- a/Sirius/src/history.h
+++ b/Sirius/src/history.h
@@ -111,13 +111,29 @@ using ContHist = MultiArray<CHEntry, 12, 64>;
 // capture history(~19 elo)
 using CaptHist = MultiArray<HistoryEntry<HISTORY_MAX>, 7, 12, 64, 2, 2>;
 
-// correction history(~104 elo)
 constexpr int CORR_HIST_ENTRIES = 16384;
-using PawnCorrHist = MultiArray<CorrHistEntry, 2, CORR_HIST_ENTRIES>;
-using NonPawnCorrHist = MultiArray<CorrHistEntry, 2, 2, CORR_HIST_ENTRIES>;
-using ThreatsCorrHist = MultiArray<CorrHistEntry, 2, CORR_HIST_ENTRIES>;
-using MinorPieceCorrHist = MultiArray<CorrHistEntry, 2, CORR_HIST_ENTRIES>;
-using MajorPieceCorrHist = MultiArray<CorrHistEntry, 2, CORR_HIST_ENTRIES>;
+
+struct CorrHist
+{
+    CorrHistEntry& get(Color color, uint64_t key)
+    {
+        return data[static_cast<int>(color)][key % CORR_HIST_ENTRIES];
+    }
+
+    const CorrHistEntry& get(Color color, uint64_t key) const
+    {
+        return data[static_cast<int>(color)][key % CORR_HIST_ENTRIES];
+    }
+
+    MultiArray<CorrHistEntry, 2, CORR_HIST_ENTRIES> data;
+};
+
+// correction history(~104 elo)
+using PawnCorrHist = CorrHist;
+using NonPawnCorrHist = ColorArray<CorrHist>;
+using ThreatsCorrHist = CorrHist;
+using MinorPieceCorrHist = CorrHist;
+using MajorPieceCorrHist = CorrHist;
 using ContCorrEntry = MultiArray<CorrHistEntry, 12, 64>;
 using ContCorrHist = MultiArray<ContCorrEntry, 12, 64>;
 


### PR DESCRIPTION
Simplify the long indexing
No functional change
```
Elo   | 0.47 +- 2.59 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.97 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 21420 W: 5532 L: 5503 D: 10385
Penta | [213, 2437, 5387, 2454, 219]
```
https://mcthouacbb.pythonanywhere.com/test/836/

Bench: 6444306