### PR TITLE
Fully utilize root moves to get the best move out of search + refactor UCI printing

### DIFF
--- a/Sirius/src/search.cpp
+++ b/Sirius/src/search.cpp
@@ -317,14 +317,8 @@ std::pair<int, Move> Search::iterDeep(SearchThread& thread, bool report)
     {
         thread.rootDepth = depth;
         thread.selDepth = 0;
-        int searchScore = aspWindows(thread, depth, bestMove, score, report);
+        int searchScore = aspWindows(thread, depth, score, report);
         thread.sortRootMoves();
-        // DEBUG lol
-        if (bestMove != thread.rootMoves[0].move)
-        {
-            std::cerr << "Error: incorrect root move" << std::endl;
-            std::terminate();
-        }
         if (m_ShouldStop)
             break;
         score = searchScore;
@@ -347,7 +341,7 @@ std::pair<int, Move> Search::iterDeep(SearchThread& thread, bool report)
 }
 
 // Aspiration windows(~108 elo)
-int Search::aspWindows(SearchThread& thread, int depth, Move& bestMove, int prevScore, bool report)
+int Search::aspWindows(SearchThread& thread, int depth, int prevScore, bool report)
 {
     // 1 second
     constexpr Duration ASP_WIDEN_REPORT_DELAY = Duration(1000);
@@ -384,7 +378,6 @@ int Search::aspWindows(SearchThread& thread, int depth, Move& bestMove, int prev
         }
         else
         {
-            bestMove = thread.stack[0].pv[0];
             if (searchScore >= beta)
             {
                 beta = std::min(beta + delta, SCORE_MAX);

--- a/Sirius/src/search.cpp
+++ b/Sirius/src/search.cpp
@@ -307,7 +307,6 @@ std::pair<int, Move> Search::iterDeep(SearchThread& thread, bool report)
 {
     int maxDepth = std::min(thread.limits.maxDepth, MAX_PLY - 1);
     int score = 0;
-    Move bestMove = Move::nullmove();
 
     thread.reset();
     thread.evalState.init(thread.board, thread.pawnTable);
@@ -335,7 +334,7 @@ std::pair<int, Move> Search::iterDeep(SearchThread& thread, bool report)
         m_ShouldStop.store(true, std::memory_order_relaxed);
 
     if (report)
-        uci::uci->reportBestMove(bestMove);
+        uci::uci->reportBestMove(thread.rootMoves[0].move);
 
     return {score, bestMove};
 }

--- a/Sirius/src/search.cpp
+++ b/Sirius/src/search.cpp
@@ -336,7 +336,7 @@ std::pair<int, Move> Search::iterDeep(SearchThread& thread, bool report)
     if (report)
         uci::uci->reportBestMove(thread.rootMoves[0].move);
 
-    return {score, bestMove};
+    return {score, thread.rootMoves[0].move};
 }
 
 // Aspiration windows(~108 elo)
@@ -421,7 +421,7 @@ std::pair<int, Move> Search::datagenSearch(const SearchLimits& limits, const Boa
 
     m_ShouldStop.store(false, std::memory_order_relaxed);
 
-    return iterDeep(*thread, false, false);
+    return iterDeep(*thread, false);
 }
 
 int Search::search(SearchThread& thread, int depth, SearchStack* stack, int alpha, int beta,

--- a/Sirius/src/search.cpp
+++ b/Sirius/src/search.cpp
@@ -286,6 +286,23 @@ void Search::unmakeNullMove(SearchThread& thread, SearchStack* stack)
     stack->contCorrEntry = nullptr;
 }
 
+void Search::reportUCIInfo(const SearchThread& thread, int multiPVIdx, int depth) const
+{
+    SearchInfo info;
+    info.nodes = 0;
+    for (auto& searchThread : m_Threads)
+        info.nodes += searchThread->nodes.load(std::memory_order_relaxed);
+    info.depth = depth;
+    info.selDepth = thread.rootMoves[multiPVIdx].selDepth;
+    info.hashfull = m_TT.hashfull();
+    info.time = m_TimeMan.elapsed();
+    info.pv = thread.rootMoves[multiPVIdx].pv;
+    info.score = thread.rootMoves[multiPVIdx].displayScore;
+    info.lowerbound = thread.rootMoves[multiPVIdx].lowerbound;
+    info.upperbound = thread.rootMoves[multiPVIdx].upperbound;
+    uci::uci->reportSearchInfo(info);
+}
+
 std::pair<int, Move> Search::iterDeep(SearchThread& thread, bool report, bool normalSearch)
 {
     int maxDepth = std::min(thread.limits.maxDepth, MAX_PLY - 1);
@@ -302,28 +319,23 @@ std::pair<int, Move> Search::iterDeep(SearchThread& thread, bool report, bool no
     {
         thread.rootDepth = depth;
         thread.selDepth = 0;
-        int searchScore = aspWindows(thread, depth, bestMove, score);
+        int searchScore = aspWindows(thread, depth, bestMove, score, report);
         thread.sortRootMoves();
+        // DEBUG lol
+        if (bestMove != thread.rootMoves[0].move)
+        {
+            std::cerr << "Error: incorrect root move" << std::endl;
+            std::terminate();
+        }
         if (m_ShouldStop)
             break;
         score = searchScore;
         if (report)
-        {
-            SearchInfo info;
-            info.nodes = 0;
-            for (auto& searchThread : m_Threads)
-                info.nodes += searchThread->nodes.load(std::memory_order_relaxed);
-            info.depth = depth;
-            info.selDepth = thread.selDepth;
-            info.hashfull = m_TT.hashfull();
-            info.time = m_TimeMan.elapsed();
-            info.pvBegin = thread.stack[0].pv.data();
-            info.pvEnd = thread.stack[0].pv.data() + thread.stack[0].pvLength;
-            info.score = searchScore;
-            uci::uci->reportSearchInfo(info);
-        }
-        uint64_t bmNodes = thread.findRootMove(bestMove).nodes;
-        if (thread.isMainThread() && m_TimeMan.stopSoft(bestMove, bmNodes, thread.nodes, thread.limits))
+            reportUCIInfo(thread, 0, depth);
+
+        uint64_t bmNodes = thread.rootMoves[0].nodes;
+        if (thread.isMainThread()
+            && m_TimeMan.stopSoft(thread.rootMoves[0].move, bmNodes, thread.nodes, thread.limits))
             break;
     }
 
@@ -337,7 +349,7 @@ std::pair<int, Move> Search::iterDeep(SearchThread& thread, bool report, bool no
 }
 
 // Aspiration windows(~108 elo)
-int Search::aspWindows(SearchThread& thread, int depth, Move& bestMove, int prevScore)
+int Search::aspWindows(SearchThread& thread, int depth, Move& bestMove, int prevScore, bool report)
 {
     int delta = aspInitDelta + prevScore * prevScore / 16384;
     int alpha = -SCORE_MAX;
@@ -354,8 +366,13 @@ int Search::aspWindows(SearchThread& thread, int depth, Move& bestMove, int prev
     {
         int searchScore =
             search(thread, std::max(aspDepth, 1), &thread.stack[0], alpha, beta, true, false);
+
+        thread.sortRootMoves();
         if (m_ShouldStop)
             return searchScore;
+
+        if (report && (searchScore <= alpha || searchScore >= beta) /* && thread.nodes > 10000000*/)
+            reportUCIInfo(thread, 0, depth);
 
         if (searchScore <= alpha)
         {
@@ -783,7 +800,25 @@ int Search::search(SearchThread& thread, int depth, SearchStack* stack, int alph
 
             if (movesPlayed == 1 || score > alpha)
             {
-                rootMove.score = score;
+                rootMove.displayScore = rootMove.score = score;
+                rootMove.selDepth = thread.selDepth;
+                rootMove.lowerbound = false;
+                rootMove.upperbound = false;
+
+                if (score >= beta)
+                {
+                    rootMove.displayScore = beta;
+                    rootMove.lowerbound = true;
+                }
+                else if (score <= alpha)
+                {
+                    rootMove.displayScore = alpha;
+                    rootMove.upperbound = true;
+                }
+
+                rootMove.pv = {move};
+                for (int i = 0; i < (stack + 1)->pvLength; i++)
+                    rootMove.pv.push_back((stack + 1)->pv[i]);
             }
             else
             {

--- a/Sirius/src/search.cpp
+++ b/Sirius/src/search.cpp
@@ -238,7 +238,7 @@ void Search::threadLoop(SearchThread& thread)
             case WakeFlag::QUIT:
                 return;
             case WakeFlag::SEARCH:
-                iterDeep(thread, thread.isMainThread(), true);
+                iterDeep(thread, thread.isMainThread());
                 break;
             case WakeFlag::NONE:
                 // unreachable;
@@ -303,7 +303,7 @@ void Search::reportUCIInfo(const SearchThread& thread, int multiPVIdx, int depth
     uci::uci->reportSearchInfo(info);
 }
 
-std::pair<int, Move> Search::iterDeep(SearchThread& thread, bool report, bool normalSearch)
+std::pair<int, Move> Search::iterDeep(SearchThread& thread, bool report)
 {
     int maxDepth = std::min(thread.limits.maxDepth, MAX_PLY - 1);
     int score = 0;
@@ -312,8 +312,6 @@ std::pair<int, Move> Search::iterDeep(SearchThread& thread, bool report, bool no
     thread.reset();
     thread.evalState.init(thread.board, thread.pawnTable);
     thread.initRootMoves();
-
-    report = report && normalSearch;
 
     for (int depth = 1; depth <= maxDepth; depth++)
     {
@@ -351,6 +349,9 @@ std::pair<int, Move> Search::iterDeep(SearchThread& thread, bool report, bool no
 // Aspiration windows(~108 elo)
 int Search::aspWindows(SearchThread& thread, int depth, Move& bestMove, int prevScore, bool report)
 {
+    // 1 second
+    constexpr Duration ASP_WIDEN_REPORT_DELAY = Duration(1000);
+
     int delta = aspInitDelta + prevScore * prevScore / 16384;
     int alpha = -SCORE_MAX;
     int beta = SCORE_MAX;
@@ -371,7 +372,8 @@ int Search::aspWindows(SearchThread& thread, int depth, Move& bestMove, int prev
         if (m_ShouldStop)
             return searchScore;
 
-        if (report && (searchScore <= alpha || searchScore >= beta) /* && thread.nodes > 10000000*/)
+        if (report && (searchScore <= alpha || searchScore >= beta)
+            && m_TimeMan.elapsed() > ASP_WIDEN_REPORT_DELAY)
             reportUCIInfo(thread, 0, depth);
 
         if (searchScore <= alpha)
@@ -409,7 +411,7 @@ BenchData Search::benchSearch(int depth, const Board& board)
 
     m_ShouldStop.store(false, std::memory_order_relaxed);
 
-    iterDeep(*thread, false, false);
+    iterDeep(*thread, false);
 
     BenchData data = {};
     data.nodes = thread->nodes;

--- a/Sirius/src/search.h
+++ b/Sirius/src/search.h
@@ -155,7 +155,9 @@ private:
     void joinThreads();
     void threadLoop(SearchThread& thread);
 
-    std::pair<int, Move> iterDeep(SearchThread& thread, bool report, bool normalSearch);
+    void reportUCIInfo(const SearchThread& thread, int multiPVIdx, int depth) const;
+
+    std::pair<int, Move> iterDeep(SearchThread& thread, bool report);
     int aspWindows(SearchThread& thread, int depth, Move& bestMove, int prevScore, bool report);
 
     int search(SearchThread& thread, int depth, SearchStack* stack, int alpha, int beta,

--- a/Sirius/src/search.h
+++ b/Sirius/src/search.h
@@ -158,7 +158,7 @@ private:
     void reportUCIInfo(const SearchThread& thread, int multiPVIdx, int depth) const;
 
     std::pair<int, Move> iterDeep(SearchThread& thread, bool report);
-    int aspWindows(SearchThread& thread, int depth, Move& bestMove, int prevScore, bool report);
+    int aspWindows(SearchThread& thread, int depth, int prevScore, bool report);
 
     int search(SearchThread& thread, int depth, SearchStack* stack, int alpha, int beta,
         bool pvNode, bool cutnode);

--- a/Sirius/src/search.h
+++ b/Sirius/src/search.h
@@ -44,8 +44,10 @@ struct SearchInfo
     int hashfull;
     uint64_t nodes;
     Duration time;
-    const Move *pvBegin, *pvEnd;
+    std::vector<Move> pv;
     int score;
+    bool lowerbound;
+    bool upperbound;
 };
 
 struct BenchData
@@ -67,10 +69,15 @@ enum class WakeFlag
 
 struct RootMove
 {
-    Move move;
+    Move move = Move::nullmove();
     uint64_t nodes = 0;
     int score = SCORE_NONE;
     int previousScore = SCORE_NONE;
+    int displayScore = SCORE_NONE;
+    int selDepth = 0;
+    bool lowerbound = false;
+    bool upperbound = false;
+    std::vector<Move> pv;
 
     RootMove(Move move);
 };
@@ -149,7 +156,7 @@ private:
     void threadLoop(SearchThread& thread);
 
     std::pair<int, Move> iterDeep(SearchThread& thread, bool report, bool normalSearch);
-    int aspWindows(SearchThread& thread, int depth, Move& bestMove, int prevScore);
+    int aspWindows(SearchThread& thread, int depth, Move& bestMove, int prevScore, bool report);
 
     int search(SearchThread& thread, int depth, SearchStack* stack, int alpha, int beta,
         bool pvNode, bool cutnode);

--- a/Sirius/src/uci/uci.cpp
+++ b/Sirius/src/uci/uci.cpp
@@ -135,23 +135,30 @@ void UCI::prettyPrintSearchInfo(const SearchInfo& info) const
     std::cout << info.hashfull % 10 << "%";
     std::cout << "  ";
 
+    std::string bound_str = "  ";
+    if (info.lowerbound)
+        bound_str = ">=";
+    else if (info.upperbound)
+        bound_str = "<=";
+
     // score
     if (isMateScore(info.score))
     {
         if (info.score > 0)
         {
-            std::cout << "     #" << std::left << std::setw(4) << std::setfill(' ')
-                      << ((SCORE_MATE - info.score) + 1) / 2;
+            std::cout << "   " << bound_str << "  #" << std::left << std::setw(4)
+                      << std::setfill(' ') << ((SCORE_MATE - info.score) + 1) / 2;
         }
         else
         {
-            std::cout << "    #-" << std::left << std::setw(4) << std::setfill(' ')
-                      << (info.score + SCORE_MATE) / 2;
+            std::cout << "   " << bound_str << " #-" << std::left << std::setw(4)
+                      << std::setfill(' ') << (info.score + SCORE_MATE) / 2;
         }
     }
     else
     {
-        std::cout << std::right << std::setw(6) << std::setfill(' ') << info.score << "cp  ";
+        std::cout << "  " << bound_str << std::right << std::setw(6) << std::setfill(' ')
+                  << info.score << "cp  ";
     }
 
     if (m_Options.at("UCI_ShowWDL").boolValue())
@@ -181,12 +188,12 @@ void UCI::prettyPrintSearchInfo(const SearchInfo& info) const
     Board board;
     board.setToFen(m_Board.fenStr());
 
-    for (const Move* move = info.pvBegin; move != info.pvEnd; move++)
+    for (Move move : info.pv)
     {
         MoveList moves;
         genMoves<MoveGenType::LEGAL>(board, moves);
-        std::cout << uci::convMoveToSAN(board, moves, *move) << ' ';
-        board.makeMove(*move);
+        std::cout << uci::convMoveToSAN(board, moves, move) << ' ';
+        board.makeMove(move);
     }
 
     std::cout << std::endl;
@@ -218,6 +225,10 @@ void UCI::printUCISearchInfo(const SearchInfo& info) const
         std::cout << "cp " << normalizedScore(info.score);
     }
 
+    if (info.lowerbound)
+        std::cout << " lowerbound";
+    else if (info.upperbound)
+        std::cout << " upperbound";
     if (m_Options.at("UCI_ShowWDL").boolValue())
     {
         if (isMateScore(info.score) && info.score > 0)
@@ -241,9 +252,9 @@ void UCI::printUCISearchInfo(const SearchInfo& info) const
     }
 
     std::cout << " pv ";
-    for (const Move* move = info.pvBegin; move != info.pvEnd; move++)
+    for (Move move : info.pv)
     {
-        std::cout << uci::convMoveToUCI(m_Board, *move) << ' ';
+        std::cout << uci::convMoveToUCI(m_Board, move) << ' ';
     }
     std::cout << std::endl;
 }


### PR DESCRIPTION
I also tested it to make sure it always returns the same best move

```
Elo   | 0.06 +- 2.22 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 27238 W: 6932 L: 6927 D: 13379
Penta | [230, 3002, 7157, 2993, 237]
```
https://mcthouacbb.pythonanywhere.com/test/1056/

No functional change
Bench: 5902264