### PR TITLE
Simplify noisy futility pruning best score raise

### DIFF
--- a/Sirius/src/search.cpp
+++ b/Sirius/src/search.cpp
@@ -643,8 +643,6 @@ int Search::search(SearchThread& thread, int depth, SearchStack* stack, int alph
             if (depth <= noisyFpMaxDepth && !quiet && !inCheck && alpha < SCORE_WIN
                 && stack->staticEval + fpMargin <= alpha)
             {
-                if (!isMateScore(bestScore) && bestScore <= stack->staticEval + fpMargin)
-                    bestScore = stack->staticEval + fpMargin;
                 break;
             }
 


### PR DESCRIPTION
```
Elo   | 1.04 +- 2.97 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.01 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 16722 W: 4240 L: 4190 D: 8292
Penta | [148, 2023, 3991, 2029, 170]
```
https://mcthouacbb.pythonanywhere.com/test/1019/

Bench: 6168513