### PR TITLE
Adjust noisy futility pruning margin by history

### DIFF
--- a/Sirius/src/search.cpp
+++ b/Sirius/src/search.cpp
@@ -625,8 +625,9 @@ int Search::search(SearchThread& thread, int depth, SearchStack* stack, int alph
                 continue;
             }
 
-            // capture futility pruning
-            fpMargin = std::max(noisyFPBaseMargin + noisyFpDepthMargin * depth + histScore / 250, 20);
+            // noisy futility pruning
+            fpMargin = std::max(
+                noisyFPBaseMargin + noisyFpDepthMargin * depth + histScore / noisyFpHistDivisor, 20);
             if (depth <= noisyFpMaxDepth && !quiet && !inCheck && alpha < SCORE_WIN
                 && stack->staticEval + fpMargin <= alpha)
             {

--- a/Sirius/src/search_params.h
+++ b/Sirius/src/search_params.h
@@ -116,14 +116,15 @@ SEARCH_PARAM(mvvBishop, 2382, -20000, 20000, 200);
 SEARCH_PARAM(mvvRook, 4799, -20000, 20000, 200);
 SEARCH_PARAM(mvvQueen, 7140, -20000, 20000, 200);
 
+SEARCH_PARAM(fpMaxDepth, 8, 4, 9, 1);
 SEARCH_PARAM(fpBaseMargin, 145, 60, 360, 12);
 SEARCH_PARAM(fpDepthMargin, 130, 10, 180, 12);
 SEARCH_PARAM(fpHistDivisor, 406, 256, 512, 16);
-SEARCH_PARAM(fpMaxDepth, 8, 4, 9, 1);
 
 SEARCH_PARAM(noisyFpMaxDepth, 5, 2, 9, 1);
 SEARCH_PARAM(noisyFPBaseMargin, 1, -100, 200, 10);
 SEARCH_PARAM(noisyFpDepthMargin, 110, 10, 360, 12);
+SEARCH_PARAM(noisyFpHistDivisor, 250, 100, 512, 16);
 
 SEARCH_PARAM(lmpImpBase, 518, 128, 2048, 64);
 SEARCH_PARAM(lmpImpDepth, 301, 64, 512, 48);


### PR DESCRIPTION
```
Elo   | 2.37 +- 1.85 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 45990 W: 11973 L: 11659 D: 22358
Penta | [470, 5639, 10577, 5725, 584]
```
https://mcthouacbb.pythonanywhere.com/test/859/

Bench: 6450905