### PR TITLE
Simplify LMR Corrplexity to not use TT eval

### DIFF
--- a/Sirius/src/search.cpp
+++ b/Sirius/src/search.cpp
@@ -719,7 +719,7 @@ int Search::search(SearchThread& thread, int depth, SearchStack* stack, int alph
             reduction -= ttPV;
             reduction -= givesCheck;
             reduction -= inCheck;
-            reduction -= std::abs(stack->eval - rawStaticEval) > lmrCorrplexityMargin;
+            reduction -= std::abs(stack->staticEval - rawStaticEval) > lmrCorrplexityMargin;
             reduction += cutnode;
             reduction += (stack + 1)->failHighCount >= static_cast<uint32_t>(lmrFailHighCountMargin);
 


### PR DESCRIPTION
```
Elo   | 0.94 +- 3.03 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.96 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 17388 W: 4472 L: 4425 D: 8491
Penta | [214, 2100, 4022, 2141, 217]
```
https://mcthouacbb.pythonanywhere.com/test/924/

Bench: 5983305