### PR TITLE
Fix not clearing pinners when calculating check info

### DIFF
--- a/Sirius/src/board.cpp
+++ b/Sirius/src/board.cpp
@@ -548,6 +548,7 @@ Bitboard Board::pinnersBlockers(Square square, Bitboard attackers, Bitboard& pin
         | (attacks::bishopAttacks(square, EMPTY_BB) & (pieces(PieceType::BISHOP) | queens));
 
     Bitboard blockers = EMPTY_BB;
+    pinners = EMPTY_BB;
 
     Bitboard blockMask = allPieces() ^ attackers;
 


### PR DESCRIPTION
When making a move, it would keep all the old pinners in the pinners bitboard
Pinners are only used in SEE, so this doesn't have much effect on the engine

SPRT is just a sanity test, I would merge this even if it failed because it is just a straight up bug
```
Elo   | -0.92 +- 8.92 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 0.07 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 1884 W: 458 L: 463 D: 963
Penta | [18, 231, 452, 220, 21]
```
https://mcthouacbb.pythonanywhere.com/test/920/

Bench: 6012887