### PR TITLE
Do all move loop pruning in pv nodes

### DIFF
--- a/Sirius/src/search.cpp
+++ b/Sirius/src/search.cpp
@@ -639,7 +639,7 @@ int Search::search(SearchThread& thread, int depth, SearchStack* stack, int alph
             // late move pruning(~23 elo)
             int lmpMargin = improving ? (lmpImpBase + depth * depth * lmpImpDepth) / 256
                                       : (lmpNonImpBase + depth * depth * lmpNonImpDepth) / 256;
-            if (!pvNode && !inCheck && movesPlayed >= lmpMargin)
+            if (!inCheck && movesPlayed >= lmpMargin)
                 break;
 
             // static exchange evaluation pruning(~5 elo)
@@ -649,7 +649,7 @@ int Search::search(SearchThread& thread, int depth, SearchStack* stack, int alph
                 int max = seeCaptHistMax * depth;
                 seeMargin -= std::clamp(histScore / seeCaptHistDivisor, -max, max);
             }
-            if (!pvNode && !board.see(move, seeMargin))
+            if (!board.see(move, seeMargin))
                 continue;
 
             // history pruning(~14 elo)


### PR DESCRIPTION
Suggestion to simplify this from @Ciekce
```
Elo   | -0.36 +- 1.99 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.96 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 38330 W: 9785 L: 9825 D: 18720
Penta | [437, 4593, 9100, 4643, 392]
```
https://mcthouacbb.pythonanywhere.com/test/864/

Bench: 6109837