### PR TITLE
Simplify noisy move scoring

### DIFF
--- a/Sirius/src/move_ordering.cpp
+++ b/Sirius/src/move_ordering.cpp
@@ -30,7 +30,7 @@ i32 mvv(const Board& board, Move move)
 
 i32 promotionBonus(Move move)
 {
-    return 1 + (static_cast<i32>(move.promotion()) >> 14);
+    return move.promotion() == Promotion::QUEEN ? 10000 : 0;
 }
 
 }
@@ -51,17 +51,20 @@ bool moveIsCapture(const Board& board, Move move)
 i32 MoveOrdering::scoreNoisy(Move move) const
 {
     bool isCapture = moveIsCapture(m_Board, move);
+    bool isPromotion = move.type() == MoveType::PROMOTION;
+
+    i32 score = m_History.getNoisyStats(m_Board, move);
+
+    if (isPromotion)
+        score += promotionBonus(move);
 
     if (isCapture)
-    {
-        i32 hist = m_History.getNoisyStats(m_Board, move);
-        i32 score = hist + mvv(m_Board, move);
-        return score + CAPTURE_SCORE * m_Board.see(move, -score / 32);
-    }
-    else
-    {
-        return m_History.getNoisyStats(m_Board, move) + PROMOTION_SCORE + promotionBonus(move);
-    }
+        score += mvv(m_Board, move);
+
+    if (isPromotion || m_Board.see(move, -score / 32))
+        score += GOOD_NOISY_SCORE;
+
+    return score;
 }
 
 i32 MoveOrdering::scoreQuiet(Move move) const
@@ -127,7 +130,7 @@ ScoredMove MoveOrdering::selectMove()
                 ScoredMove scoredMove = selectHighest();
                 if (scoredMove.move == m_TTMove)
                     continue;
-                if (scoredMove.score < PROMOTION_SCORE - 50000)
+                if (scoredMove.score < GOOD_NOISY_SCORE - 50000)
                 {
                     m_Curr--;
                     break;

--- a/Sirius/src/move_ordering.h
+++ b/Sirius/src/move_ordering.h
@@ -44,8 +44,7 @@ public:
     static constexpr i32 NO_MOVE = -8000000;
     static constexpr i32 FIRST_KILLER_SCORE = 300001;
     static constexpr i32 SECOND_KILLER_SCORE = 300000;
-    static constexpr i32 PROMOTION_SCORE = 400000;
-    static constexpr i32 CAPTURE_SCORE = 500000;
+    static constexpr i32 GOOD_NOISY_SCORE = 400000;
 
     MoveOrdering(const Board& board, Move ttMove, const History& history);
     MoveOrdering(const Board& board, Move hashMove, const std::array<Move, 2>& killers,


### PR DESCRIPTION
```
Elo   | 11.52 +- 5.29 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [-3.00, 0.00]
Games | N: 5580 W: 1519 L: 1334 D: 2727
Penta | [53, 624, 1265, 781, 67]
```
https://mcthouacbb.pythonanywhere.com/test/1197/