### PR TITLE
Consider alpha raises as upperbounds in qsearch

### DIFF
--- a/Sirius/src/search.cpp
+++ b/Sirius/src/search.cpp
@@ -959,7 +959,6 @@ int Search::qsearch(SearchThread& thread, SearchStack* stack, int alpha, int bet
                     stack->pv[i + 1] = (stack + 1)->pv[i];
 
                 alpha = bestScore;
-                bound = TTEntry::Bound::EXACT;
             }
 
             if (bestScore >= beta)


### PR DESCRIPTION
This is how stockfish and a few other engines do it
```
Elo   | 3.46 +- 4.33 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.97 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 8542 W: 2265 L: 2180 D: 4097
Penta | [87, 1043, 1967, 1046, 128]
```
https://mcthouacbb.pythonanywhere.com/test/845/

Bench: 6619595