### PR TITLE
Make corrplexity 0 in singular searches

### DIFF
--- a/Sirius/src/search.cpp
+++ b/Sirius/src/search.cpp
@@ -450,6 +450,7 @@ int Search::search(SearchThread& thread, int depth, SearchStack* stack, int alph
     bool ttHit = false;
 
     int rawStaticEval = SCORE_NONE;
+    int corrplexity = 0;
 
     if (!excluded)
     {
@@ -479,6 +480,7 @@ int Search::search(SearchThread& thread, int depth, SearchStack* stack, int alph
                     || (ttData.bound == TTEntry::Bound::LOWER_BOUND && ttData.score >= stack->eval)
                     || (ttData.bound == TTEntry::Bound::UPPER_BOUND && ttData.score <= stack->eval)))
                 stack->eval = ttData.score;
+            corrplexity = std::abs(stack->staticEval - rawStaticEval);
         }
     }
 
@@ -728,8 +730,7 @@ int Search::search(SearchThread& thread, int depth, SearchStack* stack, int alph
             reduction -= lmrTTPV * ttPV;
             reduction -= lmrGivesCheck * givesCheck;
             reduction -= lmrInCheck * inCheck;
-            reduction -=
-                lmrCorrplexity * (std::abs(stack->staticEval - rawStaticEval) > lmrCorrplexityMargin);
+            reduction -= lmrCorrplexity * (corrplexity > lmrCorrplexityMargin);
             reduction += lmrCutnode * cutnode;
             reduction += lmrFailHighCount
                 * ((stack + 1)->failHighCount >= static_cast<uint32_t>(lmrFailHighCountMargin));


### PR DESCRIPTION
```
Elo   | -0.16 +- 2.15 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.97 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 32330 W: 8247 L: 8262 D: 15821
Penta | [316, 3918, 7729, 3869, 333]
```
https://mcthouacbb.pythonanywhere.com/test/976/

Bench: 5822041